### PR TITLE
[SES-2968] [SES-2929] - Fix up misc kicked and re-invited message syncing issues

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
@@ -307,7 +307,7 @@ class ConfigToDatabaseSync @Inject constructor(
             groupThreadsToKeep[closedGroup.groupAccountId] = threadId
 
             storage.setPinned(threadId, closedGroup.priority == PRIORITY_PINNED)
-            if (!closedGroup.invited) {
+            if (!closedGroup.invited && !closedGroup.kicked) {
                 pollerFactory.pollerFor(closedGroup.groupAccountId)?.start()
             }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/ConfigFactory.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/ConfigFactory.kt
@@ -271,7 +271,15 @@ class ConfigFactory @Inject constructor(
             it.convoInfoVolatile.eraseClosedGroup(groupId.hexString)
         }
 
+        deleteGroupConfigs(groupId)
+    }
+
+    override fun deleteGroupConfigs(groupId: AccountId) {
         configDatabase.deleteGroupConfigs(groupId)
+
+        synchronized(groupConfigs) {
+            groupConfigs.remove(groupId)
+        }
     }
 
     override fun decryptForUser(

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/PollerFactory.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/PollerFactory.kt
@@ -8,6 +8,7 @@ import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.groups.GroupManagerV2
 import org.session.libsession.messaging.sending_receiving.pollers.ClosedGroupPoller
 import org.session.libsession.snode.SnodeClock
+import org.session.libsession.utilities.getGroup
 import org.session.libsignal.database.LokiAPIDatabaseProtocol
 import org.session.libsignal.utilities.AccountId
 import java.util.concurrent.ConcurrentHashMap
@@ -26,9 +27,7 @@ class PollerFactory(
 
     fun pollerFor(sessionId: AccountId): ClosedGroupPoller? {
         // Check if the group is currently in our config and approved, don't start if it isn't
-        val invited = configFactory.withUserConfigs {
-            it.userGroups.getClosedGroup(sessionId.hexString)?.invited
-        }
+        val invited = configFactory.getGroup(sessionId)?.invited
 
         if (invited != false) return null
 

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -62,6 +62,7 @@ import org.thoughtcrime.securesms.database.MmsSmsDatabase
 import org.thoughtcrime.securesms.database.ThreadDatabase
 import org.thoughtcrime.securesms.dependencies.ConfigFactory
 import org.thoughtcrime.securesms.dependencies.PollerFactory
+import org.thoughtcrime.securesms.util.SessionMetaProtocol
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -790,6 +791,10 @@ class GroupManagerV2Impl @Inject constructor(
             approveGroupInvite(closedGroupInfo, inviteMessageHash)
         } else {
             lokiDatabase.addGroupInviteReferrer(groupThreadId, inviter.hexString, inviteMessageHash)
+            // Clear existing message in the thread whenever we receive an invitation that we can't
+            // auto approve
+            storage.clearMessages(groupThreadId)
+
             // In most cases, when we receive invitation, the thread has just been created,
             // and "has_sent" is set to false. But there are cases that we could be "re-invited"
             // to a group, where we need to go through approval process again.
@@ -865,6 +870,11 @@ class GroupManagerV2Impl @Inject constructor(
             storage.clearMessages(threadId)
         }
 
+        // Clear all polling states
+        lokiAPIDatabase.clearLastMessageHashes(groupId.hexString)
+        lokiAPIDatabase.clearReceivedMessageHashValues(groupId.hexString)
+        SessionMetaProtocol.clearReceivedMessages()
+
         // Insert a message to indicate we were kicked
         storage.insertIncomingInfoMessage(
             context = application,
@@ -874,8 +884,10 @@ class GroupManagerV2Impl @Inject constructor(
             name = groupName,
             members = emptyList(),
             admins = emptyList(),
-            sentTimestamp = clock.currentTimeMills(),
+            sentTimestamp = clock.currentTimeMills (),
         )
+
+        configFactory.deleteGroupConfigs(groupId)
     }
 
     override suspend fun setName(groupId: AccountId, newName: String): Unit =

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -884,7 +884,7 @@ class GroupManagerV2Impl @Inject constructor(
             name = groupName,
             members = emptyList(),
             admins = emptyList(),
-            sentTimestamp = clock.currentTimeMills (),
+            sentTimestamp = clock.currentTimeMills(),
         )
 
         configFactory.deleteGroupConfigs(groupId)

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/ClosedGroupPoller.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/ClosedGroupPoller.kt
@@ -182,15 +182,19 @@ class ClosedGroupPoller(
         }
 
         val groupMessageRetrieval = async {
+            val lastHash = lokiApiDatabase.getLastMessageHashValue(
+                snode,
+                closedGroupSessionId.hexString,
+                Namespace.CLOSED_GROUP_MESSAGES()
+            ).orEmpty()
+
+            Log.d(TAG, "Retrieving group message since lastHash = $lastHash")
+
             SnodeAPI.sendBatchRequest(
                 snode = snode,
                 publicKey = closedGroupSessionId.hexString,
                 request = SnodeAPI.buildAuthenticatedRetrieveBatchRequest(
-                    lastHash = lokiApiDatabase.getLastMessageHashValue(
-                        snode,
-                        closedGroupSessionId.hexString,
-                        Namespace.CLOSED_GROUP_MESSAGES()
-                    ).orEmpty(),
+                    lastHash = lastHash,
                     auth = groupAuth,
                     namespace = Namespace.CLOSED_GROUP_MESSAGES(),
                     maxSize = null,

--- a/libsession/src/main/java/org/session/libsession/utilities/ConfigFactoryProtocol.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/ConfigFactoryProtocol.kt
@@ -75,6 +75,8 @@ interface ConfigFactoryProtocol {
         keysPush: ConfigPushResult?
     )
 
+    fun deleteGroupConfigs(groupId: AccountId)
+
 }
 
 class ConfigMessage(


### PR DESCRIPTION
There are issues syncing group message when a member is kicked and reinvited to the group. In order to fix them, these have been done:
1. Once kicked, messages, relevant group configs and polling states must all be cleared
2. Once kicked, group message polling should stop and should not resurrect upon config sync.
3. After approving an invitation, thread needs to be cleared to clean out the manually inserted control messages. As once the real messages come through, they will also contain similar control messages and we don't want them to double up.
