### PR TITLE
SES-3001 - Note to self vs 1on1 delete

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationMenuHelper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationMenuHelper.kt
@@ -34,6 +34,7 @@ import org.session.libsession.utilities.GroupUtil.doubleDecodeGroupID
 import org.session.libsession.utilities.StringSubstitutionConstants.APP_NAME_KEY
 import org.session.libsession.utilities.StringSubstitutionConstants.GROUP_NAME_KEY
 import org.session.libsession.utilities.TextSecurePreferences
+import org.session.libsession.utilities.TextSecurePreferences.Companion.CALL_NOTIFICATIONS_ENABLED
 import org.session.libsession.utilities.recipients.Recipient
 import org.session.libsession.utilities.wasKickedFromGroupV2
 import org.session.libsignal.utilities.AccountId
@@ -221,7 +222,10 @@ object ConversationMenuHelper {
                 title(R.string.callsPermissionsRequired)
                 text(R.string.callsPermissionsRequiredDescription)
                 button(R.string.sessionSettings, R.string.AccessibilityId_sessionSettings) {
-                    Intent(context, PrivacySettingsActivity::class.java).let(context::startActivity)
+                    val intent = Intent(context, PrivacySettingsActivity::class.java)
+                    // allow the screen to auto scroll to the appropriate toggle
+                    intent.putExtra(PrivacySettingsActivity.SCROLL_KEY, CALL_NOTIFICATIONS_ENABLED)
+                    context.startActivity(intent)
                 }
                 cancelButton()
             }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/ControlMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/ControlMessageView.kt
@@ -21,6 +21,7 @@ import org.session.libsession.messaging.utilities.UpdateMessageData
 import org.session.libsession.utilities.StringSubstitutionConstants.APP_NAME_KEY
 import org.session.libsession.utilities.StringSubstitutionConstants.NAME_KEY
 import org.session.libsession.utilities.TextSecurePreferences
+import org.session.libsession.utilities.TextSecurePreferences.Companion.CALL_NOTIFICATIONS_ENABLED
 import org.session.libsession.utilities.getColorFromAttr
 import org.thoughtcrime.securesms.conversation.disappearingmessages.DisappearingMessages
 import org.thoughtcrime.securesms.conversation.disappearingmessages.expiryMode
@@ -168,8 +169,10 @@ class ControlMessageView : LinearLayout {
                                     text(bodyTxt)
 
                                     button(R.string.sessionSettings) {
-                                        Intent(context, PrivacySettingsActivity::class.java)
-                                            .let(context::startActivity)
+                                        val intent = Intent(context, PrivacySettingsActivity::class.java)
+                                        // allow the screen to auto scroll to the appropriate toggle
+                                        intent.putExtra(PrivacySettingsActivity.SCROLL_KEY, CALL_NOTIFICATIONS_ENABLED)
+                                        context.startActivity(intent)
                                     }
                                     cancelButton()
                                 }

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/BaseGroupMembersViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/BaseGroupMembersViewModel.kt
@@ -114,7 +114,7 @@ abstract class BaseGroupMembersViewModel (
             }
                 .thenBy { !it.showAsAdmin } // Admins come first
                 .thenBy { it.accountId != currentUserId } // Being myself comes first
-                .thenBy { it.name } // Sort by name
+                .thenComparing(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name }) // Sort by name (case insensitive)
                 .thenBy { it.accountId } // Last resort: sort by account ID
         )
 

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/SelectContactsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/SelectContactsViewModel.kt
@@ -99,7 +99,7 @@ class SelectContactsViewModel @AssistedInject constructor(
                 )
             }
             .toList()
