### PR TITLE
Introducing thread status for groups

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
@@ -193,11 +193,7 @@ class ConfigToDatabaseSync @Inject constructor(
         profileManager.setName(context, recipient, groupInfoConfig.name.orEmpty())
 
         if (groupInfoConfig.destroyed) {
-            handleDestroyedGroup(
-                threadId = threadId,
-                groupId = groupInfoConfig.id.hexString,
-                groupName = groupInfoConfig.name.orEmpty()
-            )
+            handleDestroyedGroup(threadId = threadId)
         } else {
             groupInfoConfig.deleteBefore?.let { removeBefore ->
                 val messages = mmsSmsDatabase.getAllMessageRecordsBefore(threadId, TimeUnit.SECONDS.toMillis(removeBefore))
@@ -304,6 +300,7 @@ class ConfigToDatabaseSync @Inject constructor(
             storage.setRecipientApproved(recipient, !closedGroup.invited)
             profileManager.setName(context, recipient, closedGroup.name)
             val threadId = storage.getOrCreateThreadIdFor(recipient.address)
+            threadDatabase.setDate(threadId, TimeUnit.SECONDS.toMillis(closedGroup.joinedAtSecs))
             groupThreadsToKeep[closedGroup.groupAccountId] = threadId
 
             storage.setPinned(threadId, closedGroup.priority == PRIORITY_PINNED)
@@ -312,24 +309,7 @@ class ConfigToDatabaseSync @Inject constructor(
             }
 
             if (closedGroup.destroyed) {
-                handleDestroyedGroup(
-                    threadId = threadId,
-                    groupId = closedGroup.groupAccountId.hexString,
-                    groupName = closedGroup.name
-                )
-            } else if (closedGroup.kicked && storage.getMessageCount(threadId) == 0L) {
-                // If we don't have any messages in a "kicked" group, we will need to add a control
-                // message showing we were kicked
-                storage.insertIncomingInfoMessage(
-                    context = context,
-                    senderPublicKey = localUserPublicKey,
-                    groupID = closedGroup.groupAccountId.hexString,
-                    type = SignalServiceGroup.Type.KICKED,
-                    name = closedGroup.name,
-                    members = emptyList(),
-                    admins = emptyList(),
-                    sentTimestamp = clock.currentTimeMills(),
-                )
+                handleDestroyedGroup(threadId = threadId)
             }
         }
 
@@ -394,25 +374,8 @@ class ConfigToDatabaseSync @Inject constructor(
 
     private fun handleDestroyedGroup(
         threadId: Long,
-        groupId: String,
-        groupName: String,
     ) {
         storage.clearMessages(threadId)
-        val localUserPublicKey = storage.getUserPublicKey() ?: return Log.w(
-            TAG,
-            "No user public key when trying to handle destroyed group"
-        )
-        
-        storage.insertIncomingInfoMessage(
-            context = context,
-            senderPublicKey = localUserPublicKey,
-            groupID = groupId,
-            type = SignalServiceGroup.Type.DESTROYED,
-            name = groupName,
-            members = emptyList(),
-            admins = emptyList(),
-            sentTimestamp = clock.currentTimeMills(),
-        )
     }
 
     private data class UpdateConvoVolatile(val convos: List<Conversation?>)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -55,6 +55,7 @@ import org.thoughtcrime.securesms.database.GroupDatabase
 import org.thoughtcrime.securesms.database.LokiMessageDatabase
 import org.thoughtcrime.securesms.database.ReactionDatabase
 import org.thoughtcrime.securesms.database.ThreadDatabase
+import org.thoughtcrime.securesms.database.model.GroupThreadStatus
 import org.thoughtcrime.securesms.database.model.MessageId
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord
@@ -152,6 +153,20 @@ class ConversationViewModel(
             if (!recipient.isGroupV2Recipient) return null
 
             return repository.getInvitingAdmin(threadId)
+        }
+
+    val groupV2ThreadState: GroupThreadStatus
+        get() {
+            val recipient = recipient ?: return GroupThreadStatus.None
+            if (!recipient.isGroupV2Recipient) return GroupThreadStatus.None
+
+            return configFactory.getGroup(AccountId(recipient.address.serialize())).let { group ->
+                when {
+                    group?.destroyed == true -> GroupThreadStatus.Destroyed
+                    group?.kicked == true -> GroupThreadStatus.Kicked
+                    else -> GroupThreadStatus.None
+                }
+            }
         }
 
     private val _openGroup: MutableStateFlow<OpenGroup?> by lazy {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/MessageUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/MessageUtilities.kt
@@ -9,7 +9,7 @@ import java.util.Locale
 private const val maxTimeBetweenBreaks = 5 * 60 * 1000L // 5 minutes
 
 fun TextView.showDateBreak(message: MessageRecord, previous: MessageRecord?) {
-    val showDateBreak = message.canShowDateBreak() && (previous == null || message.timestamp - previous.timestamp > maxTimeBetweenBreaks)
+    val showDateBreak = previous == null || message.timestamp - previous.timestamp > maxTimeBetweenBreaks
     isVisible = showDateBreak
     text = if (showDateBreak) DateUtils.getDisplayFormattedTimeSpanString(context, Locale.getDefault(), message.timestamp) else ""
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/GroupThreadStatus.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/GroupThreadStatus.kt
@@ -1,0 +1,7 @@
+package org.thoughtcrime.securesms.database.model
+
+enum class GroupThreadStatus {
+    None,
+    Kicked,
+    Destroyed,
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -131,27 +131,6 @@ public abstract class MessageRecord extends DisplayRecord {
     return groupUpdateMessage;
   }
 
-  /**
-   * @return Whether the date text can be shown for this message. By default, every message
-   *         can show a date break, only certain messages can't. Note: a positive value
-   *         DOES NOT guarantee the date break will be shown, only a negative value can
-   *         hide the date break.
-   */
-  public boolean canShowDateBreak() {
-    UpdateMessageData update = getGroupUpdateMessage();
-
-    if (update == null) {
-      return true;
-    }
-
-    if (update.getKind() instanceof UpdateMessageData.Kind.GroupDestroyed ||
-      update.getKind() instanceof UpdateMessageData.Kind.GroupKicked) {
-      return false;
-    }
-
-    return true;
-  }
-
   @Override
   public CharSequence getDisplayBody(@NonNull Context context) {
     if (isGroupUpdateMessage()) {

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -864,18 +864,6 @@ class GroupManagerV2Impl @Inject constructor(
         if (threadId != null) {
             storage.clearMessages(threadId)
         }
-
-        // Insert a message to indicate we were kicked
-        storage.insertIncomingInfoMessage(
-            context = application,
-            senderPublicKey = userId,
-            groupID = groupId.hexString,
-            type = SignalServiceGroup.Type.KICKED,
-            name = groupName,
-            members = emptyList(),
-            admins = emptyList(),
-            sentTimestamp = clock.currentTimeMills(),
-        )
     }
 
     override suspend fun setName(groupId: AccountId, newName: String): Unit =

--- a/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
@@ -313,16 +313,6 @@ object UpdateMessageBuilder {
             is UpdateMessageData.Kind.GroupErrorQuit -> {
                 return context.getString(R.string.groupLeaveErrorFailed)
             }
-            is UpdateMessageData.Kind.GroupKicked -> {
-                return Phrase.from(context, R.string.groupRemovedYou)
-                    .put(GROUP_NAME_KEY, updateData.groupName)
-                    .format()
-            }
-            is UpdateMessageData.Kind.GroupDestroyed -> {
-                return Phrase.from(context, R.string.groupDeletedMemberDescription)
-                    .put(GROUP_NAME_KEY, updateData.groupName)
-                    .format()
-            }
         }
     }
 

--- a/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageData.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageData.kt
@@ -32,8 +32,6 @@ class UpdateMessageData () {
         JsonSubTypes.Type(Kind.GroupInvitation::class, name = "GroupInvitation"),
         JsonSubTypes.Type(Kind.GroupLeaving::class, name = "GroupLeaving"),
         JsonSubTypes.Type(Kind.GroupErrorQuit::class, name = "GroupErrorQuit"),
-        JsonSubTypes.Type(Kind.GroupKicked::class, name = "GroupKicked"),
-        JsonSubTypes.Type(Kind.GroupDestroyed::class, name = "GroupDestroyed")
     )
     sealed class Kind {
         data object GroupCreation: Kind()
@@ -74,14 +72,6 @@ class UpdateMessageData () {
         ) : Kind() {
             constructor(): this("", "", null, "")
         }
-
-        class GroupKicked(val groupName: String) : Kind() {
-            constructor(): this("")
-        }
-
-        class GroupDestroyed(val groupName: String) : Kind() {
-            constructor(): this("")
-        }
     }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
@@ -112,12 +102,10 @@ class UpdateMessageData () {
                 SignalServiceGroup.Type.QUIT -> UpdateMessageData(Kind.GroupMemberLeft(members, name))
                 SignalServiceGroup.Type.LEAVING -> UpdateMessageData(Kind.GroupLeaving)
                 SignalServiceGroup.Type.ERROR_QUIT -> UpdateMessageData(Kind.GroupErrorQuit)
-                SignalServiceGroup.Type.KICKED -> UpdateMessageData(Kind.GroupKicked(name))
                 SignalServiceGroup.Type.UNKNOWN,
                 SignalServiceGroup.Type.UPDATE,
                 SignalServiceGroup.Type.DELIVER,
                 SignalServiceGroup.Type.REQUEST_INFO -> null
-                SignalServiceGroup.Type.DESTROYED -> UpdateMessageData(Kind.GroupDestroyed(name))
             }
         }
 

--- a/libsignal/src/main/java/org/session/libsignal/messages/SignalServiceGroup.java
+++ b/libsignal/src/main/java/org/session/libsignal/messages/SignalServiceGroup.java
@@ -43,8 +43,6 @@ public class SignalServiceGroup {
     MEMBER_REMOVED,
     LEAVING,
     ERROR_QUIT,
-    KICKED,
-    DESTROYED,
   }
 
   private final byte[]                            groupId;


### PR DESCRIPTION
Previously, we used control messages to indicate whether the group is destroyed/kicked. This turns out to be a really bad idea because a message can really screws up the conversation state. For example, if you insert a kicked control message into the conversation when restoring an account, it will appear you have received a new "kicked" message which will be really odd.

The messing up has caused several other bugs so this PR will rectify this issue once for all: basically the `GroupThreadStatus` will be introduced into:
1. `ThreadRecord`, where you display the state of a particular thread. For our case, we will say "You were removed" or "Group is deleted" respectively. The display text comes from a state, not a message.
2. `ConversationActivityV2`, where you can control the "state banner" to show a special state for this conversation. For example you can show the user this convo is empty. We'll re-use the same facility to tell the user that the convo is kicked/deleted.
