### PR TITLE
Fix/phone call from lockscreen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -304,7 +304,7 @@ dependencies {
     implementation 'androidx.media3:media3-ui:1.4.0'
     implementation 'org.conscrypt:conscrypt-android:2.5.2'
     implementation 'org.signal:aesgcmprovider:0.0.3'
-    implementation 'io.github.webrtc-sdk:android:125.6422.04'
+    implementation 'io.github.webrtc-sdk:android:125.6422.06.1'
     implementation "me.leolin:ShortcutBadger:1.1.16"
     implementation 'se.emilsjolander:stickylistheaders:2.7.0'
     implementation 'com.jpardogo.materialtabstrip:library:1.0.9'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,13 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" /> <!-- We cannot declare this is good fair because we don't implement `ConnectionService` - see: https://developer.android.com/reference/android/telecom/ConnectionService -->
+
+    <!-- Google may (potentially) insist we implement `ConnectionService` to request MANAGE_OWN_CALLS - see:
+           - https://developer.android.com/reference/android/Manifest.permission#MANAGE_OWN_CALLS
+           - https://developer.android.com/reference/android/telecom/ConnectionService
+    -->
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
+
     <uses-permission android:name="android.app.role.DIALER" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,12 +37,14 @@
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" tools:node="remove" />
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />           <!-- For video calls -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" /> <!-- For calls that get audio from bluetooth headsets -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" /> <!-- We cannot declare this is good fair because we don't implement `ConnectionService` - see: https://developer.android.com/reference/android/telecom/ConnectionService -->
     <uses-permission android:name="android.app.role.DIALER" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,38 +29,41 @@
         android:name="android.hardware.touchscreen"
         android:required="false" />
 
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BROADCAST_STICKY" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" tools:node="remove" />
+    <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
-    <uses-permission android:name="network.loki.messenger.ACCESS_SESSION_SECRETS" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> <!-- Only used on Android API 29 and lower -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
+    <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
+    <uses-permission android:name="android.app.role.DIALER" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.RAISED_THREAD_PRIORITY" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
-    <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
-    <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
-    <uses-permission android:name="android.permission.INSTALL_SHORTCUT" />
-    <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
-    <uses-permission android:name="android.permission.BROADCAST_STICKY" />
-    <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
-    <uses-permission android:name="android.permission.RAISED_THREAD_PRIORITY" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
-    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" tools:node="remove"/>
-    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT"/>
+    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> <!-- Only used on Android API 29 and lower -->
+    <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
+    <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
+    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
+    <uses-permission android:name="network.loki.messenger.ACCESS_SESSION_SECRETS" />
 
     <queries>
         <intent>
@@ -314,8 +317,10 @@
         </activity>
         <activity android:name="org.thoughtcrime.securesms.media.MediaOverviewActivity" />
 
-        <service android:enabled="true" android:name="org.thoughtcrime.securesms.service.WebRtcCallService"
-            android:foregroundServiceType="microphone"
+        <service
+            android:enabled="true"
+            android:name="org.thoughtcrime.securesms.service.WebRtcCallService"
+            android:foregroundServiceType="phoneCall"
             android:exported="false" />
         <service
             android:name="org.thoughtcrime.securesms.service.KeyCachingService"

--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -169,7 +169,7 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
     @Inject LokiAPIDatabase apiDB;
     @Inject EmojiSearchDatabase emojiSearchDb;
 
-    private volatile boolean isAppVisible;
+    public static volatile boolean isAppVisible;
 
     @Override
     public Object getSystemService(String name) {

--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -406,7 +406,6 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
   @SuppressWarnings("CodeBlock2Expr")
   @SuppressLint("InlinedApi")
   private void saveToDisk() {
-    Log.w("ACL", "Asked to save to disk!");
     MediaItem mediaItem = getCurrentMediaItem();
     if (mediaItem == null) return;
 

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
@@ -262,7 +262,7 @@ class WebRtcCallActivity : PassphraseRequiredActionBarActivity() {
                 Orientation.REVERSED_LANDSCAPE -> 90f
                 else -> 0f
             }
-
+R.drawable.ic_baseline_call_24
             userAvatar.animate().cancel()
             userAvatar.animate().rotation(rotation).start()
             contactAvatar.animate().cancel()

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -146,11 +146,8 @@ public abstract class MessageRecord extends DisplayRecord {
       } else if (isOutgoingCall()) {
         callType = CallMessageType.CALL_OUTGOING;
       } else if (isMissedCall()) {
-        Log.w("ACL", "We think CALL_MISSSED");
-
         callType = CallMessageType.CALL_MISSED;
       } else {
-        Log.w("ACL", "We think CALL_FIRST_MISSSED");
         callType = CallMessageType.CALL_FIRST_MISSED;
       }
       return new SpannableString(UpdateMessageBuilder.INSTANCE.buildCallMessage(context, callType, getIndividualRecipient().getAddress().serialize()));

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -32,6 +32,7 @@ import org.session.libsession.messaging.utilities.UpdateMessageData;
 import org.session.libsession.utilities.IdentityKeyMismatch;
 import org.session.libsession.utilities.NetworkFailure;
 import org.session.libsession.utilities.recipients.Recipient;
+import org.session.libsignal.utilities.Log;
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent;
 
 import java.util.List;
@@ -145,8 +146,11 @@ public abstract class MessageRecord extends DisplayRecord {
       } else if (isOutgoingCall()) {
         callType = CallMessageType.CALL_OUTGOING;
       } else if (isMissedCall()) {
+        Log.w("ACL", "We think CALL_MISSSED");
+
         callType = CallMessageType.CALL_MISSED;
       } else {
+        Log.w("ACL", "We think CALL_FIRST_MISSSED");
         callType = CallMessageType.CALL_FIRST_MISSED;
       }
       return new SpannableString(UpdateMessageBuilder.INSTANCE.buildCallMessage(context, callType, getIndividualRecipient().getAddress().serialize()));

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -105,7 +105,7 @@ public class ThreadRecord extends DisplayRecord {
     @Override
     public CharSequence getDisplayBody(@NonNull Context context) {
         // no need to display anything if there are no messages
-        if(lastMessage == null){
+        if (lastMessage == null){
             return "";
         }
         else if (isGroupUpdateMessage()) {

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -224,14 +224,14 @@ class DefaultMessageNotifier : MessageNotifier {
                         sendSingleThreadNotification(context, NotificationState(notificationState.getNotificationsForThread(threadId)), false, true)
                     }
                     sendMultipleThreadNotification(context, notificationState, playNotificationAudio)
-                } else if (notificationState.messageCount > 0) {
+                } else if (notificationState.notificationCount > 0) {
                     sendSingleThreadNotification(context, notificationState, playNotificationAudio, false)
                 } else {
                     cancelActiveNotifications(context)
                 }
 
                 cancelOrphanedNotifications(context, notificationState)
-                updateBadge(context, notificationState.messageCount)
+                updateBadge(context, notificationState.notificationCount)
 
                 if (playNotificationAudio) {
                     scheduleReminder(context, reminderCount)
@@ -289,7 +289,7 @@ class DefaultMessageNotifier : MessageNotifier {
         if (ApplicationContext.isAppVisible && notificationText == missedCallString) { return }
 
         builder.setThread(notifications[0].recipient)
-        builder.setMessageCount(notificationState.messageCount)
+        builder.setMessageCount(notificationState.notificationCount)
 
         val builderCS = notificationText ?: ""
         val ss = highlightMentions(
@@ -385,7 +385,7 @@ class DefaultMessageNotifier : MessageNotifier {
         val builder = MultipleRecipientNotificationBuilder(context, getNotificationPrivacy(context))
         val notifications = notificationState.notifications
 
-        builder.setMessageCount(notificationState.messageCount, notificationState.threadCount)
+        builder.setMessageCount(notificationState.notificationCount, notificationState.threadCount)
         builder.setMostRecentSender(notifications[0].individualRecipient, notifications[0].recipient)
         builder.setGroup(NOTIFICATION_GROUP)
         builder.setDeleteIntent(notificationState.getDeleteIntent(context))

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -263,7 +263,7 @@ class DefaultMessageNotifier : MessageNotifier {
 
         val builder = SingleRecipientNotificationBuilder(context, getNotificationPrivacy(context))
         val notifications = notificationState.notifications
-        val recipient = notifications[0].recipient
+        val messageOriginator = notifications[0].recipient
         val notificationId = (SUMMARY_NOTIFICATION_ID + (if (bundled) notifications[0].threadId else 0)).toInt()
         val messageIdTag = notifications[0].timestamp.toString()
 
@@ -282,10 +282,6 @@ class DefaultMessageNotifier : MessageNotifier {
         builder.putStringExtra(LATEST_MESSAGE_ID_TAG, messageIdTag)
 
         val notificationText = notifications[0].text
-
-        // TODO: We get missed call notifications whenever we get a call - I have no idea why, and it would be better to strip them out
-        // TODO: at the source - but I'll stop them here if we recognise the notification text and the home screen is visible
-
 
         // For some reason, even when we're starting a call we get a missed call notification - so we'll bail before that happens.
         // TODO: Probably better to fix this at the source so that this never gets called rather then here - do this.
@@ -306,7 +302,7 @@ class DefaultMessageNotifier : MessageNotifier {
         )
 
         builder.setPrimaryMessageBody(
-            recipient,
+            messageOriginator,
             notifications[0].individualRecipient,
             ss,
             notifications[0].slideDeck
@@ -318,12 +314,12 @@ class DefaultMessageNotifier : MessageNotifier {
         builder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
         builder.setAutoCancel(true)
 
-        val replyMethod = ReplyMethod.forRecipient(context, recipient)
+        val replyMethod = ReplyMethod.forRecipient(context, messageOriginator)
 
-        val canReply = canUserReplyToNotification(recipient)
+        val canReply = canUserReplyToNotification(messageOriginator)
 
-        val quickReplyIntent = if (canReply) notificationState.getQuickReplyIntent(context, recipient) else null
-        val remoteReplyIntent = if (canReply) notificationState.getRemoteReplyIntent(context, recipient, replyMethod) else null
+        val quickReplyIntent = if (canReply) notificationState.getQuickReplyIntent(context, messageOriginator) else null
+        val remoteReplyIntent = if (canReply) notificationState.getRemoteReplyIntent(context, messageOriginator, replyMethod) else null
 
         builder.addActions(
             notificationState.getMarkAsReadIntent(context, notificationId),
@@ -334,7 +330,7 @@ class DefaultMessageNotifier : MessageNotifier {
 
         if (canReply) {
             builder.addAndroidAutoAction(
-                notificationState.getAndroidAutoReplyIntent(context, recipient),
+                notificationState.getAndroidAutoReplyIntent(context, messageOriginator),
                 notificationState.getAndroidAutoHeardIntent(context, notificationId),
                 notifications[0].timestamp
             )

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/NotificationState.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/NotificationState.java
@@ -3,20 +3,18 @@ package org.thoughtcrime.securesms.notifications;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
-import org.session.libsession.utilities.recipients.Recipient;
-import org.session.libsession.utilities.recipients.Recipient.VibrateState;
-import org.session.libsignal.utilities.Log;
-import org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2;
-
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import org.session.libsession.utilities.recipients.Recipient.VibrateState;
+import org.session.libsession.utilities.recipients.Recipient;
+import org.session.libsignal.utilities.Log;
+import org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2;
 
 public class NotificationState {
 
@@ -36,68 +34,54 @@ public class NotificationState {
   }
 
   public void addNotification(NotificationItem item) {
+    // Add this new notification at the beginning of the list
     notifications.addFirst(item);
 
+    // TODO: This doesn't make sense - why would be remove a threadId from the threads LinkedHashSet<Long> and then immediately put it back? `add` already only adds it if doesn't already exist - skipping this for now as a test -ACL
+    /*
     if (threads.contains(item.getThreadId())) {
       threads.remove(item.getThreadId());
     }
-
+    */
     threads.add(item.getThreadId());
+
     notificationCount++;
   }
 
   public @Nullable Uri getRingtone(@NonNull Context context) {
     if (!notifications.isEmpty()) {
       Recipient recipient = notifications.getFirst().getRecipient();
-
-      if (recipient != null) {
-        return NotificationChannels.getMessageRingtone(context, recipient);
-      }
+      return NotificationChannels.getMessageRingtone(context, recipient);
     }
 
-    return null;
+    // TODO: Going to try returning the default ringtone for a notification rather than null here - seems like a more sensible option.
+    //return null;
+
+    return RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
   }
 
   public VibrateState getVibrate() {
     if (!notifications.isEmpty()) {
       Recipient recipient = notifications.getFirst().getRecipient();
-
-      if (recipient != null) {
-        return recipient.resolve().getMessageVibrate();
-      }
+      return recipient.resolve().getMessageVibrate();
     }
-
     return VibrateState.DEFAULT;
   }
 
-  public boolean hasMultipleThreads() {
-    return threads.size() > 1;
-  }
-
-  public LinkedHashSet<Long> getThreads() {
-    return threads;
-  }
-
-  public int getThreadCount() {
-    return threads.size();
-  }
-
-  public int getMessageCount() {
-    return notificationCount;
-  }
-
-  public List<NotificationItem> getNotifications() {
-    return notifications;
-  }
+  public boolean hasMultipleThreads()              { return threads.size() > 1; }
+  public LinkedHashSet<Long> getThreads()          { return threads;            }
+  public int getThreadCount()                      { return threads.size();     }
+  public int getNotificationCount()                { return notificationCount;  }
+  public List<NotificationItem> getNotifications() { return notifications;      }
 
   public List<NotificationItem> getNotificationsForThread(long threadId) {
-    LinkedList<NotificationItem> list = new LinkedList<>();
+    LinkedList<NotificationItem> notificationsInThread = new LinkedList<>();
 
     for (NotificationItem item : notifications) {
-      if (item.getThreadId() == threadId) list.addFirst(item);
+      if (item.getThreadId() == threadId) notificationsInThread.addFirst(item);
     }
 
-    return list;
+    return notificationsInThread;
   }
 
   public PendingIntent getMarkAsReadIntent(Context context, int notificationId) {
@@ -111,7 +95,7 @@ public class NotificationState {
 
     Intent intent = new Intent(MarkReadReceiver.CLEAR_ACTION);
     intent.setClass(context, MarkReadReceiver.class);
-    intent.setData((Uri.parse("custom://"+System.currentTimeMillis())));
+    intent.setData((Uri.parse("custom://" + System.currentTimeMillis())));
     intent.putExtra(MarkReadReceiver.THREAD_IDS_EXTRA, threadArray);
     intent.putExtra(MarkReadReceiver.NOTIFICATION_ID_EXTRA, notificationId);
 
@@ -171,7 +155,7 @@ public class NotificationState {
     Intent intent = new Intent(AndroidAutoHeardReceiver.HEARD_ACTION);
     intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
     intent.setClass(context, AndroidAutoHeardReceiver.class);
-    intent.setData((Uri.parse("custom://"+System.currentTimeMillis())));
+    intent.setData((Uri.parse("custom://" + System.currentTimeMillis())));
     intent.putExtra(AndroidAutoHeardReceiver.THREAD_IDS_EXTRA, threadArray);
     intent.putExtra(AndroidAutoHeardReceiver.NOTIFICATION_ID_EXTRA, notificationId);
     intent.setPackage(context.getPackageName());
@@ -223,6 +207,4 @@ public class NotificationState {
 
     return PendingIntent.getBroadcast(context, 0, intent, intentFlags);
   }
-
-
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/NotificationState.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/NotificationState.java
@@ -37,12 +37,8 @@ public class NotificationState {
     // Add this new notification at the beginning of the list
     notifications.addFirst(item);
 
-    // TODO: This doesn't make sense - why would be remove a threadId from the threads LinkedHashSet<Long> and then immediately put it back? `add` already only adds it if doesn't already exist - skipping this for now as a test -ACL
-    /*
-    if (threads.contains(item.getThreadId())) {
-      threads.remove(item.getThreadId());
-    }
-    */
+    // Put a notification at the front by removing it then re-adding it?
+    threads.remove(item.getThreadId());
     threads.add(item.getThreadId());
 
     notificationCount++;
@@ -53,9 +49,6 @@ public class NotificationState {
       Recipient recipient = notifications.getFirst().getRecipient();
       return NotificationChannels.getMessageRingtone(context, recipient);
     }
-
-    // TODO: Going to try returning the default ringtone for a notification rather than null here - seems like a more sensible option.
-    //return null;
 
     return RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/PushManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/PushManager.kt
@@ -1,5 +1,0 @@
-package org.thoughtcrime.securesms.notifications
-
-interface PushManager {
-    fun refresh(force: Boolean)
-}

--- a/app/src/main/java/org/thoughtcrime/securesms/service/KeyCachingService.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/KeyCachingService.java
@@ -235,7 +235,6 @@ public class KeyCachingService extends Service {
 
   private void foregroundService() {
     if (TextSecurePreferences.isPasswordDisabled(this) && !TextSecurePreferences.isScreenLockEnabled(this)) {
-      Log.w("ACL", "Stopping foreground service in KeyCachingService");
       stopForeground(true);
       return;
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/service/KeyCachingService.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/KeyCachingService.java
@@ -235,6 +235,7 @@ public class KeyCachingService extends Service {
 
   private void foregroundService() {
     if (TextSecurePreferences.isPasswordDisabled(this) && !TextSecurePreferences.isScreenLockEnabled(this)) {
+      Log.w("ACL", "Stopping foreground service in KeyCachingService");
       stopForeground(true);
       return;
     }
@@ -248,8 +249,6 @@ public class KeyCachingService extends Service {
             .put(APP_NAME_KEY, c.getString(R.string.app_name))
             .format().toString();
     builder.setContentTitle(unlockedTxt);
-
-    builder.setContentText(getString(R.string.lockAppUnlock));
     builder.setSmallIcon(R.drawable.icon_cached);
     builder.setWhen(0);
     builder.setPriority(Notification.PRIORITY_MIN);

--- a/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
@@ -730,7 +730,7 @@ class WebRtcCallService : LifecycleService(), CallManager.WebRtcListener {
                 this,
                 CallNotificationBuilder.WEBRTC_NOTIFICATION,
                 CallNotificationBuilder.getCallInProgressNotification(this, type, recipient),
-                if (Build.VERSION.SDK_INT >= 30) ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE else 0
+                if (Build.VERSION.SDK_INT >= 30) ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL else 0
             )
         } catch (e: IllegalStateException) {
             Log.e(TAG, "Failed to setCallInProgressNotification as a foreground service for type: ${type}, trying to update instead", e)

--- a/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
@@ -743,6 +743,8 @@ class WebRtcCallService : LifecycleService(), CallManager.WebRtcListener {
     }
 
     private fun wakeUpDeviceIfLocked() {
+        Log.w("ACL", "Hit WRCS.wakeUpDeviceIfLocked at: ${System.currentTimeMillis()} !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+
         // Get the KeyguardManager and PowerManager
         val keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
         val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
@@ -765,12 +767,19 @@ class WebRtcCallService : LifecycleService(), CallManager.WebRtcListener {
             wakeLock.acquire(3000)
 
             while (!powerManager.isInteractive) {
-                /* Busy wait until we're awake - typically takes less than ~10ms */
+                /* Busy wait until we're awake - typically this takes less than ~10ms */
             }
         }
 
-        // Dismiss the keyguard
-        val keyguardLock = keyguardManager.newKeyguardLock("MyApp:KeyguardLock")
+        // Dismiss the keyguard.
+        // Note: This will NOT work if Session itself has a lock on it, which is what we want, as
+        // otherwise this would be a lock-bypass mechanism! When Session has a lock the user must
+        // unlock their device, then unlock Session - however without a lock on Session (but with
+        // one on the device) then this will bypass the device lock to show the full-screen intent
+        // regarding the incoming call.
+        // TODO: When we move to a minimum Android API of 27 (our minimum is API 26 as of 9th Dec 2024) then replace these deprecated calls.
+        // TODO: If we try to remove them before this it gets messy because the replacements only came in at API 27.
+        val keyguardLock = keyguardManager.newKeyguardLock("{${NonTranslatableStringConstants.APP_NAME}:KeyguardLock")
         keyguardLock.disableKeyguard()
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/util/CallNotificationBuilder.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/CallNotificationBuilder.kt
@@ -25,42 +25,17 @@ class CallNotificationBuilder {
     companion object {
         const val WEBRTC_NOTIFICATION = 313388
 
-        const val TYPE_INCOMING_RINGING = 1
-        const val TYPE_OUTGOING_RINGING = 2
-        const val TYPE_ESTABLISHED = 3
+        const val TYPE_INCOMING_RINGING    = 1
+        const val TYPE_OUTGOING_RINGING    = 2
+        const val TYPE_ESTABLISHED         = 3
         const val TYPE_INCOMING_CONNECTING = 4
-        const val TYPE_INCOMING_PRE_OFFER = 5
+        const val TYPE_INCOMING_PRE_OFFER  = 5
 
         @JvmStatic
         fun areNotificationsEnabled(context: Context): Boolean {
             val notificationManager = NotificationManagerCompat.from(context)
             return notificationManager.areNotificationsEnabled()
         }
-
-//        @JvmStatic
-//        fun getFirstCallNotification(context: Context, callerName: String): Notification {
-//            val contentIntent = Intent(context, SettingsActivity::class.java)
-//
-//            val pendingIntent = PendingIntent.getActivity(context, 0, contentIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-//
-//            val titleTxt = context.getSubbedString(R.string.callsMissedCallFrom, NAME_KEY to callerName)
-//            val bodyTxt = context.getSubbedCharSequence(
-//                R.string.callsYouMissedCallPermissions,
-//                NAME_KEY to callerName
-//            )
-//
-//            val builder = NotificationCompat.Builder(context, NotificationChannels.CALLS)
-//                    .setSound(null)
-//                    .setSmallIcon(R.drawable.ic_baseline_call_24)
-//                    .setContentIntent(pendingIntent)
-//                    .setPriority(NotificationCompat.PRIORITY_HIGH)
-//                    .setContentTitle(titleTxt)
-//                    .setContentText(bodyTxt)
-//                    .setStyle(NotificationCompat.BigTextStyle().bigText(bodyTxt))
-//                    .setAutoCancel(true)
-//
-//            return builder.build()
-//        }
 
         @JvmStatic
         fun getCallInProgressNotification(context: Context, type: Int, recipient: Recipient?): Notification {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/CallNotificationBuilder.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/CallNotificationBuilder.kt
@@ -37,30 +37,30 @@ class CallNotificationBuilder {
             return notificationManager.areNotificationsEnabled()
         }
 
-        @JvmStatic
-        fun getFirstCallNotification(context: Context, callerName: String): Notification {
-            val contentIntent = Intent(context, SettingsActivity::class.java)
-
-            val pendingIntent = PendingIntent.getActivity(context, 0, contentIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-
-            val titleTxt = context.getSubbedString(R.string.callsMissedCallFrom, NAME_KEY to callerName)
-            val bodyTxt = context.getSubbedCharSequence(
-                R.string.callsYouMissedCallPermissions,
-                NAME_KEY to callerName
-            )
-
-            val builder = NotificationCompat.Builder(context, NotificationChannels.CALLS)
-                    .setSound(null)
-                    .setSmallIcon(R.drawable.ic_baseline_call_24)
-                    .setContentIntent(pendingIntent)
-                    .setPriority(NotificationCompat.PRIORITY_HIGH)
-                    .setContentTitle(titleTxt)
-                    .setContentText(bodyTxt)
-                    .setStyle(NotificationCompat.BigTextStyle().bigText(bodyTxt))
-                    .setAutoCancel(true)
-
-            return builder.build()
-        }
+//        @JvmStatic
+//        fun getFirstCallNotification(context: Context, callerName: String): Notification {
+//            val contentIntent = Intent(context, SettingsActivity::class.java)
+//
+//            val pendingIntent = PendingIntent.getActivity(context, 0, contentIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+//
+//            val titleTxt = context.getSubbedString(R.string.callsMissedCallFrom, NAME_KEY to callerName)
+//            val bodyTxt = context.getSubbedCharSequence(
+//                R.string.callsYouMissedCallPermissions,
+//                NAME_KEY to callerName
+//            )
+//
+//            val builder = NotificationCompat.Builder(context, NotificationChannels.CALLS)
+//                    .setSound(null)
+//                    .setSmallIcon(R.drawable.ic_baseline_call_24)
+//                    .setContentIntent(pendingIntent)
+//                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+//                    .setContentTitle(titleTxt)
+//                    .setContentText(bodyTxt)
+//                    .setStyle(NotificationCompat.BigTextStyle().bigText(bodyTxt))
+//                    .setAutoCancel(true)
+//
+//            return builder.build()
+//        }
 
         @JvmStatic
         fun getCallInProgressNotification(context: Context, type: Int, recipient: Recipient?): Notification {

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
@@ -232,7 +232,7 @@ class Poller(
             }
         }
     }
-    
+
     private fun poll(snode: Snode, deferred: Deferred<Unit, Exception>): Promise<Unit, Exception> {
         if (!hasStarted) { return Promise.ofFail(PromiseCanceledException()) }
         return GlobalScope.asyncPromise {

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
@@ -2,6 +2,9 @@ package org.session.libsession.messaging.sending_receiving.pollers
 
 import android.util.SparseArray
 import androidx.core.util.valueIterator
+import java.util.Timer
+import java.util.TimerTask
+import kotlin.time.Duration.Companion.days
 import kotlinx.coroutines.GlobalScope
 import nl.komponents.kovenant.Deferred
 import nl.komponents.kovenant.Promise
@@ -27,9 +30,6 @@ import org.session.libsignal.utilities.Log
 import org.session.libsignal.utilities.Namespace
 import org.session.libsignal.utilities.Snode
 import org.session.libsignal.utilities.Util.SECURE_RANDOM
-import java.util.Timer
-import java.util.TimerTask
-import kotlin.time.Duration.Companion.days
 
 private const val TAG = "Poller"
 
@@ -49,8 +49,9 @@ class Poller(
 
     // region Settings
     companion object {
-        private const val retryInterval: Long = 2 * 1000
-        private const val maxInterval: Long = 15 * 1000
+        private const val RETRY_INTERVAL_MS: Long       = 2  * 1000
+        private const val MAX_RETRY_INTERVAL_MS: Long   = 15 * 1000
+        private const val NEXT_RETRY_MULTIPLIER: Float = 1.2f // If we fail to poll we multiply our current retry interval by this (up to the above max) then try again
     }
     // endregion
 
@@ -59,7 +60,7 @@ class Poller(
         if (hasStarted) { return }
         Log.d(TAG, "Started polling.")
         hasStarted = true
-        setUpPolling(retryInterval)
+        setUpPolling(RETRY_INTERVAL_MS)
     }
 
     fun stopIfNeeded() {
@@ -72,11 +73,11 @@ class Poller(
         Log.d(TAG, "Retrieving user profile. for key = $userPublicKey")
         SnodeAPI.getSwarm(userPublicKey).bind {
             usedSnodes.clear()
-            deferred<Unit, Exception>().also {
-                pollNextSnode(userProfileOnly = true, it)
+            deferred<Unit, Exception>().also { exception ->
+                pollNextSnode(userProfileOnly = true, exception)
             }.promise
-        }.fail {
-            Log.e(TAG, "Failed to retrieve user profile.", it)
+        }.fail { exception ->
+            Log.e(TAG, "Failed to retrieve user profile.", exception)
         }
     }
     // endregion
@@ -91,14 +92,14 @@ class Poller(
             pollNextSnode(deferred = deferred)
             deferred.promise
         }.success {
-            val nextDelay = if (isCaughtUp) retryInterval else 0
+            val nextDelay = if (isCaughtUp) RETRY_INTERVAL_MS else 0
             Timer().schedule(object : TimerTask() {
                 override fun run() {
-                    thread.run { setUpPolling(retryInterval) }
+                    thread.run { setUpPolling(RETRY_INTERVAL_MS) }
                 }
             }, nextDelay)
         }.fail {
-            val nextDelay = minOf(maxInterval, (delay * 1.2).toLong())
+            val nextDelay = minOf(MAX_RETRY_INTERVAL_MS, (delay * NEXT_RETRY_MULTIPLIER).toLong())
             Timer().schedule(object : TimerTask() {
                 override fun run() {
                     thread.run { setUpPolling(nextDelay) }
@@ -231,8 +232,7 @@ class Poller(
             }
         }
     }
-
-
+    
     private fun poll(snode: Snode, deferred: Deferred<Unit, Exception>): Promise<Unit, Exception> {
         if (!hasStarted) { return Promise.ofFail(PromiseCanceledException()) }
         return GlobalScope.asyncPromise {


### PR DESCRIPTION
### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fix to prevents failure to display call notifications when the device is asleep or locked. Android 12 and above has tightened permissions with regard to start services, in particularly foreground services in such cases. As such, this patch wakes the device up in order to start the call service and display an incoming call notification.

### Test steps:
With two devices running (Alice and Bob) - have Alice call Bob under the following conditions:
- With Bob having the app visible in the foreground,
- With Bob having the app running the background (i.e., dismissed but not closed),
- With Bob having force-closed the app (i.e., manually closed it from the back-stack) but the device is awake,
- With Bob having force-closed the app and then locked the device.

In each case Bob should receive an incoming call notification. You may also wish to test with adding a lock-screen to Bob's device (pin or pattern etc.), and optionally locking Session (which will require a second unlock identical to that required to lock the device). Again, in each case Bob should receive an incoming call notification which he can answer or decline.

It should be noted that Calls are in Beta and may not always successfully set up a call, so it may be possible to fail to initialise a call entirely, which may not necessarily be caused by the changes in this branch, which on the whole have been observed to improve the availability of call notifications.