### PR TITLE
Fix phone call from lock screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -299,7 +299,7 @@ dependencies {
     implementation 'androidx.media3:media3-ui:1.4.0'
     implementation 'org.conscrypt:conscrypt-android:2.5.2'
     implementation 'org.signal:aesgcmprovider:0.0.3'
-    implementation 'io.github.webrtc-sdk:android:125.6422.04'
+    implementation 'io.github.webrtc-sdk:android:125.6422.06.1'
     implementation "me.leolin:ShortcutBadger:1.1.16"
     implementation 'se.emilsjolander:stickylistheaders:2.7.0'
     implementation 'com.jpardogo.materialtabstrip:library:1.0.9'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ configurations.forEach {
     it.exclude module: "commons-logging"
 }
 
-def canonicalVersionCode = 389
-def canonicalVersionName = "1.20.7"
+def canonicalVersionCode = 390
+def canonicalVersionName = "1.20.8"
 
 def postFixSize = 10
 def abiPostFix = ['armeabi-v7a' : 1,

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,38 +29,41 @@
         android:name="android.hardware.touchscreen"
         android:required="false" />
 
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BROADCAST_STICKY" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" tools:node="remove" />
+    <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
-    <uses-permission android:name="network.loki.messenger.ACCESS_SESSION_SECRETS" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> <!-- Only used on Android API 29 and lower -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
+    <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
+    <uses-permission android:name="android.app.role.DIALER" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.RAISED_THREAD_PRIORITY" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
-    <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
-    <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
-    <uses-permission android:name="android.permission.INSTALL_SHORTCUT" />
-    <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
-    <uses-permission android:name="android.permission.BROADCAST_STICKY" />
-    <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
-    <uses-permission android:name="android.permission.RAISED_THREAD_PRIORITY" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
-    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" tools:node="remove"/>
-    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT"/>
+    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> <!-- Only used on Android API 29 and lower -->
+    <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
+    <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
+    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
+    <uses-permission android:name="network.loki.messenger.ACCESS_SESSION_SECRETS" />
 
     <queries>
         <intent>
@@ -304,8 +307,10 @@
         </activity>
         <activity android:name="org.thoughtcrime.securesms.media.MediaOverviewActivity" />
 
-        <service android:enabled="true" android:name="org.thoughtcrime.securesms.service.WebRtcCallService"
-            android:foregroundServiceType="microphone"
+        <service
+            android:enabled="true"
+            android:name="org.thoughtcrime.securesms.service.WebRtcCallService"
+            android:foregroundServiceType="phoneCall"
             android:exported="false" />
         <service
             android:name="org.thoughtcrime.securesms.service.KeyCachingService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,13 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" /> <!-- We cannot declare this is good fair because we don't implement `ConnectionService` - see: https://developer.android.com/reference/android/telecom/ConnectionService -->
+
+    <!-- Google may (potentially) insist we implement `ConnectionService` to request MANAGE_OWN_CALLS - see:
+           - https://developer.android.com/reference/android/Manifest.permission#MANAGE_OWN_CALLS
+           - https://developer.android.com/reference/android/telecom/ConnectionService
+    -->
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
+
     <uses-permission android:name="android.app.role.DIALER" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,12 +37,14 @@
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" tools:node="remove" />
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />           <!-- For video calls -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" /> <!-- For calls that get audio from bluetooth headsets -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" /> <!-- We cannot declare this is good fair because we don't implement `ConnectionService` - see: https://developer.android.com/reference/android/telecom/ConnectionService -->
     <uses-permission android:name="android.app.role.DIALER" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>

--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -148,7 +148,7 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
     CallMessageProcessor callMessageProcessor;
     MessagingModuleConfiguration messagingModuleConfiguration;
 
-    private volatile boolean isAppVisible;
+    public static volatile boolean isAppVisible;
 
     @Override
     public Object getSystemService(String name) {

--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -155,7 +155,7 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
 
     public volatile boolean isAppVisible;
     public String KEYGUARD_LOCK_TAG = NonTranslatableStringConstants.APP_NAME + ":KeyguardLock";
-    public String WAKELOCK_TAG      = NonTranslatableStringConstants.APP_NAME + "WakeLock";
+    public String WAKELOCK_TAG      = NonTranslatableStringConstants.APP_NAME + ":WakeLock";
 
     @Override
     public Object getSystemService(String name) {

--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -513,6 +513,17 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
 
             // Acquire the wake lock to wake up the device
             wakeLock.acquire(3000);
+
+            // Wait for the device to actually wake up
+            AtomicBoolean stopWaitingForWakeUp = new AtomicBoolean(false);
+            long MAX_WAIT_PERIOD_MS = 50L;
+            Handler handler = new Handler(Looper.getMainLooper());
+            handler.postDelayed(() -> stopWaitingForWakeUp.set(true), MAX_WAIT_PERIOD_MS);
+
+            // Busy-wait until the screen is interactive - to be safe, we'll wait a maximum of 50ms.
+            do {
+                 /* Typically this loop runs very briefly - for somewhere in the order of 10ms or less */
+            } while (!powerManager.isInteractive() && !stopWaitingForWakeUp.get());
         }
 
         // Dismiss the keyguard.

--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -496,12 +496,7 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
 
     // endregion
 
-    // Method to wake up the screen and dismiss the keyguard.
-    // Call this method off the main thread because it deliberately busy-waits for the device to wake up.
-    // For example, you can call it via:
-    //      ThreadUtils.queue {
-    //          (context as ApplicationContext).wakeUpDeviceAndDismissKeyguardIfRequired()
-    //      }
+    // Method to wake up the screen and dismiss the keyguard
     public void wakeUpDeviceAndDismissKeyguardIfRequired() {
         // Get the KeyguardManager and PowerManager
         KeyguardManager keyguardManager = (KeyguardManager)getSystemService(Context.KEYGUARD_SERVICE);

--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -26,10 +26,7 @@ import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.os.Looper;
 import android.os.PowerManager;
-import android.os.SystemClock;
-
 import androidx.annotation.NonNull;
 import androidx.core.content.pm.ShortcutInfoCompat;
 import androidx.core.content.pm.ShortcutManagerCompat;
@@ -37,7 +34,20 @@ import androidx.core.graphics.drawable.IconCompat;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.ProcessLifecycleOwner;
-
+import dagger.hilt.EntryPoints;
+import dagger.hilt.android.HiltAndroidApp;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Timer;
+import java.util.concurrent.Executors;
+import javax.inject.Inject;
+import network.loki.messenger.BuildConfig;
+import network.loki.messenger.R;
+import network.loki.messenger.libsession_util.ConfigBase;
+import network.loki.messenger.libsession_util.UserProfile;
 import org.conscrypt.Conscrypt;
 import org.session.libsession.database.MessageDataProvider;
 import org.session.libsession.messaging.MessagingModuleConfiguration;
@@ -93,26 +103,8 @@ import org.thoughtcrime.securesms.sskenvironment.TypingStatusRepository;
 import org.thoughtcrime.securesms.util.Broadcaster;
 import org.thoughtcrime.securesms.util.VersionDataFetcher;
 import org.thoughtcrime.securesms.webrtc.CallMessageProcessor;
-import org.webrtc.PeerConnectionFactory;
 import org.webrtc.PeerConnectionFactory.InitializationOptions;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.security.Security;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Timer;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.inject.Inject;
-
-import dagger.hilt.EntryPoints;
-import dagger.hilt.android.HiltAndroidApp;
-import network.loki.messenger.BuildConfig;
-import network.loki.messenger.R;
-import network.loki.messenger.libsession_util.ConfigBase;
-import network.loki.messenger.libsession_util.UserProfile;
+import org.webrtc.PeerConnectionFactory;
 
 /**
  * Will be called once when the TextSecure process is created.

--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -515,19 +515,6 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
 
             // Acquire the wake lock to wake up the device
             wakeLock.acquire(3000);
-
-            // Wait for the device to actually wake up
-            ThreadUtils.queue(() -> {
-                long MAX_WAIT_PERIOD_MS = 50L;
-                final long start = SystemClock.uptimeMillis();
-                while (!powerManager.isInteractive() && SystemClock.uptimeMillis() - start <= MAX_WAIT_PERIOD_MS) {
-                    try {
-                        Thread.sleep(10);
-                    } catch (InterruptedException e) {
-                        // If we were woken up we'll just proceed - we typically only need to wait less than 10ms
-                    }
-                }
-            });
         }
 
         // Dismiss the keyguard.

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
@@ -40,7 +40,6 @@ import org.thoughtcrime.securesms.service.WebRtcCallService
 import org.thoughtcrime.securesms.webrtc.AudioManagerCommand
 import org.thoughtcrime.securesms.webrtc.CallViewModel
 import org.thoughtcrime.securesms.webrtc.CallViewModel.State.CALL_CONNECTED
-import org.thoughtcrime.securesms.webrtc.CallViewModel.State.CALL_DISCONNECTED
 import org.thoughtcrime.securesms.webrtc.CallViewModel.State.CALL_INCOMING
 import org.thoughtcrime.securesms.webrtc.CallViewModel.State.CALL_OUTGOING
 import org.thoughtcrime.securesms.webrtc.CallViewModel.State.CALL_PRE_INIT

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
@@ -35,11 +35,13 @@ import org.session.libsession.utilities.truncateIdForDisplay
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
+import org.thoughtcrime.securesms.home.HomeActivity
 import org.thoughtcrime.securesms.permissions.Permissions
 import org.thoughtcrime.securesms.service.WebRtcCallService
 import org.thoughtcrime.securesms.webrtc.AudioManagerCommand
 import org.thoughtcrime.securesms.webrtc.CallViewModel
 import org.thoughtcrime.securesms.webrtc.CallViewModel.State.CALL_CONNECTED
+import org.thoughtcrime.securesms.webrtc.CallViewModel.State.CALL_DISCONNECTED
 import org.thoughtcrime.securesms.webrtc.CallViewModel.State.CALL_INCOMING
 import org.thoughtcrime.securesms.webrtc.CallViewModel.State.CALL_OUTGOING
 import org.thoughtcrime.securesms.webrtc.CallViewModel.State.CALL_PRE_INIT
@@ -311,6 +313,7 @@ class WebRtcCallActivity : PassphraseRequiredActionBarActivity() {
 
     override fun onStart() {
         super.onStart()
+        val openHomeActivityIntent = Intent(this, HomeActivity::class.java)
 
         uiJob = lifecycleScope.launch {
 
@@ -331,6 +334,11 @@ class WebRtcCallActivity : PassphraseRequiredActionBarActivity() {
                             wantsToAnswer = false
                         }
                         CALL_CONNECTED -> wantsToAnswer = false
+                        CALL_DISCONNECTED -> {
+                            // Rather than leave a dangling activity start the Home activity and close this one
+                            startActivity(openHomeActivityIntent)
+                            finish()
+                        }
                         else -> {}
                     }
                     updateControls(state)

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
@@ -262,7 +262,7 @@ class WebRtcCallActivity : PassphraseRequiredActionBarActivity() {
                 Orientation.REVERSED_LANDSCAPE -> 90f
                 else -> 0f
             }
-
+R.drawable.ic_baseline_call_24
             userAvatar.animate().cancel()
             userAvatar.animate().rotation(rotation).start()
             contactAvatar.animate().cancel()

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
@@ -35,7 +35,6 @@ import org.session.libsession.utilities.truncateIdForDisplay
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
-import org.thoughtcrime.securesms.home.HomeActivity
 import org.thoughtcrime.securesms.permissions.Permissions
 import org.thoughtcrime.securesms.service.WebRtcCallService
 import org.thoughtcrime.securesms.webrtc.AudioManagerCommand

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
@@ -332,12 +332,6 @@ class WebRtcCallActivity : PassphraseRequiredActionBarActivity() {
                             wantsToAnswer = false
                         }
                         CALL_CONNECTED -> wantsToAnswer = false
-                        CALL_DISCONNECTED -> {
-                            // Get rid of the activity when the call is over.
-                            // Note: We call remove task so that if the activity was started by a fullscreen
-                            // intent when the device was locked this stale activity doesn't hang around.
-                            finishAndRemoveTask()
-                        }
                         else -> {}
                     }
                     updateControls(state)
@@ -458,11 +452,5 @@ class WebRtcCallActivity : PassphraseRequiredActionBarActivity() {
         uiJob?.cancel()
         binding.fullscreenRenderer.removeAllViews()
         binding.floatingRenderer.removeAllViews()
-
-        // Close the activity when it loses focus. This is required because if this activity is started via
-        // a fullscreen intent when the device is locked and the user declines the call then the CALL_DISCONNECTED
-        // never hits which closes the activity - so we'll force-close it here otherwise we get a stale / broken
-        // activity hanging around.
-        finishAndRemoveTask()
     }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
@@ -335,9 +335,10 @@ class WebRtcCallActivity : PassphraseRequiredActionBarActivity() {
                         }
                         CALL_CONNECTED -> wantsToAnswer = false
                         CALL_DISCONNECTED -> {
-                            // Rather than leave a dangling activity start the Home activity and close this one
-                            startActivity(openHomeActivityIntent)
-                            finish()
+                            // Get rid of the activity when the call is over.
+                            // Note: We call remove task so that if the activity was started by a fullscreen
+                            // intent when the device was locked this stale activity doesn't hang around.
+                            finishAndRemoveTask()
                         }
                         else -> {}
                     }

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
@@ -262,7 +262,7 @@ class WebRtcCallActivity : PassphraseRequiredActionBarActivity() {
                 Orientation.REVERSED_LANDSCAPE -> 90f
                 else -> 0f
             }
-R.drawable.ic_baseline_call_24
+
             userAvatar.animate().cancel()
             userAvatar.animate().rotation(rotation).start()
             contactAvatar.animate().cancel()

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
@@ -459,5 +459,11 @@ class WebRtcCallActivity : PassphraseRequiredActionBarActivity() {
         uiJob?.cancel()
         binding.fullscreenRenderer.removeAllViews()
         binding.floatingRenderer.removeAllViews()
+
+        // Close the activity when it loses focus. This is required because if this activity is started via
+        // a fullscreen intent when the device is locked and the user declines the call then the CALL_DISCONNECTED
+        // never hits which closes the activity - so we'll force-close it here otherwise we get a stale / broken
+        // activity hanging around.
+        finishAndRemoveTask()
     }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
@@ -313,7 +313,6 @@ class WebRtcCallActivity : PassphraseRequiredActionBarActivity() {
 
     override fun onStart() {
         super.onStart()
-        val openHomeActivityIntent = Intent(this, HomeActivity::class.java)
 
         uiJob = lifecycleScope.launch {
 

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -31,6 +31,7 @@ import org.session.libsession.messaging.utilities.UpdateMessageData;
 import org.session.libsession.utilities.IdentityKeyMismatch;
 import org.session.libsession.utilities.NetworkFailure;
 import org.session.libsession.utilities.recipients.Recipient;
+import org.session.libsignal.utilities.Log;
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent;
 
 import java.util.List;
@@ -133,8 +134,11 @@ public abstract class MessageRecord extends DisplayRecord {
       } else if (isOutgoingCall()) {
         callType = CallMessageType.CALL_OUTGOING;
       } else if (isMissedCall()) {
+        Log.w("ACL", "We think CALL_MISSSED");
+
         callType = CallMessageType.CALL_MISSED;
       } else {
+        Log.w("ACL", "We think CALL_FIRST_MISSSED");
         callType = CallMessageType.CALL_FIRST_MISSED;
       }
       return new SpannableString(UpdateMessageBuilder.INSTANCE.buildCallMessage(context, callType, getIndividualRecipient().getAddress().serialize()));

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -134,11 +134,8 @@ public abstract class MessageRecord extends DisplayRecord {
       } else if (isOutgoingCall()) {
         callType = CallMessageType.CALL_OUTGOING;
       } else if (isMissedCall()) {
-        Log.w("ACL", "We think CALL_MISSSED");
-
         callType = CallMessageType.CALL_MISSED;
       } else {
-        Log.w("ACL", "We think CALL_FIRST_MISSSED");
         callType = CallMessageType.CALL_FIRST_MISSED;
       }
       return new SpannableString(UpdateMessageBuilder.INSTANCE.buildCallMessage(context, callType, getIndividualRecipient().getAddress().serialize()));

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -21,9 +21,9 @@ import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.style.RelativeSizeSpan;
 import android.text.style.StyleSpan;
-
 import androidx.annotation.NonNull;
-
+import java.util.List;
+import java.util.Objects;
 import org.session.libsession.messaging.calls.CallMessageType;
 import org.session.libsession.messaging.sending_receiving.data_extraction.DataExtractionNotificationInfoMessage;
 import org.session.libsession.messaging.utilities.UpdateMessageBuilder;
@@ -31,11 +31,7 @@ import org.session.libsession.messaging.utilities.UpdateMessageData;
 import org.session.libsession.utilities.IdentityKeyMismatch;
 import org.session.libsession.utilities.NetworkFailure;
 import org.session.libsession.utilities.recipients.Recipient;
-import org.session.libsignal.utilities.Log;
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent;
-
-import java.util.List;
-import java.util.Objects;
 
 /**
  * The base class for message record models that are displayed in

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -103,7 +103,7 @@ public class ThreadRecord extends DisplayRecord {
     @Override
     public CharSequence getDisplayBody(@NonNull Context context) {
         // no need to display anything if there are no messages
-        if(lastMessage == null){
+        if (lastMessage == null){
             return "";
         }
         else if (isGroupUpdateMessage()) {

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -268,7 +268,7 @@ class DefaultMessageNotifier : MessageNotifier {
 
         val builder = SingleRecipientNotificationBuilder(context, getNotificationPrivacy(context))
         val notifications = notificationState.notifications
-        val recipient = notifications[0].recipient
+        val messageOriginator = notifications[0].recipient
         val notificationId = (SUMMARY_NOTIFICATION_ID + (if (bundled) notifications[0].threadId else 0)).toInt()
         val messageIdTag = notifications[0].timestamp.toString()
 
@@ -287,10 +287,6 @@ class DefaultMessageNotifier : MessageNotifier {
         builder.putStringExtra(LATEST_MESSAGE_ID_TAG, messageIdTag)
 
         val notificationText = notifications[0].text
-
-        // TODO: We get missed call notifications whenever we get a call - I have no idea why, and it would be better to strip them out
-        // TODO: at the source - but I'll stop them here if we recognise the notification text and the home screen is visible
-
 
         // For some reason, even when we're starting a call we get a missed call notification - so we'll bail before that happens.
         // TODO: Probably better to fix this at the source so that this never gets called rather then here - do this.
@@ -311,7 +307,7 @@ class DefaultMessageNotifier : MessageNotifier {
         )
 
         builder.setPrimaryMessageBody(
-            recipient,
+            messageOriginator,
             notifications[0].individualRecipient,
             ss,
             notifications[0].slideDeck
@@ -323,12 +319,12 @@ class DefaultMessageNotifier : MessageNotifier {
         builder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
         builder.setAutoCancel(true)
 
-        val replyMethod = ReplyMethod.forRecipient(context, recipient)
+        val replyMethod = ReplyMethod.forRecipient(context, messageOriginator)
 
-        val canReply = canUserReplyToNotification(recipient)
+        val canReply = canUserReplyToNotification(messageOriginator)
 
-        val quickReplyIntent = if (canReply) notificationState.getQuickReplyIntent(context, recipient) else null
-        val remoteReplyIntent = if (canReply) notificationState.getRemoteReplyIntent(context, recipient, replyMethod) else null
+        val quickReplyIntent = if (canReply) notificationState.getQuickReplyIntent(context, messageOriginator) else null
+        val remoteReplyIntent = if (canReply) notificationState.getRemoteReplyIntent(context, messageOriginator, replyMethod) else null
 
         builder.addActions(
             notificationState.getMarkAsReadIntent(context, notificationId),
@@ -339,7 +335,7 @@ class DefaultMessageNotifier : MessageNotifier {
 
         if (canReply) {
             builder.addAndroidAutoAction(
-                notificationState.getAndroidAutoReplyIntent(context, recipient),
+                notificationState.getAndroidAutoReplyIntent(context, messageOriginator),
                 notificationState.getAndroidAutoHeardIntent(context, notificationId),
                 notifications[0].timestamp
             )

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -229,14 +229,14 @@ class DefaultMessageNotifier : MessageNotifier {
                         sendSingleThreadNotification(context, NotificationState(notificationState.getNotificationsForThread(threadId)), false, true)
                     }
                     sendMultipleThreadNotification(context, notificationState, playNotificationAudio)
-                } else if (notificationState.messageCount > 0) {
+                } else if (notificationState.notificationCount > 0) {
                     sendSingleThreadNotification(context, notificationState, playNotificationAudio, false)
                 } else {
                     cancelActiveNotifications(context)
                 }
 
                 cancelOrphanedNotifications(context, notificationState)
-                updateBadge(context, notificationState.messageCount)
+                updateBadge(context, notificationState.notificationCount)
 
                 if (playNotificationAudio) {
                     scheduleReminder(context, reminderCount)
@@ -294,7 +294,7 @@ class DefaultMessageNotifier : MessageNotifier {
         if (ApplicationContext.isAppVisible && notificationText == missedCallString) { return }
 
         builder.setThread(notifications[0].recipient)
-        builder.setMessageCount(notificationState.messageCount)
+        builder.setMessageCount(notificationState.notificationCount)
 
         val builderCS = notificationText ?: ""
         val ss = highlightMentions(
@@ -390,7 +390,7 @@ class DefaultMessageNotifier : MessageNotifier {
         val builder = MultipleRecipientNotificationBuilder(context, getNotificationPrivacy(context))
         val notifications = notificationState.notifications
 
-        builder.setMessageCount(notificationState.messageCount, notificationState.threadCount)
+        builder.setMessageCount(notificationState.notificationCount, notificationState.threadCount)
         builder.setMostRecentSender(notifications[0].individualRecipient, notifications[0].recipient)
         builder.setGroup(NOTIFICATION_GROUP)
         builder.setDeleteIntent(notificationState.getDeleteIntent(context))

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -282,11 +282,6 @@ class DefaultMessageNotifier : MessageNotifier {
 
         val notificationText = notifications[0].text
 
-        // For some reason, even when we're starting a call we get a missed call notification - so we'll bail before that happens.
-        // TODO: Probably better to fix this at the source so that this never gets called rather then here - do this.
-        val missedCallString = Phrase.from(context, R.string.callsMissedCallFrom).put(NAME_KEY, notifications[0].recipient.name).format()
-        if ((context.applicationContext as ApplicationContext).isAppVisible && notificationText == missedCallString) { return }
-
         builder.setThread(notifications[0].recipient)
         builder.setMessageCount(notificationState.notificationCount)
 

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -28,8 +28,6 @@ import android.database.Cursor
 import android.os.AsyncTask
 import android.os.Build
 import android.text.TextUtils
-import android.widget.Toast
-import androidx.camera.core.impl.utils.ContextUtil.getApplicationContext
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -47,7 +45,6 @@ import org.session.libsession.messaging.utilities.AccountId
 import org.session.libsession.messaging.utilities.SodiumUtilities.blindedKeyPair
 import org.session.libsession.utilities.Address.Companion.fromSerialized
 import org.session.libsession.utilities.ServiceUtil
-import org.session.libsession.utilities.StringSubstitutionConstants.APP_NAME_KEY
 import org.session.libsession.utilities.StringSubstitutionConstants.EMOJI_KEY
 import org.session.libsession.utilities.StringSubstitutionConstants.NAME_KEY
 import org.session.libsession.utilities.TextSecurePreferences.Companion.getLocalNumber
@@ -71,8 +68,6 @@ import org.thoughtcrime.securesms.database.model.MmsMessageRecord
 import org.thoughtcrime.securesms.database.model.ReactionRecord
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent.Companion.get
 import org.thoughtcrime.securesms.mms.SlideDeck
-import org.thoughtcrime.securesms.permissions.Permissions
-import org.thoughtcrime.securesms.preferences.ShareLogsDialog
 import org.thoughtcrime.securesms.service.KeyCachingService
 import org.thoughtcrime.securesms.util.SessionMetaProtocol.canUserReplyToNotification
 import org.thoughtcrime.securesms.util.SpanUtil
@@ -373,7 +368,6 @@ class DefaultMessageNotifier : MessageNotifier {
             // for ActivityCompat#requestPermissions for more details.
             return
         }
-
 
         NotificationManagerCompat.from(context).notify(notificationId, notification)
         Log.i(TAG, "Posted notification. $notification")

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -198,7 +198,6 @@ class DefaultMessageNotifier : MessageNotifier {
     override fun updateNotification(context: Context, signal: Boolean, reminderCount: Int) {
         var playNotificationAudio = signal // Local copy of the argument so we can modify it
         var telcoCursor: Cursor? = null
-        val pushCursor: Cursor? = null
 
         try {
             telcoCursor = get(context).mmsSmsDatabase().unread // TODO: add a notification specific lighter query here
@@ -286,7 +285,7 @@ class DefaultMessageNotifier : MessageNotifier {
         // For some reason, even when we're starting a call we get a missed call notification - so we'll bail before that happens.
         // TODO: Probably better to fix this at the source so that this never gets called rather then here - do this.
         val missedCallString = Phrase.from(context, R.string.callsMissedCallFrom).put(NAME_KEY, notifications[0].recipient.name).format()
-        if (ApplicationContext.isAppVisible && notificationText == missedCallString) { return }
+        if ((context.applicationContext as ApplicationContext).isAppVisible && notificationText == missedCallString) { return }
 
         builder.setThread(notifications[0].recipient)
         builder.setMessageCount(notificationState.notificationCount)

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -49,6 +49,7 @@ import org.session.libsession.utilities.Address.Companion.fromSerialized
 import org.session.libsession.utilities.ServiceUtil
 import org.session.libsession.utilities.StringSubstitutionConstants.APP_NAME_KEY
 import org.session.libsession.utilities.StringSubstitutionConstants.EMOJI_KEY
+import org.session.libsession.utilities.StringSubstitutionConstants.NAME_KEY
 import org.session.libsession.utilities.TextSecurePreferences.Companion.getLocalNumber
 import org.session.libsession.utilities.TextSecurePreferences.Companion.getNotificationPrivacy
 import org.session.libsession.utilities.TextSecurePreferences.Companion.getRepeatAlertsCount
@@ -285,12 +286,21 @@ class DefaultMessageNotifier : MessageNotifier {
 
         builder.putStringExtra(LATEST_MESSAGE_ID_TAG, messageIdTag)
 
-        val text = notifications[0].text
+        val notificationText = notifications[0].text
+
+        // TODO: We get missed call notifications whenever we get a call - I have no idea why, and it would be better to strip them out
+        // TODO: at the source - but I'll stop them here if we recognise the notification text and the home screen is visible
+
+
+        // For some reason, even when we're starting a call we get a missed call notification - so we'll bail before that happens.
+        // TODO: Probably better to fix this at the source so that this never gets called rather then here - do this.
+        val missedCallString = Phrase.from(context, R.string.callsMissedCallFrom).put(NAME_KEY, notifications[0].recipient.name).format()
+        if (ApplicationContext.isAppVisible && notificationText == missedCallString) { return }
 
         builder.setThread(notifications[0].recipient)
         builder.setMessageCount(notificationState.messageCount)
 
-        val builderCS = text ?: ""
+        val builderCS = notificationText ?: ""
         val ss = highlightMentions(
             builderCS,
             false,
@@ -336,7 +346,6 @@ class DefaultMessageNotifier : MessageNotifier {
         }
 
         val iterator: ListIterator<NotificationItem> = notifications.listIterator(notifications.size)
-
         while (iterator.hasPrevious()) {
             val item = iterator.previous()
             builder.addMessageBody(item.recipient, item.individualRecipient, item.text)
@@ -368,6 +377,8 @@ class DefaultMessageNotifier : MessageNotifier {
             // for ActivityCompat#requestPermissions for more details.
             return
         }
+
+
         NotificationManagerCompat.from(context).notify(notificationId, notification)
         Log.i(TAG, "Posted notification. $notification")
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -282,6 +282,13 @@ class DefaultMessageNotifier : MessageNotifier {
 
         val notificationText = notifications[0].text
 
+        // For some reason, even when we're starting a call we get a missed call notification - so we'll bail before that happens.
+        // TODO: Probably better to fix this at the source so that this never gets called rather then here - do this.
+        val missedCallString = Phrase.from(context, R.string.callsMissedCallFrom).put(NAME_KEY, notifications[0].recipient.name).format()
+        if ((context.applicationContext as ApplicationContext).isAppVisible && notificationText == missedCallString) {
+            return
+        }
+
         builder.setThread(notifications[0].recipient)
         builder.setMessageCount(notificationState.notificationCount)
 

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -285,14 +285,6 @@ class DefaultMessageNotifier : MessageNotifier {
         builder.setThread(notifications[0].recipient)
         builder.setMessageCount(notificationState.notificationCount)
 
-        //val missedCallString = Phrase.from(context, R.string.callsMissedCallFrom).put(NAME_KEY, notifications[0].recipient.name).format()
-        //if (ApplicationContext.isAppVisible && notificationText == missedCallString) { return }
-
-//        for (n in notifications) {
-//            if n.
-//        }
-
-
         val builderCS = notificationText ?: ""
         val ss = highlightMentions(
             builderCS,

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -282,13 +282,6 @@ class DefaultMessageNotifier : MessageNotifier {
 
         val notificationText = notifications[0].text
 
-        // For some reason, even when we're starting a call we get a missed call notification - so we'll bail before that happens.
-        // TODO: Probably better to fix this at the source so that this never gets called rather then here - do this.
-        val missedCallString = Phrase.from(context, R.string.callsMissedCallFrom).put(NAME_KEY, notifications[0].recipient.name).format()
-        if ((context.applicationContext as ApplicationContext).isAppVisible && notificationText == missedCallString) {
-            return
-        }
-
         builder.setThread(notifications[0].recipient)
         builder.setMessageCount(notificationState.notificationCount)
 

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -285,6 +285,14 @@ class DefaultMessageNotifier : MessageNotifier {
         builder.setThread(notifications[0].recipient)
         builder.setMessageCount(notificationState.notificationCount)
 
+        //val missedCallString = Phrase.from(context, R.string.callsMissedCallFrom).put(NAME_KEY, notifications[0].recipient.name).format()
+        //if (ApplicationContext.isAppVisible && notificationText == missedCallString) { return }
+
+//        for (n in notifications) {
+//            if n.
+//        }
+
+
         val builderCS = notificationText ?: ""
         val ss = highlightMentions(
             builderCS,

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/NotificationState.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/NotificationState.java
@@ -3,20 +3,18 @@ package org.thoughtcrime.securesms.notifications;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
-import org.session.libsession.utilities.recipients.Recipient;
-import org.session.libsession.utilities.recipients.Recipient.VibrateState;
-import org.session.libsignal.utilities.Log;
-import org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2;
-
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import org.session.libsession.utilities.recipients.Recipient.VibrateState;
+import org.session.libsession.utilities.recipients.Recipient;
+import org.session.libsignal.utilities.Log;
+import org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2;
 
 public class NotificationState {
 
@@ -36,68 +34,54 @@ public class NotificationState {
   }
 
   public void addNotification(NotificationItem item) {
+    // Add this new notification at the beginning of the list
     notifications.addFirst(item);
 
+    // TODO: This doesn't make sense - why would be remove a threadId from the threads LinkedHashSet<Long> and then immediately put it back? `add` already only adds it if doesn't already exist - skipping this for now as a test -ACL
+    /*
     if (threads.contains(item.getThreadId())) {
       threads.remove(item.getThreadId());
     }
-
+    */
     threads.add(item.getThreadId());
+
     notificationCount++;
   }
 
   public @Nullable Uri getRingtone(@NonNull Context context) {
     if (!notifications.isEmpty()) {
       Recipient recipient = notifications.getFirst().getRecipient();
-
-      if (recipient != null) {
-        return NotificationChannels.getMessageRingtone(context, recipient);
-      }
+      return NotificationChannels.getMessageRingtone(context, recipient);
     }
 
-    return null;
+    // TODO: Going to try returning the default ringtone for a notification rather than null here - seems like a more sensible option.
+    //return null;
+
+    return RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
   }
 
   public VibrateState getVibrate() {
     if (!notifications.isEmpty()) {
       Recipient recipient = notifications.getFirst().getRecipient();
-
-      if (recipient != null) {
-        return recipient.resolve().getMessageVibrate();
-      }
+      return recipient.resolve().getMessageVibrate();
     }
-
     return VibrateState.DEFAULT;
   }
 
-  public boolean hasMultipleThreads() {
-    return threads.size() > 1;
-  }
-
-  public LinkedHashSet<Long> getThreads() {
-    return threads;
-  }
-
-  public int getThreadCount() {
-    return threads.size();
-  }
-
-  public int getMessageCount() {
-    return notificationCount;
-  }
-
-  public List<NotificationItem> getNotifications() {
-    return notifications;
-  }
+  public boolean hasMultipleThreads()              { return threads.size() > 1; }
+  public LinkedHashSet<Long> getThreads()          { return threads;            }
+  public int getThreadCount()                      { return threads.size();     }
+  public int getNotificationCount()                { return notificationCount;  }
+  public List<NotificationItem> getNotifications() { return notifications;      }
 
   public List<NotificationItem> getNotificationsForThread(long threadId) {
-    LinkedList<NotificationItem> list = new LinkedList<>();
+    LinkedList<NotificationItem> notificationsInThread = new LinkedList<>();
 
     for (NotificationItem item : notifications) {
-      if (item.getThreadId() == threadId) list.addFirst(item);
+      if (item.getThreadId() == threadId) notificationsInThread.addFirst(item);
     }
 
-    return list;
+    return notificationsInThread;
   }
 
   public PendingIntent getMarkAsReadIntent(Context context, int notificationId) {
@@ -111,7 +95,7 @@ public class NotificationState {
 
     Intent intent = new Intent(MarkReadReceiver.CLEAR_ACTION);
     intent.setClass(context, MarkReadReceiver.class);
-    intent.setData((Uri.parse("custom://"+System.currentTimeMillis())));
+    intent.setData((Uri.parse("custom://" + System.currentTimeMillis())));
     intent.putExtra(MarkReadReceiver.THREAD_IDS_EXTRA, threadArray);
     intent.putExtra(MarkReadReceiver.NOTIFICATION_ID_EXTRA, notificationId);
 
@@ -171,7 +155,7 @@ public class NotificationState {
     Intent intent = new Intent(AndroidAutoHeardReceiver.HEARD_ACTION);
     intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
     intent.setClass(context, AndroidAutoHeardReceiver.class);
-    intent.setData((Uri.parse("custom://"+System.currentTimeMillis())));
+    intent.setData((Uri.parse("custom://" + System.currentTimeMillis())));
     intent.putExtra(AndroidAutoHeardReceiver.THREAD_IDS_EXTRA, threadArray);
     intent.putExtra(AndroidAutoHeardReceiver.NOTIFICATION_ID_EXTRA, notificationId);
     intent.setPackage(context.getPackageName());
@@ -223,6 +207,4 @@ public class NotificationState {
 
     return PendingIntent.getBroadcast(context, 0, intent, intentFlags);
   }
-
-
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/NotificationState.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/NotificationState.java
@@ -37,12 +37,8 @@ public class NotificationState {
     // Add this new notification at the beginning of the list
     notifications.addFirst(item);
 
-    // TODO: This doesn't make sense - why would be remove a threadId from the threads LinkedHashSet<Long> and then immediately put it back? `add` already only adds it if doesn't already exist - skipping this for now as a test -ACL
-    /*
-    if (threads.contains(item.getThreadId())) {
-      threads.remove(item.getThreadId());
-    }
-    */
+    // Put a notification at the front by removing it then re-adding it?
+    threads.remove(item.getThreadId());
     threads.add(item.getThreadId());
 
     notificationCount++;
@@ -53,9 +49,6 @@ public class NotificationState {
       Recipient recipient = notifications.getFirst().getRecipient();
       return NotificationChannels.getMessageRingtone(context, recipient);
     }
-
-    // TODO: Going to try returning the default ringtone for a notification rather than null here - seems like a more sensible option.
-    //return null;
 
     return RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/PushManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/PushManager.kt
@@ -1,5 +1,0 @@
-package org.thoughtcrime.securesms.notifications
-
-interface PushManager {
-    fun refresh(force: Boolean)
-}

--- a/app/src/main/java/org/thoughtcrime/securesms/service/KeyCachingService.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/KeyCachingService.java
@@ -235,7 +235,6 @@ public class KeyCachingService extends Service {
 
   private void foregroundService() {
     if (TextSecurePreferences.isPasswordDisabled(this) && !TextSecurePreferences.isScreenLockEnabled(this)) {
-      Log.w("ACL", "Stopping foreground service in KeyCachingService");
       stopForeground(true);
       return;
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/service/KeyCachingService.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/KeyCachingService.java
@@ -235,6 +235,7 @@ public class KeyCachingService extends Service {
 
   private void foregroundService() {
     if (TextSecurePreferences.isPasswordDisabled(this) && !TextSecurePreferences.isScreenLockEnabled(this)) {
+      Log.w("ACL", "Stopping foreground service in KeyCachingService");
       stopForeground(true);
       return;
     }
@@ -248,8 +249,6 @@ public class KeyCachingService extends Service {
             .put(APP_NAME_KEY, c.getString(R.string.app_name))
             .format().toString();
     builder.setContentTitle(unlockedTxt);
-
-    builder.setContentText(getString(R.string.lockAppUnlock));
     builder.setSmallIcon(R.drawable.icon_cached);
     builder.setWhen(0);
     builder.setPriority(Notification.PRIORITY_MIN);

--- a/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT
+import android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.content.IntentFilter
 import android.content.pm.PackageManager
@@ -814,7 +815,7 @@ class WebRtcCallService : LifecycleService(), CallManager.WebRtcListener {
 
             // Start an intent for the fullscreen call activity
             val foregroundIntent = Intent(this, WebRtcCallActivity::class.java)
-                .setFlags(FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_BROUGHT_TO_FRONT or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                .setFlags(FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TOP)
                 .setAction(WebRtcCallActivity.ACTION_FULL_SCREEN_INTENT)
             startActivity(foregroundIntent)
             return

--- a/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
@@ -730,7 +730,7 @@ class WebRtcCallService : LifecycleService(), CallManager.WebRtcListener {
                 this,
                 CallNotificationBuilder.WEBRTC_NOTIFICATION,
                 CallNotificationBuilder.getCallInProgressNotification(this, type, recipient),
-                if (Build.VERSION.SDK_INT >= 30) ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE else 0
+                if (Build.VERSION.SDK_INT >= 30) ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL else 0
             )
         } catch (e: IllegalStateException) {
             Log.e(TAG, "Failed to setCallInProgressNotification as a foreground service for type: ${type}, trying to update instead", e)

--- a/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
@@ -810,12 +810,10 @@ class WebRtcCallService : LifecycleService(), CallManager.WebRtcListener {
         }
 
         if ((type == TYPE_INCOMING_PRE_OFFER || type == TYPE_INCOMING_RINGING) && failedToStartForegroundService) {
-
-            wakeUpDeviceIfLockedAndDismissKeyguard()
-
             // Start an intent for the fullscreen call activity
             val foregroundIntent = Intent(this, WebRtcCallActivity::class.java)
-                .setFlags(FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TOP)
+                //.setFlags(FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TOP)
+                .setFlags(FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_BROUGHT_TO_FRONT or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
                 .setAction(WebRtcCallActivity.ACTION_FULL_SCREEN_INTENT)
             startActivity(foregroundIntent)
             return

--- a/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
@@ -1,10 +1,8 @@
 package org.thoughtcrime.securesms.service
 
-import android.app.KeyguardManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.content.Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT
 import android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.content.IntentFilter
@@ -12,7 +10,6 @@ import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.media.AudioManager
 import android.os.Build
-import android.os.PowerManager
 import android.os.ResultReceiver
 import android.telephony.TelephonyManager
 import androidx.core.app.ServiceCompat
@@ -31,7 +28,6 @@ import javax.inject.Inject
 import org.session.libsession.messaging.calls.CallMessageType
 import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.FutureTaskListener
-import org.session.libsession.utilities.NonTranslatableStringConstants
 import org.session.libsession.utilities.recipients.Recipient
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.ApplicationContext

--- a/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
@@ -743,6 +743,8 @@ class WebRtcCallService : LifecycleService(), CallManager.WebRtcListener {
     }
 
     private fun wakeUpDeviceIfLocked() {
+        Log.w("ACL", "Hit WRCS.wakeUpDeviceIfLocked at: ${System.currentTimeMillis()} !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+
         // Get the KeyguardManager and PowerManager
         val keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
         val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
@@ -765,12 +767,19 @@ class WebRtcCallService : LifecycleService(), CallManager.WebRtcListener {
             wakeLock.acquire(3000)
 
             while (!powerManager.isInteractive) {
-                /* Busy wait until we're awake - typically takes less than ~10ms */
+                /* Busy wait until we're awake - typically this takes less than ~10ms */
             }
         }
 
-        // Dismiss the keyguard
-        val keyguardLock = keyguardManager.newKeyguardLock("MyApp:KeyguardLock")
+        // Dismiss the keyguard.
+        // Note: This will NOT work if Session itself has a lock on it, which is what we want, as
+        // otherwise this would be a lock-bypass mechanism! When Session has a lock the user must
+        // unlock their device, then unlock Session - however without a lock on Session (but with
+        // one on the device) then this will bypass the device lock to show the full-screen intent
+        // regarding the incoming call.
+        // TODO: When we move to a minimum Android API of 27 (our minimum is API 26 as of 9th Dec 2024) then replace these deprecated calls.
+        // TODO: If we try to remove them before this it gets messy because the replacements only came in at API 27.
+        val keyguardLock = keyguardManager.newKeyguardLock("{${NonTranslatableStringConstants.APP_NAME}:KeyguardLock")
         keyguardLock.disableKeyguard()
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
@@ -30,6 +30,7 @@ import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.FutureTaskListener
 import org.session.libsession.utilities.recipients.Recipient
 import org.session.libsignal.utilities.Log
+import org.session.libsignal.utilities.ThreadUtils
 import org.thoughtcrime.securesms.ApplicationContext
 import org.thoughtcrime.securesms.calls.WebRtcCallActivity
 import org.thoughtcrime.securesms.notifications.BackgroundPollWorker
@@ -745,7 +746,7 @@ class WebRtcCallService : LifecycleService(), CallManager.WebRtcListener {
     // Over the course of setting up a phone call this method is called multiple times with `types`
     // of PRE_OFFER -> RING_INCOMING -> ICE_MESSAGE
     private fun setCallInProgressNotification(type: Int, recipient: Recipient?) {
-
+        // Wake the device if needed
         (applicationContext as ApplicationContext).wakeUpDeviceAndDismissKeyguardIfRequired()
 
         // If notifications are enabled we'll try and start a foreground service to show the notification

--- a/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
@@ -743,8 +743,6 @@ class WebRtcCallService : LifecycleService(), CallManager.WebRtcListener {
     }
 
     private fun wakeUpDeviceIfLockedAndDismissKeyguard() {
-        Log.w("ACL", "Hit WRCS.wakeUpDeviceIfLocked at: ${System.currentTimeMillis()} !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-
         // Get the KeyguardManager and PowerManager
         val keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
         val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager

--- a/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
@@ -30,7 +30,6 @@ import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.FutureTaskListener
 import org.session.libsession.utilities.recipients.Recipient
 import org.session.libsignal.utilities.Log
-import org.session.libsignal.utilities.ThreadUtils
 import org.thoughtcrime.securesms.ApplicationContext
 import org.thoughtcrime.securesms.calls.WebRtcCallActivity
 import org.thoughtcrime.securesms.notifications.BackgroundPollWorker

--- a/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/WebRtcCallService.kt
@@ -812,8 +812,7 @@ class WebRtcCallService : LifecycleService(), CallManager.WebRtcListener {
         if ((type == TYPE_INCOMING_PRE_OFFER || type == TYPE_INCOMING_RINGING) && failedToStartForegroundService) {
             // Start an intent for the fullscreen call activity
             val foregroundIntent = Intent(this, WebRtcCallActivity::class.java)
-                //.setFlags(FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TOP)
-                .setFlags(FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_BROUGHT_TO_FRONT or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                .setFlags(FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TOP)
                 .setAction(WebRtcCallActivity.ACTION_FULL_SCREEN_INTENT)
             startActivity(foregroundIntent)
             return

--- a/app/src/main/java/org/thoughtcrime/securesms/util/CallNotificationBuilder.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/CallNotificationBuilder.kt
@@ -25,42 +25,17 @@ class CallNotificationBuilder {
     companion object {
         const val WEBRTC_NOTIFICATION = 313388
 
-        const val TYPE_INCOMING_RINGING = 1
-        const val TYPE_OUTGOING_RINGING = 2
-        const val TYPE_ESTABLISHED = 3
+        const val TYPE_INCOMING_RINGING    = 1
+        const val TYPE_OUTGOING_RINGING    = 2
+        const val TYPE_ESTABLISHED         = 3
         const val TYPE_INCOMING_CONNECTING = 4
-        const val TYPE_INCOMING_PRE_OFFER = 5
+        const val TYPE_INCOMING_PRE_OFFER  = 5
 
         @JvmStatic
         fun areNotificationsEnabled(context: Context): Boolean {
             val notificationManager = NotificationManagerCompat.from(context)
             return notificationManager.areNotificationsEnabled()
         }
-
-//        @JvmStatic
-//        fun getFirstCallNotification(context: Context, callerName: String): Notification {
-//            val contentIntent = Intent(context, SettingsActivity::class.java)
-//
-//            val pendingIntent = PendingIntent.getActivity(context, 0, contentIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-//
-//            val titleTxt = context.getSubbedString(R.string.callsMissedCallFrom, NAME_KEY to callerName)
-//            val bodyTxt = context.getSubbedCharSequence(
-//                R.string.callsYouMissedCallPermissions,
-//                NAME_KEY to callerName
-//            )
-//
-//            val builder = NotificationCompat.Builder(context, NotificationChannels.CALLS)
-//                    .setSound(null)
-//                    .setSmallIcon(R.drawable.ic_baseline_call_24)
-//                    .setContentIntent(pendingIntent)
-//                    .setPriority(NotificationCompat.PRIORITY_HIGH)
-//                    .setContentTitle(titleTxt)
-//                    .setContentText(bodyTxt)
-//                    .setStyle(NotificationCompat.BigTextStyle().bigText(bodyTxt))
-//                    .setAutoCancel(true)
-//
-//            return builder.build()
-//        }
 
         @JvmStatic
         fun getCallInProgressNotification(context: Context, type: Int, recipient: Recipient?): Notification {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/CallNotificationBuilder.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/CallNotificationBuilder.kt
@@ -37,30 +37,30 @@ class CallNotificationBuilder {
             return notificationManager.areNotificationsEnabled()
         }
 
-        @JvmStatic
-        fun getFirstCallNotification(context: Context, callerName: String): Notification {
-            val contentIntent = Intent(context, SettingsActivity::class.java)
-
-            val pendingIntent = PendingIntent.getActivity(context, 0, contentIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-
-            val titleTxt = context.getSubbedString(R.string.callsMissedCallFrom, NAME_KEY to callerName)
-            val bodyTxt = context.getSubbedCharSequence(
-                R.string.callsYouMissedCallPermissions,
-                NAME_KEY to callerName
-            )
-
-            val builder = NotificationCompat.Builder(context, NotificationChannels.CALLS)
-                    .setSound(null)
-                    .setSmallIcon(R.drawable.ic_baseline_call_24)
-                    .setContentIntent(pendingIntent)
-                    .setPriority(NotificationCompat.PRIORITY_HIGH)
-                    .setContentTitle(titleTxt)
-                    .setContentText(bodyTxt)
-                    .setStyle(NotificationCompat.BigTextStyle().bigText(bodyTxt))
-                    .setAutoCancel(true)
-
-            return builder.build()
-        }
+//        @JvmStatic
+//        fun getFirstCallNotification(context: Context, callerName: String): Notification {
+//            val contentIntent = Intent(context, SettingsActivity::class.java)
+//
+//            val pendingIntent = PendingIntent.getActivity(context, 0, contentIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+//
+//            val titleTxt = context.getSubbedString(R.string.callsMissedCallFrom, NAME_KEY to callerName)
+//            val bodyTxt = context.getSubbedCharSequence(
+//                R.string.callsYouMissedCallPermissions,
+//                NAME_KEY to callerName
+//            )
+//
+//            val builder = NotificationCompat.Builder(context, NotificationChannels.CALLS)
+//                    .setSound(null)
+//                    .setSmallIcon(R.drawable.ic_baseline_call_24)
+//                    .setContentIntent(pendingIntent)
+//                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+//                    .setContentTitle(titleTxt)
+//                    .setContentText(bodyTxt)
+//                    .setStyle(NotificationCompat.BigTextStyle().bigText(bodyTxt))
+//                    .setAutoCancel(true)
+//
+//            return builder.build()
+//        }
 
         @JvmStatic
         fun getCallInProgressNotification(context: Context, type: Int, recipient: Recipient?): Notification {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/CallNotificationBuilder.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/CallNotificationBuilder.kt
@@ -73,9 +73,7 @@ class CallNotificationBuilder {
                             R.string.decline
                     ))
                     // If notifications aren't enabled, we will trigger the intent from WebRtcCallService
-                    builder.setFullScreenIntent(getFullScreenPendingIntent(
-                        context
-                    ), true)
+                    builder.setFullScreenIntent(getFullScreenPendingIntent(context), true)
                     builder.addAction(getActivityNotificationAction(
                             context,
                             if (type == TYPE_INCOMING_PRE_OFFER) WebRtcCallActivity.ACTION_PRE_OFFER else WebRtcCallActivity.ACTION_ANSWER,
@@ -118,9 +116,10 @@ class CallNotificationBuilder {
 
         private fun getFullScreenPendingIntent(context: Context): PendingIntent {
             val intent = Intent(context, WebRtcCallActivity::class.java)
-                .setFlags(FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT)
+                // When launching the call activity do NOT keep it in the history when finished, as it does not pass through CALL_DISCONNECTED
+                // if the call was denied outright, and without this the "dead" activity will sit around in the history when the device is unlocked.
+                .setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NO_HISTORY or Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
                 .setAction(WebRtcCallActivity.ACTION_FULL_SCREEN_INTENT)
-
             return PendingIntent.getActivity(context, 1, intent, PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
         }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/webrtc/CallMessageProcessor.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/webrtc/CallMessageProcessor.kt
@@ -47,7 +47,7 @@ class CallMessageProcessor(private val context: Context, private val textSecureP
                 //      service network.loki.messenger/org.thoughtcrime.securesms.service.WebRtcCallService
                 //
                 // ..as such, we'll wake the device up before attempting to start the foreground service.
-                wakeUpDeviceAndDismissKeyguardIfNecessary(context)
+                wakeUpDeviceAndDismissKeyguard(context)
                 try { ContextCompat.startForegroundService(context, intent) }
                 catch (e2: Exception) {
                     Log.e("Loki", "Unable to start CallMessage intent: ${e2.message}")
@@ -56,7 +56,7 @@ class CallMessageProcessor(private val context: Context, private val textSecureP
         }
 
         // Wake the device up if it's asleep / locked (used when we receive an incoming call)
-        private fun wakeUpDeviceAndDismissKeyguardIfNecessary(context: Context) {
+        private fun wakeUpDeviceAndDismissKeyguard(context: Context) {
             val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
             val keyguardManager = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
 

--- a/app/src/main/java/org/thoughtcrime/securesms/webrtc/CallMessageProcessor.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/webrtc/CallMessageProcessor.kt
@@ -27,6 +27,7 @@ import org.session.libsignal.protos.SignalServiceProtos.CallMessage.Type.OFFER
 import org.session.libsignal.protos.SignalServiceProtos.CallMessage.Type.PRE_OFFER
 import org.session.libsignal.protos.SignalServiceProtos.CallMessage.Type.PROVISIONAL_ANSWER
 import org.session.libsignal.utilities.Log
+import org.session.libsignal.utilities.ThreadUtils
 import org.thoughtcrime.securesms.ApplicationContext
 import org.thoughtcrime.securesms.permissions.Permissions
 import org.thoughtcrime.securesms.service.WebRtcCallService
@@ -43,7 +44,7 @@ class CallMessageProcessor(private val context: Context, private val textSecureP
             // a BackgroundServiceStartNotAllowedException such as:
             //      Unable to start CallMessage intent: startForegroundService() not allowed due to mAllowStartForeground false:
             //      service network.loki.messenger/org.thoughtcrime.securesms.service.WebRtcCallService
-            (context.applicationContext as ApplicationContext).wakeUpDeviceAndDismissKeyguardIfRequired()
+            (context as ApplicationContext).wakeUpDeviceAndDismissKeyguardIfRequired()
 
             // Attempt to start the call service..
             try {

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
@@ -9,6 +9,10 @@ import network.loki.messenger.libsession_util.Contacts
 import network.loki.messenger.libsession_util.ConversationVolatileConfig
 import network.loki.messenger.libsession_util.UserGroupsConfig
 import network.loki.messenger.libsession_util.UserProfile
+import java.util.Timer
+import java.util.TimerTask
+import kotlin.time.Duration.Companion.days
+import kotlinx.coroutines.GlobalScope
 import nl.komponents.kovenant.Deferred
 import nl.komponents.kovenant.Promise
 import nl.komponents.kovenant.deferred
@@ -28,9 +32,6 @@ import org.session.libsignal.utilities.Log
 import org.session.libsignal.utilities.Namespace
 import org.session.libsignal.utilities.Snode
 import org.session.libsignal.utilities.Util.SECURE_RANDOM
-import java.util.Timer
-import java.util.TimerTask
-import kotlin.time.Duration.Companion.days
 
 private const val TAG = "Poller"
 
@@ -44,8 +45,9 @@ class Poller(private val configFactory: ConfigFactoryProtocol, debounceTimer: Ti
 
     // region Settings
     companion object {
-        private const val retryInterval: Long = 2 * 1000
-        private const val maxInterval: Long = 15 * 1000
+        private const val RETRY_INTERVAL_MS: Long       = 2  * 1000
+        private const val MAX_RETRY_INTERVAL_MS: Long   = 15 * 1000
+        private const val NEXT_RETRY_MULTIPLIER: Float = 1.2f // If we fail to poll we multiply our current retry interval by this (up to the above max) then try again
     }
     // endregion
 
@@ -54,7 +56,7 @@ class Poller(private val configFactory: ConfigFactoryProtocol, debounceTimer: Ti
         if (hasStarted) { return }
         Log.d(TAG, "Started polling.")
         hasStarted = true
-        setUpPolling(retryInterval)
+        setUpPolling(RETRY_INTERVAL_MS)
     }
 
     fun stopIfNeeded() {
@@ -67,9 +69,11 @@ class Poller(private val configFactory: ConfigFactoryProtocol, debounceTimer: Ti
         Log.d(TAG, "Retrieving user profile.")
         SnodeAPI.getSwarm(userPublicKey).bind {
             usedSnodes.clear()
-            deferred<Unit, Exception>().also {
-                pollNextSnode(userProfileOnly = true, it)
+            deferred<Unit, Exception>().also { exception ->
+                pollNextSnode(userProfileOnly = true, exception)
             }.promise
+        }.fail { exception ->
+            Log.e(TAG, "Failed to retrieve user profile.", exception)
         }
     }
     // endregion
@@ -84,14 +88,14 @@ class Poller(private val configFactory: ConfigFactoryProtocol, debounceTimer: Ti
             pollNextSnode(deferred = deferred)
             deferred.promise
         }.success {
-            val nextDelay = if (isCaughtUp) retryInterval else 0
+            val nextDelay = if (isCaughtUp) RETRY_INTERVAL_MS else 0
             Timer().schedule(object : TimerTask() {
                 override fun run() {
-                    thread.run { setUpPolling(retryInterval) }
+                    thread.run { setUpPolling(RETRY_INTERVAL_MS) }
                 }
             }, nextDelay)
         }.fail {
-            val nextDelay = minOf(maxInterval, (delay * 1.2).toLong())
+            val nextDelay = minOf(MAX_RETRY_INTERVAL_MS, (delay * NEXT_RETRY_MULTIPLIER).toLong())
             Timer().schedule(object : TimerTask() {
                 override fun run() {
                     thread.run { setUpPolling(nextDelay) }

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
@@ -45,8 +45,8 @@ class Poller(private val configFactory: ConfigFactoryProtocol, debounceTimer: Ti
 
     // region Settings
     companion object {
-        private const val RETRY_INTERVAL_MS: Long       = 2  * 1000
-        private const val MAX_RETRY_INTERVAL_MS: Long   = 15 * 1000
+        private const val RETRY_INTERVAL_MS: Long      = 2  * 1000
+        private const val MAX_RETRY_INTERVAL_MS: Long  = 15 * 1000
         private const val NEXT_RETRY_MULTIPLIER: Float = 1.2f // If we fail to poll we multiply our current retry interval by this (up to the above max) then try again
     }
     // endregion


### PR DESCRIPTION
### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fix to prevent failure to display call notifications when the device is asleep or locked. Android 12 and above has tightened permissions with regard to starting services, in particular foreground services. As such, this patch wakes the device up in order to start the call service and display an incoming call notification, and may start a full-screen intent for the `WebRtcCallActivity` if necessary.

### Test steps:
With two devices running (Alice and Bob) - have Alice call Bob under the following conditions:
- With Bob having the app visible in the foreground,
- With Bob having the app running the background (i.e., dismissed but not closed),
- With Bob having force-closed the app (i.e., manually closed it from the back-stack) but the device is awake,
- With Bob having force-closed the app and then locked the device (in this case a full-screen intent will open the call activity, which will likely occur before the push notification arrives - but the push notification regarding the call _does_ (typically) arrive a few seconds later).

In each case Bob should receive an incoming call notification.

The scenario which has shown to be most problematic is if Bob has **force-closed the app**, and has the **lock on the app**, and has **locked their device**. In such a scenario, while most times we get the incoming call notification (but have to unlock the device twice - once for the device then again for the app),  sometimes we don't get the incoming call notification at all. Reasons for this discrepancy are unknown at the present time - but regardless of this issue, in my experience the call notification behaviour from this work significantly improves upon the current production behaviour.

Finally, it should be noted that Calls are in Beta and may not always successfully set up a call, so it may be possible to fail to initialise a call entirely, and this may not necessarily be caused by the changes in this branch.