### PR TITLE
Handle config migration

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
@@ -2,6 +2,9 @@ package org.thoughtcrime.securesms.configs
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import network.loki.messenger.libsession_util.ConfigBase.Companion.PRIORITY_HIDDEN
 import network.loki.messenger.libsession_util.ConfigBase.Companion.PRIORITY_PINNED
 import network.loki.messenger.libsession_util.ReadableGroupInfoConfig
@@ -67,8 +70,10 @@ class ConfigToDatabaseSync @Inject constructor(
         if (!preferences.migratedToGroupV2Config) {
             preferences.migratedToGroupV2Config = true
 
-            for (configType in UserConfigType.entries) {
-                syncUserConfigs(configType, null)
+            GlobalScope.launch(Dispatchers.Default) {
+                for (configType in UserConfigType.entries) {
+                    syncUserConfigs(configType, null)
+                }
             }
         }
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
@@ -63,6 +63,16 @@ class ConfigToDatabaseSync @Inject constructor(
     private val profileManager: ProfileManager,
     private val preferences: TextSecurePreferences,
 ) {
+    init {
+        if (!preferences.migratedToGroupV2Config) {
+            preferences.migratedToGroupV2Config = true
+
+            for (configType in UserConfigType.entries) {
+                syncUserConfigs(configType, null)
+            }
+        }
+    }
+
     fun syncGroupConfigs(groupId: AccountId) {
         val info = configFactory.withGroupConfigs(groupId) {
             UpdateGroupInfo(it.groupInfo)
@@ -71,7 +81,7 @@ class ConfigToDatabaseSync @Inject constructor(
         updateGroup(info)
     }
 
-    fun syncUserConfigs(userConfigType: UserConfigType, updateTimestamp: Long) {
+    fun syncUserConfigs(userConfigType: UserConfigType, updateTimestamp: Long?) {
         val configUpdate = configFactory.withUserConfigs { configs ->
             when (userConfigType) {
                 UserConfigType.USER_PROFILE -> UpdateUserInfo(configs.userProfile)
@@ -104,7 +114,7 @@ class ConfigToDatabaseSync @Inject constructor(
         )
     }
 
-    private fun updateUser(userProfile: UpdateUserInfo, messageTimestamp: Long) {
+    private fun updateUser(userProfile: UpdateUserInfo, messageTimestamp: Long?) {
         val userPublicKey = storage.getUserPublicKey() ?: return
         // would love to get rid of recipient and context from this
         val recipient = Recipient.from(context, fromSerialized(userPublicKey), false)
@@ -139,11 +149,13 @@ class ConfigToDatabaseSync @Inject constructor(
         }
 
         // Set or reset the shared library to use latest expiration config
-        storage.getThreadId(recipient)?.let {
-            storage.setExpirationConfiguration(
-                storage.getExpirationConfiguration(it)?.takeIf { it.updatedTimestampMs > messageTimestamp } ?:
-                ExpirationConfiguration(it, userProfile.ntsExpiry, messageTimestamp)
-            )
+        if (messageTimestamp != null) {
+            storage.getThreadId(recipient)?.let { theadId ->
+                storage.setExpirationConfiguration(
+                    storage.getExpirationConfiguration(theadId)?.takeIf { it.updatedTimestampMs > messageTimestamp } ?:
+                    ExpirationConfiguration(theadId, userProfile.ntsExpiry, messageTimestamp)
+                )
+            }
         }
     }
 
@@ -187,7 +199,7 @@ class ConfigToDatabaseSync @Inject constructor(
 
     private data class UpdateContacts(val contacts: List<Contact>)
 
-    private fun updateContacts(contacts: UpdateContacts, messageTimestamp: Long) {
+    private fun updateContacts(contacts: UpdateContacts, messageTimestamp: Long?) {
         storage.addLibSessionContacts(contacts.contacts, messageTimestamp)
     }
 
@@ -203,7 +215,7 @@ class ConfigToDatabaseSync @Inject constructor(
         )
     }
 
-    private fun updateUserGroups(userGroups: UpdateUserGroupsInfo, messageTimestamp: Long) {
+    private fun updateUserGroups(userGroups: UpdateUserGroupsInfo, messageTimestamp: Long?) {
         val localUserPublicKey = storage.getUserPublicKey() ?: return Log.w(
             TAG,
             "No user public key when trying to update user groups from config"
@@ -349,11 +361,14 @@ class ConfigToDatabaseSync @Inject constructor(
                 // Start polling
                 LegacyClosedGroupPollerV2.shared.startPolling(group.accountId)
             }
-            storage.getThreadId(fromSerialized(groupId))?.let {
-                storage.setExpirationConfiguration(
-                    storage.getExpirationConfiguration(it)?.takeIf { it.updatedTimestampMs > messageTimestamp }
-                        ?: ExpirationConfiguration(it, afterSend(group.disappearingTimer), messageTimestamp)
-                )
+
+            if (messageTimestamp != null) {
+                storage.getThreadId(fromSerialized(groupId))?.let { theadId ->
+                    storage.setExpirationConfiguration(
+                        storage.getExpirationConfiguration(theadId)?.takeIf { it.updatedTimestampMs > messageTimestamp }
+                            ?: ExpirationConfiguration(theadId, afterSend(group.disappearingTimer), messageTimestamp)
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -1245,7 +1245,7 @@ open class Storage @Inject constructor(
         return recipientDatabase.isAutoDownloadFlagSet(recipient)
     }
 
-    override fun addLibSessionContacts(contacts: List<LibSessionContact>, timestamp: Long) {
+    override fun addLibSessionContacts(contacts: List<LibSessionContact>, timestamp: Long?) {
         val mappingDb = blindedIdMappingDatabase
         val moreContacts = contacts.filter { contact ->
             val id = AccountId(contact.id)
@@ -1285,11 +1285,13 @@ open class Storage @Inject constructor(
                     }
                 ).also { setPinned(it, contact.priority == PRIORITY_PINNED) }
             }
-            getThreadId(recipient)?.let {
-                setExpirationConfiguration(
-                    getExpirationConfiguration(it)?.takeIf { it.updatedTimestampMs > timestamp }
-                        ?: ExpirationConfiguration(it, contact.expiryMode, timestamp)
-                )
+            if (timestamp != null) {
+                getThreadId(recipient)?.let {
+                    setExpirationConfiguration(
+                        getExpirationConfiguration(it)?.takeIf { it.updatedTimestampMs > timestamp }
+                            ?: ExpirationConfiguration(it, contact.expiryMode, timestamp)
+                    )
+                }
             }
             setRecipientHash(recipient, contact.hashCode().toString())
         }

--- a/libsession/src/main/java/org/session/libsession/database/StorageProtocol.kt
+++ b/libsession/src/main/java/org/session/libsession/database/StorageProtocol.kt
@@ -211,7 +211,7 @@ interface StorageProtocol {
     fun setContact(contact: Contact)
     fun getRecipientForThread(threadId: Long): Recipient?
     fun getRecipientSettings(address: Address): RecipientSettings?
-    fun addLibSessionContacts(contacts: List<LibSessionContact>, timestamp: Long)
+    fun addLibSessionContacts(contacts: List<LibSessionContact>, timestamp: Long?)
     fun hasAutoDownloadFlagBeenSet(recipient: Recipient): Boolean
     fun addContacts(contacts: List<ConfigurationMessage.Contact>)
     fun shouldAutoDownloadAttachments(recipient: Recipient): Boolean

--- a/libsession/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
@@ -196,6 +196,8 @@ interface TextSecurePreferences {
     fun getEnvironment(): Environment
     fun setEnvironment(value: Environment)
 
+    var migratedToGroupV2Config: Boolean
+
     companion object {
         val TAG = TextSecurePreferences::class.simpleName
 
@@ -284,6 +286,7 @@ interface TextSecurePreferences {
         const val SELECTED_ACCENT_COLOR = "selected_accent_color"
         const val LAST_VERSION_CHECK = "pref_last_version_check"
         const val ENVIRONMENT = "debug_environment"
+        const val MIGRATED_TO_GROUP_V2_CONFIG = "migrated_to_group_v2_config"
 
         const val HAS_RECEIVED_LEGACY_CONFIG = "has_received_legacy_config"
         const val HAS_FORCED_NEW_CONFIG = "has_forced_new_config"
@@ -988,6 +991,10 @@ class AppTextSecurePreferences @Inject constructor(
     }
 
     private val localNumberState = MutableStateFlow(getStringPreference(TextSecurePreferences.LOCAL_NUMBER_PREF, null))
+
+    override var migratedToGroupV2Config: Boolean
+        get() = getBooleanPreference(TextSecurePreferences.MIGRATED_TO_GROUP_V2_CONFIG, false)
+        set(value) = setBooleanPreference(TextSecurePreferences.MIGRATED_TO_GROUP_V2_CONFIG, value)
 
     override fun getConfigurationMessageSynced(): Boolean {
         return getBooleanPreference(TextSecurePreferences.CONFIGURATION_SYNCED, false)


### PR DESCRIPTION
This handles the case where the groupsv2 config already exists in the old version of the app, installing groupsv2 app doesn't trigger a groupsv2 sync.

It only needs to trigger a config -> local sync to makes this happen.
