### PR TITLE
Fix sqlite migration crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -327,7 +327,7 @@ dependencies {
     implementation 'com.annimon:stream:1.1.8'
     implementation 'com.github.dmytrodanylyk.circular-progress-button:library:1.1.3-S2'
     implementation 'androidx.sqlite:sqlite-ktx:2.3.1'
-    implementation 'net.zetetic:sqlcipher-android:4.5.4@aar'
+    implementation 'net.zetetic:sqlcipher-android:4.6.1@aar'
     implementation project(":libsignal")
     implementation project(":libsession")
     implementation project(":libsession-util")

--- a/app/src/main/java/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
@@ -668,7 +668,7 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper {
   }
 
   private static boolean columnExists(@NonNull SQLiteDatabase db, @NonNull String table, @NonNull String column) {
-    try (Cursor cursor = db.rawQuery("PRAGMA table_info(" + table + ")", null)) {
+    try (Cursor cursor = db.rawQuery("PRAGMA table_xinfo(" + table + ")", null)) {
       int nameColumnIndex = cursor.getColumnIndexOrThrow("name");
 
       while (cursor.moveToNext()) {


### PR DESCRIPTION
This PR:

* Makes sure `columnExists` uses `sqlite_xinfo` so that it can look at virtual columns
* Update sqlcipher's version
* 
See https://github.com/diesel-rs/diesel/issues/2912
