### PR TITLE
SES-2929 - Fix member not having access to old messages

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/LokiAPIDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/LokiAPIDatabase.kt
@@ -293,6 +293,11 @@ class LokiAPIDatabase(context: Context, helper: SQLCipherOpenHelper) : Database(
         val lastHash = database.insertOrUpdate(lastMessageHashValueTable2, row, query, arrayOf( snode.toString(), publicKey, namespace.toString() ))
     }
 
+    override fun clearLastMessageHashes(publicKey: String) {
+        databaseHelper.writableDatabase
+            .delete(lastMessageHashValueTable2, "${Companion.publicKey} = ?", arrayOf(publicKey))
+    }
+
     override fun clearAllLastMessageHashes() {
         val database = databaseHelper.writableDatabase
         database.delete(lastMessageHashValueTable2, null, null)
@@ -317,6 +322,11 @@ class LokiAPIDatabase(context: Context, helper: SQLCipherOpenHelper) : Database(
         ))
         val query = "${Companion.publicKey} = ? AND $receivedMessageHashNamespace = ?"
         database.insertOrUpdate(receivedMessageHashValuesTable, row, query, arrayOf( publicKey, namespace.toString() ))
+    }
+
+    override fun clearReceivedMessageHashValues(publicKey: String) {
+        databaseHelper.writableDatabase
+            .delete(receivedMessageHashValuesTable, "${Companion.publicKey} = ?", arrayOf(publicKey))
     }
 
     override fun clearReceivedMessageHashValues() {

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -56,6 +56,7 @@ import org.session.libsignal.utilities.AccountId
 import org.session.libsignal.utilities.Base64
 import org.session.libsignal.utilities.Log
 import org.session.libsignal.utilities.Namespace
+import org.thoughtcrime.securesms.database.LokiAPIDatabase
 import org.thoughtcrime.securesms.database.LokiMessageDatabase
 import org.thoughtcrime.securesms.database.MmsSmsDatabase
 import org.thoughtcrime.securesms.database.ThreadDatabase
@@ -79,6 +80,7 @@ class GroupManagerV2Impl @Inject constructor(
     @ApplicationContext val application: Context,
     private val clock: SnodeClock,
     private val messageDataProvider: MessageDataProvider,
+    private val lokiAPIDatabase: LokiAPIDatabase,
 ) : GroupManagerV2 {
     private val dispatcher = Dispatchers.Default
 
@@ -472,6 +474,8 @@ class GroupManagerV2Impl @Inject constructor(
             storage.getThreadId(Address.fromSerialized(groupId.hexString))
                 ?.let(storage::deleteConversation)
             configFactory.removeGroup(groupId)
+            lokiAPIDatabase.clearLastMessageHashes(groupId.hexString)
+            lokiAPIDatabase.clearReceivedMessageHashValues(groupId.hexString)
         }
     }
 

--- a/libsignal/src/main/java/org/session/libsignal/database/LokiAPIDatabaseProtocol.kt
+++ b/libsignal/src/main/java/org/session/libsignal/database/LokiAPIDatabaseProtocol.kt
@@ -17,9 +17,11 @@ interface LokiAPIDatabaseProtocol {
     fun setSwarm(publicKey: String, newValue: Set<Snode>)
     fun getLastMessageHashValue(snode: Snode, publicKey: String, namespace: Int): String?
     fun setLastMessageHashValue(snode: Snode, publicKey: String, newValue: String, namespace: Int)
+    fun clearLastMessageHashes(publicKey: String)
     fun clearAllLastMessageHashes()
     fun getReceivedMessageHashValues(publicKey: String, namespace: Int): Set<String>?
     fun setReceivedMessageHashValues(publicKey: String, newValue: Set<String>, namespace: Int)
+    fun clearReceivedMessageHashValues(publicKey: String)
     fun clearReceivedMessageHashValues()
     fun getAuthToken(server: String): String?
     fun setAuthToken(server: String, newValue: String?)


### PR DESCRIPTION
Basically when a member leaves/deletes a group, the polling meta should be cleared from the db, so next time they get reinvited, they start from scratch instead. This way they will have access to all messages that are decryptable.
