### PR TITLE
Set the recovery phrase as being viewed when the user has visited the…

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
@@ -129,7 +129,7 @@ class SettingsActivity : PassphraseRequiredActionBarActivity() {
     private val onPickImage = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ){ result ->
-        if (result.resultCode != Activity.RESULT_OK) return@registerForActivityResult
+        if (result.resultCode != RESULT_OK) return@registerForActivityResult
 
         val outputFile = Uri.fromFile(File(cacheDir, "cropped"))
         val inputFile: Uri? = result.data?.data ?: viewModel.getTempFile()?.let(Uri::fromFile)
@@ -139,7 +139,7 @@ class SettingsActivity : PassphraseRequiredActionBarActivity() {
     private val hideRecoveryLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
-        if (result.resultCode != Activity.RESULT_OK) return@registerForActivityResult
+        if (result.resultCode != RESULT_OK) return@registerForActivityResult
 
         if(result.data?.getBooleanExtra(RecoveryPasswordActivity.RESULT_RECOVERY_HIDDEN, false) == true){
             viewModel.permanentlyHidePassword()

--- a/app/src/main/java/org/thoughtcrime/securesms/recoverypassword/RecoveryPasswordActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/recoverypassword/RecoveryPasswordActivity.kt
@@ -5,11 +5,14 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import network.loki.messenger.R
+import org.session.libsession.utilities.TextSecurePreferences
 import org.thoughtcrime.securesms.BaseActionBarActivity
 import org.thoughtcrime.securesms.ui.setComposeContent
 
-
+@AndroidEntryPoint
 class RecoveryPasswordActivity : BaseActionBarActivity() {
 
     companion object {
@@ -17,6 +20,8 @@ class RecoveryPasswordActivity : BaseActionBarActivity() {
     }
 
     private val viewModel: RecoveryPasswordViewModel by viewModels()
+
+    @Inject lateinit var prefs: TextSecurePreferences
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -38,5 +43,9 @@ class RecoveryPasswordActivity : BaseActionBarActivity() {
                 copyMnemonic = viewModel::copyMnemonic
             )
         }
+
+        // Set the seed as having been viewed when the user has seen this activity, which
+        // removes the reminder banner on the HomeActivity.
+        prefs.setHasViewedSeed(true)
     }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/recoverypassword/RecoveryPasswordActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/recoverypassword/RecoveryPasswordActivity.kt
@@ -38,6 +38,12 @@ class RecoveryPasswordActivity : BaseActionBarActivity() {
                     val returnIntent = Intent()
                     returnIntent.putExtra(RESULT_RECOVERY_HIDDEN, true)
                     setResult(RESULT_OK, returnIntent)
+
+                    // The returnIntent assumes we're going back to the SettingsActivity, which handles the result - but
+                    // if we entered this activity through the recovery phrase banner then we're going back to the
+                    // HomeActivity, which does not. As such we'll write the change here to cover all our bases.
+                    prefs.setHidePassword(true)
+
                     finish()
                 },
                 copyMnemonic = viewModel::copyMnemonic

--- a/app/src/main/java/org/thoughtcrime/securesms/recoverypassword/RecoveryPasswordViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/recoverypassword/RecoveryPasswordViewModel.kt
@@ -7,21 +7,19 @@ import android.content.Context
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.session.libsession.utilities.AppTextSecurePreferences
-import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.crypto.MnemonicCodec
 import org.session.libsignal.utilities.hexEncodedPrivateKey
 import org.thoughtcrime.securesms.crypto.IdentityKeyUtil
 import org.thoughtcrime.securesms.crypto.MnemonicUtilities
-import javax.inject.Inject
 
 @HiltViewModel
 class RecoveryPasswordViewModel @Inject constructor(


### PR DESCRIPTION
Hides the banner which reminds the user to make a note of their recovery phrase after having viewed it in the RecoveryPasswordActivity.

Previous behaviour was to only hide the banner when the user had copied their recovery phrase via the [Copy] button - which left the banner visible if they wrote down the phrase rather than copy & pasted it, and this also left the banner visible with no way to remove it if they permanently hid the recovery phrase section without first copying it to dismiss the banner.