### PR TITLE
[SES-3089] - Also delete group invite from swarm when rejecting invitation

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -603,6 +603,15 @@ class GroupManagerV2Impl @Inject constructor(
             } else {
                 configFactory.withMutableUserConfigs { it.userGroups.eraseClosedGroup(groupId.hexString) }
                 storage.deleteConversation(threadId)
+
+                if (groupInviteMessageHash != null) {
+                    val auth = requireNotNull(storage.userAuth)
+                    SnodeAPI.deleteMessage(
+                        publicKey = auth.accountId.hexString,
+                        swarmAuth = auth,
+                        serverHashes = listOf(groupInviteMessageHash)
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
When an group invitation is rejected, also delete the invite from swarm.
