### PR TITLE
[SES-3050] - Kicked group message state

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/MessageUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/MessageUtilities.kt
@@ -9,7 +9,7 @@ import java.util.Locale
 private const val maxTimeBetweenBreaks = 5 * 60 * 1000L // 5 minutes
 
 fun TextView.showDateBreak(message: MessageRecord, previous: MessageRecord?) {
-    val showDateBreak = (previous == null || message.timestamp - previous.timestamp > maxTimeBetweenBreaks)
+    val showDateBreak = message.canShowDateBreak() && (previous == null || message.timestamp - previous.timestamp > maxTimeBetweenBreaks)
     isVisible = showDateBreak
     text = if (showDateBreak) DateUtils.getDisplayFormattedTimeSpanString(context, Locale.getDefault(), message.timestamp) else ""
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -38,8 +38,6 @@ import org.thoughtcrime.securesms.dependencies.DatabaseComponent;
 import java.util.List;
 import java.util.Objects;
 
-import kotlin.Lazy;
-
 /**
  * The base class for message record models that are displayed in
  * conversations, as opposed to models that are displayed in a thread list.

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -23,6 +23,7 @@ import android.text.style.RelativeSizeSpan;
 import android.text.style.StyleSpan;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.session.libsession.messaging.MessagingModuleConfiguration;
 import org.session.libsession.messaging.calls.CallMessageType;
@@ -36,6 +37,8 @@ import org.thoughtcrime.securesms.dependencies.DatabaseComponent;
 
 import java.util.List;
 import java.util.Objects;
+
+import kotlin.Lazy;
 
 /**
  * The base class for message record models that are displayed in
@@ -55,6 +58,9 @@ public abstract class MessageRecord extends DisplayRecord {
   public  final long                      id;
   private final List<ReactionRecord>      reactions;
   private final boolean                   hasMention;
+
+  @Nullable
+  private UpdateMessageData               groupUpdateMessage;
 
   public final boolean isNotDisappearAfterRead() {
     return expireStarted == getTimestamp();
@@ -115,10 +121,43 @@ public abstract class MessageRecord extends DisplayRecord {
     return isExpirationTimerUpdate() || isCallLog() || isDataExtractionNotification();
   }
 
+  /**
+   * @return Decoded group update message. Only valid if the message is a group update message.
+   */
+  @Nullable
+  public UpdateMessageData getGroupUpdateMessage() {
+    if (isGroupUpdateMessage()) {
+      groupUpdateMessage = UpdateMessageData.Companion.fromJSON(getBody());
+    }
+
+    return groupUpdateMessage;
+  }
+
+  /**
+   * @return Whether the date text can be shown for this message. By default, every message
+   *         can show a date break, only certain messages can't. Note: a positive value
+   *         DOES NOT guarantee the date break will be shown, only a negative value can
+   *         hide the date break.
+   */
+  public boolean canShowDateBreak() {
+    UpdateMessageData update = getGroupUpdateMessage();
+
+    if (update == null) {
+      return true;
+    }
+
+    if (update.getKind() instanceof UpdateMessageData.Kind.GroupDestroyed ||
+      update.getKind() instanceof UpdateMessageData.Kind.GroupKicked) {
+      return false;
+    }
+
+    return true;
+  }
+
   @Override
   public CharSequence getDisplayBody(@NonNull Context context) {
     if (isGroupUpdateMessage()) {
-      UpdateMessageData updateMessageData = UpdateMessageData.Companion.fromJSON(getBody());
+      UpdateMessageData updateMessageData = getGroupUpdateMessage();
       if (updateMessageData == null) {
         return "";
       }

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -852,6 +852,12 @@ class GroupManagerV2Impl @Inject constructor(
             )
         }
 
+        // Clear all messages in the group
+        val threadId = storage.getThreadId(Address.fromSerialized(groupId.hexString))
+        if (threadId != null) {
+            storage.clearMessages(threadId)
+        }
+
         // Insert a message to indicate we were kicked
         storage.insertIncomingInfoMessage(
             context = application,


### PR DESCRIPTION
This PR:
1. Clears the group thread when kicked
2. Makes sure the "kicked" control message doesn't have a timestamp (also disable the same for the "destroyed" message)