-            .sortedBy { it.name }
+            .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
     }
 
     fun onSearchQueryChanged(query: String) {

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/compose/CreateGroupScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/compose/CreateGroupScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
@@ -25,6 +26,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -151,13 +153,24 @@ fun CreateGroup(
                         .nestedScroll(rememberNestedScrollInteropConnection()),
                     fadingColor = LocalColors.current.backgroundSecondary
                 ) { bottomContentPadding ->
-                    LazyColumn(
-                        contentPadding = PaddingValues(bottom = bottomContentPadding)) {
-                        multiSelectMemberList(
-                            contacts = items,
-                            onContactItemClicked = onContactItemClicked,
-                            enabled = !showLoading
+                    if(items.isEmpty()){
+                        Text(
+                            modifier = Modifier.fillMaxWidth()
+                                .padding(top = LocalDimensions.current.xsSpacing),
+                            text = stringResource(R.string.contactNone),
+                            textAlign = TextAlign.Center,
+                            style = LocalType.current.base.copy(color = LocalColors.current.textSecondary)
                         )
+                    } else {
+                        LazyColumn(
+                            contentPadding = PaddingValues(bottom = bottomContentPadding)
+                        ) {
+                            multiSelectMemberList(
+                                contacts = items,
+                                onContactItemClicked = onContactItemClicked,
+                                enabled = !showLoading
+                            )
+                        }
                     }
                 }
 
@@ -190,6 +203,30 @@ private fun CreateGroupPreview(
         ContactItem(accountID = AccountId(random), name = "Alice", false),
         ContactItem(accountID = AccountId(random), name = "Bob", true),
     )
+
+    PreviewTheme {
+        CreateGroup(
+            groupName = "",
+            onGroupNameChanged = {},
+            groupNameError = "",
+            contactSearchQuery = "",
+            onContactSearchQueryChanged = {},
+            onContactItemClicked = {},
+            showLoading = false,
+            items = previewMembers,
+            onCreateClicked = {},
+            onBack = {},
+            modifier = Modifier.background(LocalColors.current.backgroundSecondary),
+        )
+    }
+
+}
+
+@Preview
+@Composable
+private fun CreateEmptyGroupPreview(
+) {
+    val previewMembers = emptyList<ContactItem>()
 
     PreviewTheme {
         CreateGroup(

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/compose/EditGroupScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/compose/EditGroupScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -57,6 +58,7 @@ import org.thoughtcrime.securesms.ui.components.ActionSheet
 import org.thoughtcrime.securesms.ui.components.ActionSheetItemData
 import org.thoughtcrime.securesms.ui.components.PrimaryOutlineButton
 import org.thoughtcrime.securesms.ui.components.SessionOutlinedTextField
+import org.thoughtcrime.securesms.ui.components.annotatedStringResource
 import org.thoughtcrime.securesms.ui.horizontalSlideComposable
 import org.thoughtcrime.securesms.ui.qaTag
 import org.thoughtcrime.securesms.ui.theme.LocalColors
@@ -351,12 +353,11 @@ private fun ConfirmRemovingMemberDialog(
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
-        text = Phrase.from(context, R.string.groupRemoveDescription)
+        text = annotatedStringResource(Phrase.from(context, R.string.groupRemoveDescription)
             .put(NAME_KEY, member.name)
             .put(GROUP_NAME_KEY, groupName)
-            .format()
-            .toString(),
-        title = stringResource(R.string.remove),
+            .format()),
+        title = AnnotatedString(stringResource(R.string.remove)),
         buttons = buttons
     )
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -44,7 +44,6 @@ import org.session.libsession.utilities.StringSubstitutionConstants.GROUP_NAME_K
 import org.session.libsession.utilities.StringSubstitutionConstants.NAME_KEY
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsession.utilities.recipients.Recipient
-import org.session.libsession.utilities.wasKickedFromGroupV2
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.ApplicationContext
 import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity
@@ -74,7 +73,6 @@ import org.thoughtcrime.securesms.recoverypassword.RecoveryPasswordActivity
 import org.thoughtcrime.securesms.showMuteDialog
 import org.thoughtcrime.securesms.showSessionDialog
 import org.thoughtcrime.securesms.ui.setThemedContent
-import org.thoughtcrime.securesms.util.IP2Country
 import org.thoughtcrime.securesms.util.disableClipping
 import org.thoughtcrime.securesms.util.push
 import org.thoughtcrime.securesms.util.show
@@ -670,15 +668,8 @@ class HomeActivity : PassphraseRequiredActionBarActivity(),
                     .format()
             }
         } else {
-            // If this is a 1-on-1 conversation
-            if (recipient.name != null) {
-                title = getString(R.string.conversationsDelete)
-                message = Phrase.from(this, R.string.conversationsDeleteDescription)
-                    .put(NAME_KEY, recipient.toShortString())
-                    .format()
-            }
-            else {
-                // If not group-related and we don't have a recipient name then this must be our Note to Self conversation
+            // Note to self
+            if (recipient.isLocalNumber) {
                 title = getString(R.string.noteToSelfHide)
                 message = getString(R.string.noteToSelfHideDescription)
                 positiveButtonId = R.string.hide
@@ -687,6 +678,12 @@ class HomeActivity : PassphraseRequiredActionBarActivity(),
                 deleteAction = {
                     homeViewModel.hideNoteToSelf()
                 }
+            }
+            else { // If this is a 1-on-1 conversation
+                title = getString(R.string.conversationsDelete)
+                message = Phrase.from(this, R.string.conversationsDeleteDescription)
+                    .put(NAME_KEY, recipient.toShortString())
+                    .format()
             }
         }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/PrivacySettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/PrivacySettingsActivity.kt
@@ -3,10 +3,15 @@ package org.thoughtcrime.securesms.preferences
 import android.os.Bundle
 import dagger.hilt.android.AndroidEntryPoint
 import network.loki.messenger.R
+import org.session.libsession.utilities.TextSecurePreferences.Companion.CALL_NOTIFICATIONS_ENABLED
 import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity
 
 @AndroidEntryPoint
 class PrivacySettingsActivity : PassphraseRequiredActionBarActivity() {
+
+    companion object{
+        const val SCROLL_KEY = "privacy_scroll_key"
+    }
 
     override fun onCreate(savedInstanceState: Bundle?, isReady: Boolean) {
         super.onCreate(savedInstanceState, isReady)
@@ -15,5 +20,9 @@ class PrivacySettingsActivity : PassphraseRequiredActionBarActivity() {
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.fragmentContainer, fragment)
         transaction.commit()
+
+        if(intent.hasExtra(SCROLL_KEY)) {
+            fragment.scrollToKey(intent.getStringExtra(SCROLL_KEY)!!)
+        }
     }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/PrivacySettingsPreferenceFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/PrivacySettingsPreferenceFragment.kt
@@ -66,6 +66,11 @@ class PrivacySettingsPreferenceFragment : CorrectedPreferenceFragment() {
             }.let(category::addPreference)
         }
         initializeVisibility()
+
+    }
+
+    fun scrollToKey(key: String) {
+        scrollToPreference(key)
     }
 
     private fun setCall(isEnabled: Boolean) {

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/components/AppBar.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/components/AppBar.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import network.loki.messenger.R
 import org.thoughtcrime.securesms.ui.Divider
+import org.thoughtcrime.securesms.ui.contentDescription
+import org.thoughtcrime.securesms.ui.qaTag
 import org.thoughtcrime.securesms.ui.theme.LocalColors
 import org.thoughtcrime.securesms.ui.theme.LocalDimensions
 import org.thoughtcrime.securesms.ui.theme.LocalType
@@ -163,10 +165,14 @@ fun AppBarText(title: String) {
 
 @Composable
 fun AppBarBackIcon(onBack: () -> Unit) {
-    IconButton(onClick = onBack) {
+    IconButton(
+        modifier = Modifier.contentDescription(stringResource(R.string.back))
+            .qaTag(stringResource(R.string.AccessibilityId_navigateBack)),
+        onClick = onBack
+    ) {
         Icon(
             painter = painterResource(id = R.drawable.ic_arrow_left),
-            contentDescription = stringResource(R.string.back)
+            contentDescription = null
         )
     }
 }

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -83,7 +83,7 @@
     </style>
 
     <style name="TextAppearance.Session.Dialog.Message" parent="TextAppearance.AppCompat.Body1">
-        <item name="android:textSize">@dimen/small_font_size</item>
+        <item name="android:textSize">@dimen/medium_font_size</item>
     </style>
 
     <style name="ThemeOverlay.Session.AlertDialog" parent="ThemeOverlay.AppCompat.Dialog.Alert">
@@ -162,19 +162,21 @@
     <style name="Widget.Session.Button.Dialog" parent="">
         <item name="android:gravity">center</item>
         <item name="android:textAllCaps">false</item>
-        <item name="android:textSize">@dimen/small_font_size</item>
+        <item name="android:textSize">@dimen/medium_font_size</item>
         <item name="android:textColor">?android:textColorPrimary</item>
     </style>
 
     <style name="Widget.Session.Button.Dialog.UnimportantText">
         <item name="android:background">@drawable/unimportant_dialog_text_button_background</item>
         <item name="android:textStyle">bold</item>
+        <item name="android:textSize">@dimen/medium_font_size</item>
     </style>
 
     <style name="Widget.Session.Button.Dialog.DangerText">
         <item name="android:background">@drawable/danger_dialog_text_button_background</item>
         <item name="android:textColor">?danger</item>
         <item name="android:textStyle">bold</item>
+        <item name="android:textSize">@dimen/medium_font_size</item>
     </style>
 
     <style name="Widget.Session.EditText.Compose" parent="@style/Signal.Text.Body">

--- a/content-descriptions/src/main/res/values/strings.xml
+++ b/content-descriptions/src/main/res/values/strings.xml
@@ -169,7 +169,7 @@
     <string name="AccessibilityId_displayName">Display name</string>
 
     <!-- Misc. -->
-    <string name="AccessibilityId_navigateBack">Navigate Back</string>
+    <string name="AccessibilityId_navigateBack">Navigate back</string>
     <string name="AccessibilityId_close">Close Dialog</string>
     <string name="AccessibilityId_expand">Expand</string>
     <string name="AccessibilityId_mediaMessage">Media message</string>


### PR DESCRIPTION
[SES-3001](https://optf.atlassian.net/browse/SES-3001) - Proper differentiation between note to self and 1on1 when deleting/hiding
[SES-2936](https://optf.atlassian.net/browse/SES-2936) - Make sure we use annotated strings to bold message in dialog
[SES-3035](https://optf.atlassian.net/browse/SES-3035) - Updated test tags
[SES-2979](https://optf.atlassian.net/browse/SES-2979) - Empty member state when creating groups and case insensitive name sorting

Also added the option to auto scroll to the right preference in the privacy screen, for example when wanting to enable the phone calls