### PR TITLE
SES-3036 - Thread should not set default creation time to now

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -158,7 +158,6 @@ public class ThreadDatabase extends Database {
     ContentValues contentValues = new ContentValues(4);
     long date                   = SnodeAPI.getNowWithOffset();
 
-    contentValues.put(THREAD_CREATION_DATE, date - date % 1000);
     contentValues.put(ADDRESS, address.serialize());
 
     if (group) contentValues.put(DISTRIBUTION_TYPE, distributionType);


### PR DESCRIPTION
When a "thread" is created in database, the "date" defaults to 0 (which is equivalent to disable showing date on home screen). However the offending code always creates a thread with a date sets to current time. This is incorrect, as the date should only be updated later with a message (which the code already does).
