### PR TITLE
[SES-3093] - Fix 1970 timestamp issue

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
@@ -36,7 +36,6 @@ import org.session.libsession.utilities.recipients.Recipient
 import org.session.libsignal.crypto.ecc.DjbECPrivateKey
 import org.session.libsignal.crypto.ecc.DjbECPublicKey
 import org.session.libsignal.crypto.ecc.ECKeyPair
-import org.session.libsignal.messages.SignalServiceGroup
 import org.session.libsignal.utilities.AccountId
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.database.MmsDatabase
@@ -153,7 +152,7 @@ class ConfigToDatabaseSync @Inject constructor(
             // create note to self thread if needed (?)
             val address = recipient.address
             val ourThread = storage.getThreadId(address) ?: storage.getOrCreateThreadIdFor(address).also {
-                storage.setThreadDate(it, 0)
+                storage.setThreadCreationDate(it, 0)
             }
             threadDatabase.setHasSent(ourThread, true)
             storage.setPinned(ourThread, userProfile.ntsPriority > 0)
@@ -315,7 +314,7 @@ class ConfigToDatabaseSync @Inject constructor(
 
             // If we don't already have a date and the config has a date, use it
             if (closedGroup.joinedAtSecs > 0L && threadDatabase.getLastUpdated(threadId) <= 0L) {
-                threadDatabase.setDate(
+                threadDatabase.setCreationDate(
                     threadId,
                     TimeUnit.SECONDS.toMillis(closedGroup.joinedAtSecs)
                 )
@@ -370,7 +369,7 @@ class ConfigToDatabaseSync @Inject constructor(
                 PushRegistryV1.subscribeGroup(group.accountId, publicKey = localUserPublicKey)
                 // Notify the user
                 val threadID = storage.getOrCreateThreadIdFor(fromSerialized(groupId))
-                threadDatabase.setDate(threadID, formationTimestamp)
+                threadDatabase.setCreationDate(threadID, formationTimestamp)
 
                 // Note: Commenting out this line prevents the timestamp of room creation being added to a new closed group,
                 // which in turn allows us to show the `groupNoMessages` control message text.

--- a/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
@@ -312,7 +312,15 @@ class ConfigToDatabaseSync @Inject constructor(
             storage.setRecipientApproved(recipient, !closedGroup.invited)
             profileManager.setName(context, recipient, closedGroup.name)
             val threadId = storage.getOrCreateThreadIdFor(recipient.address)
-            threadDatabase.setDate(threadId, TimeUnit.SECONDS.toMillis(closedGroup.joinedAtSecs))
+
+            // If we don't already have a date and the config has a date, use it
+            if (closedGroup.joinedAtSecs > 0L && threadDatabase.getLastUpdated(threadId) <= 0L) {
+                threadDatabase.setDate(
+                    threadId,
+                    TimeUnit.SECONDS.toMillis(closedGroup.joinedAtSecs)
+                )
+            }
+
             groupThreadsToKeep[closedGroup.groupAccountId] = threadId
 
             storage.setPinned(threadId, closedGroup.priority == PRIORITY_PINNED)

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -1281,7 +1281,7 @@ open class Storage @Inject constructor(
             } else {
                 (
                     getThreadId(address) ?: getOrCreateThreadIdFor(address).also {
-                        setThreadDate(it, 0)
+                        setThreadCreationDate(it, 0)
                     }
                 ).also { setPinned(it, contact.priority == PRIORITY_PINNED) }
             }
@@ -1435,9 +1435,9 @@ open class Storage @Inject constructor(
         return threadDB.isPinned(threadID)
     }
 
-    override fun setThreadDate(threadId: Long, newDate: Long) {
+    override fun setThreadCreationDate(threadId: Long, newDate: Long) {
         val threadDb = threadDatabase
-        threadDb.setDate(threadId, newDate)
+        threadDb.setCreationDate(threadId, newDate)
     }
 
     override fun getLastLegacyRecipient(threadRecipient: String): String? =

--- a/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -579,7 +579,7 @@ public class ThreadDatabase extends Database {
     }
   }
 
-  public Long getLastUpdated(long threadId) {
+  public long getLastUpdated(long threadId) {
     SQLiteDatabase db     = databaseHelper.getReadableDatabase();
     Cursor         cursor = db.query(TABLE_NAME, new String[]{THREAD_CREATION_DATE}, ID_WHERE, new String[]{String.valueOf(threadId)}, null, null, null);
 

--- a/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -56,7 +56,6 @@ import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord;
 import org.thoughtcrime.securesms.database.model.MessageRecord;
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord;
 import org.thoughtcrime.securesms.database.model.ThreadRecord;
-import org.thoughtcrime.securesms.dependencies.ConfigFactoryKt;
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent;
 import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.mms.SlideDeck;
@@ -375,7 +374,7 @@ public class ThreadDatabase extends Database {
     notifyConversationListListeners();
   }
 
-  public void setDate(long threadId, long date) {
+  public void setCreationDate(long threadId, long date) {
     ContentValues contentValues = new ContentValues(1);
     contentValues.put(THREAD_CREATION_DATE, date);
     SQLiteDatabase db = databaseHelper.getWritableDatabase();

--- a/libsession/src/main/java/org/session/libsession/database/StorageProtocol.kt
+++ b/libsession/src/main/java/org/session/libsession/database/StorageProtocol.kt
@@ -199,7 +199,7 @@ interface StorageProtocol {
     fun setPinned(threadID: Long, isPinned: Boolean)
     fun isPinned(threadID: Long): Boolean
     fun deleteConversation(threadID: Long)
-    fun setThreadDate(threadId: Long, newDate: Long)
+    fun setThreadCreationDate(threadId: Long, newDate: Long)
     fun getLastLegacyRecipient(threadRecipient: String): String?
     fun setLastLegacyRecipient(threadRecipient: String, senderRecipient: String?)
     fun clearMessages(threadID: Long, fromUser: Address? = null): Boolean


### PR DESCRIPTION
Basically we should never put 0L explicitly into db.
