### PR TITLE
[SES-2925] - Clear thread messages before accepting/rejecting group invitation

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -599,6 +599,8 @@ class GroupManagerV2Impl @Inject constructor(
             // Whether approved or not, delete the invite
             lokiDatabase.deleteGroupInviteReferrer(threadId)
 
+            storage.clearMessages(threadId)
+
             if (approved) {
                 approveGroupInvite(group, groupInviteMessageHash)
             } else {


### PR DESCRIPTION
...so that the manually inserted controll messages can be cleared out to avoid doubling up.
