### PR TITLE
Fixes from crashes and ANRs found on the playstore

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/AttachmentDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/AttachmentDatabase.java
@@ -981,7 +981,9 @@ public class AttachmentDatabase extends Database {
 
       try {
         retriever.close();
-      } catch (IOException e) {}
+      } catch (IOException e) {
+        Log.w(TAG, "Error while closing the retriever in AttachmentDatabase > generateVideoThumbnail: "+e.toString());
+      }
 
       Log.i(TAG, "Generated video thumbnail...");
       return new ThumbnailData(bitmap);

--- a/app/src/main/java/org/thoughtcrime/securesms/database/AttachmentDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/AttachmentDatabase.java
@@ -979,6 +979,10 @@ public class AttachmentDatabase extends Database {
 
       Bitmap bitmap = retriever.getFrameAtTime(1000);
 
+      try {
+        retriever.close();
+      } catch (IOException e) {}
+
       Log.i(TAG, "Generated video thumbnail...");
       return new ThumbnailData(bitmap);
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -198,8 +198,6 @@ class HomeActivity : PassphraseRequiredActionBarActivity(),
             EmptyView(isNewAccount)
         }
 
-        IP2Country.configureIfNeeded(this@HomeActivity)
-
         // Set up new conversation button
         binding.newConversationButton.setOnClickListener { showStartConversation() }
         // Observe blocked contacts changed events

--- a/app/src/main/java/org/thoughtcrime/securesms/home/PathActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/PathActivity.kt
@@ -62,6 +62,8 @@ class PathActivity : PassphraseRequiredActionBarActivity() {
         binding.learnMoreButton.setOnClickListener { learnMore() }
         update(false)
         registerObservers()
+
+        IP2Country.configureIfNeeded(this)
     }
 
     private fun registerObservers() {

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaSendActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaSendActivity.java
@@ -190,6 +190,10 @@ public class MediaSendActivity extends PassphraseRequiredActionBarActivity imple
 
   @Override
   public void onFolderSelected(@NonNull MediaFolder folder) {
+    if(folder == null || viewModel == null){
+      return;
+    }
+
     viewModel.onFolderSelected(folder.getBucketId());
 
     MediaPickerItemFragment fragment = MediaPickerItemFragment.newInstance(folder.getBucketId(), folder.getTitle(), viewModel.getMaxSelection());

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
@@ -1,4 +1,4 @@
-package org.thoughtcrime.securesms.preferences
+ package org.thoughtcrime.securesms.preferences
 
 import android.Manifest
 import android.app.Activity
@@ -57,12 +57,14 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.canhub.cropper.CropImageContract
 import com.squareup.phrase.Phrase
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import network.loki.messenger.BuildConfig
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ActivitySettingsBinding
@@ -636,4 +638,8 @@ private fun LocalBroadcastManager.hasPaths(): Flow<Boolean> = callbackFlow {
     registerReceiver(receiver, IntentFilter("pathsBuilt"))
 
     awaitClose { unregisterReceiver(receiver) }
-}.onStart { emit(Unit) }.map { OnionRequestAPI.paths.isNotEmpty() }
+}.onStart { emit(Unit) }.map {
+    withContext(Dispatchers.Default) {
+        OnionRequestAPI.paths.isNotEmpty()
+    }
+}


### PR DESCRIPTION
- Only start the ip to country code in the Path activity
- Closing retriever for attachments to avoid leaks
- Handling a null case in MediaSend activity
- Switching to a bg thread for path retrieval in settings