### PR TITLE
Fix/make file attachment message visible

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -406,14 +406,13 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
   @SuppressWarnings("CodeBlock2Expr")
   @SuppressLint("InlinedApi")
   private void saveToDisk() {
-    Log.w("ACL", "Asked to save to disk!");
     MediaItem mediaItem = getCurrentMediaItem();
     if (mediaItem == null) return;
 
     SaveAttachmentTask.showOneTimeWarningDialogOrSave(this, 1, () -> {
       Permissions.with(this)
               .request(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
-              .maxSdkVersion(Build.VERSION_CODES.P)
+              .maxSdkVersion(Build.VERSION_CODES.P) // Note: P is API 28
               .withPermanentDenialDialog(getPermanentlyDeniedStorageText())
               .onAnyDenied(() -> {
                 Toast.makeText(this, getPermanentlyDeniedStorageText(), Toast.LENGTH_LONG).show();

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -174,7 +174,8 @@ class VisibleMessageContentView : ConstraintLayout {
             }
             // DOCUMENT
             message is MmsMessageRecord && message.slideDeck.documentSlide != null -> {
-                hideBody = true // TODO: check if this is still the logic we want
+                // ACL HERE!
+                //hideBody = true // TODO: check if this is still the logic we want
                 // Document attachment
                 if (mediaDownloaded || mediaInProgress || message.isOutgoing) {
                     binding.documentView.root.bind(message, getTextColor(context, message))

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -151,7 +151,10 @@ class VisibleMessageContentView : ConstraintLayout {
 
             // AUDIO
             message is MmsMessageRecord && message.slideDeck.audioSlide != null -> {
-                hideBody = true
+
+                // Show any text message associated with the audio message (which may be a voice clip - but could also be a mp3 or such)
+                hideBody = false
+
                 // Audio attachment
                 if (mediaDownloaded || mediaInProgress || message.isOutgoing) {
                     binding.voiceMessageView.root.indexInAdapter = indexInAdapter
@@ -162,7 +165,7 @@ class VisibleMessageContentView : ConstraintLayout {
                     onContentClick.add { binding.voiceMessageView.root.togglePlayback() }
                     onContentDoubleTap = { binding.voiceMessageView.root.handleDoubleTap() }
                 } else {
-                    hideBody = true
+                    // If it's an audio message but we haven't downloaded it yet show it as pending
                     (message.slideDeck.audioSlide?.asAttachment() as? DatabaseAttachment)?.let { attachment ->
                         binding.pendingAttachmentView.root.bind(
                             PendingAttachmentView.AttachmentType.AUDIO,
@@ -176,16 +179,14 @@ class VisibleMessageContentView : ConstraintLayout {
 
             // DOCUMENT
             message is MmsMessageRecord && message.slideDeck.documentSlide != null -> {
-                // Show any message that came with document attached
+                // Show any message that came with the attached document
                 hideBody = false
 
                 // Document attachment
                 if (mediaDownloaded || mediaInProgress || message.isOutgoing) {
                     binding.documentView.root.bind(message, getTextColor(context, message))
                 } else {
-                    // If this is a pending attachment that the user hasn't agreed to automatically download then we'll
-                    // also display any attached message that came with the file.
-                    hideBody = false
+                    // If the document hasn't been downloaded yet then show it as pending
                     (message.slideDeck.documentSlide?.asAttachment() as? DatabaseAttachment)?.let { attachment ->
                         binding.pendingAttachmentView.root.bind(
                             PendingAttachmentView.AttachmentType.DOCUMENT,

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -174,13 +174,16 @@ class VisibleMessageContentView : ConstraintLayout {
             }
             // DOCUMENT
             message is MmsMessageRecord && message.slideDeck.documentSlide != null -> {
-                // ACL HERE!
-                //hideBody = true // TODO: check if this is still the logic we want
+                // Show any message that came with document attached
+                hideBody = false
+
                 // Document attachment
                 if (mediaDownloaded || mediaInProgress || message.isOutgoing) {
                     binding.documentView.root.bind(message, getTextColor(context, message))
                 } else {
-                    hideBody = true
+                    // If this is a pending attachment that the user hasn't agreed to automatically download then we'll
+                    // also display any attached message that came with the file.
+                    hideBody = false
                     (message.slideDeck.documentSlide?.asAttachment() as? DatabaseAttachment)?.let { attachment ->
                         binding.pendingAttachmentView.root.bind(
                             PendingAttachmentView.AttachmentType.DOCUMENT,

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -20,6 +20,8 @@ import androidx.core.view.children
 import androidx.core.view.isVisible
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
+import java.util.Locale
+import kotlin.math.roundToInt
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ViewVisibleMessageContentBinding
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -38,8 +40,6 @@ import org.thoughtcrime.securesms.database.model.MmsMessageRecord
 import org.thoughtcrime.securesms.util.GlowViewUtilities
 import org.thoughtcrime.securesms.util.SearchUtil
 import org.thoughtcrime.securesms.util.getAccentColor
-import java.util.Locale
-import kotlin.math.roundToInt
 
 class VisibleMessageContentView : ConstraintLayout {
     private val binding: ViewVisibleMessageContentBinding by lazy { ViewVisibleMessageContentBinding.bind(this) }
@@ -148,6 +148,7 @@ class VisibleMessageContentView : ConstraintLayout {
                 // When in a link preview ensure the bodyTextView can expand to the full width
                 binding.bodyTextView.maxWidth = binding.linkPreviewView.root.layoutParams.width
             }
+
             // AUDIO
             message is MmsMessageRecord && message.slideDeck.audioSlide != null -> {
                 hideBody = true
@@ -172,6 +173,7 @@ class VisibleMessageContentView : ConstraintLayout {
                     }
                 }
             }
+
             // DOCUMENT
             message is MmsMessageRecord && message.slideDeck.documentSlide != null -> {
                 // Show any message that came with document attached
@@ -194,6 +196,7 @@ class VisibleMessageContentView : ConstraintLayout {
                     }
                 }
             }
+
             // IMAGE / VIDEO
             message is MmsMessageRecord && !suppressThumbnails && message.slideDeck.asAttachments().isNotEmpty() -> {
                 if (mediaDownloaded || mediaInProgress || message.isOutgoing) {
@@ -205,7 +208,7 @@ class VisibleMessageContentView : ConstraintLayout {
                         isStart = isStartOfMessageCluster,
                         isEnd = isEndOfMessageCluster
                     )
-                    binding.albumThumbnailView.root.modifyLayoutParams<ConstraintLayout.LayoutParams> {
+                    binding.albumThumbnailView.root.modifyLayoutParams<LayoutParams> {
                         horizontalBias = if (message.isOutgoing) 1f else 0f
                     }
                     onContentClick.add { event ->

--- a/app/src/main/res/layout/view_visible_message_content.xml
+++ b/app/src/main/res/layout/view_visible_message_content.xml
@@ -104,7 +104,7 @@
             app:layout_constraintHorizontal_bias="0"
             tools:visibility="visible"
             android:visibility="gone"
-            app:layout_constraintTop_toBottomOf="@+id/bodyTopBarrier"
+            app:layout_constraintTop_toBottomOf="@+id/documentView"
             app:layout_constraintStart_toStartOf="parent"
             android:maxWidth="@dimen/max_text_width"
             android:paddingHorizontal="12dp"

--- a/app/src/main/res/layout/view_visible_message_content.xml
+++ b/app/src/main/res/layout/view_visible_message_content.xml
@@ -27,16 +27,6 @@
             app:layout_constraintHorizontal_bias="0"
             />
 
-        <include layout="@layout/view_pending_attachment"
-            tools:visibility="gone"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:visibility="gone"
-            android:id="@+id/pending_attachment_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-
         <include layout="@layout/view_open_group_invitation"
             tools:visibility="gone"
             app:layout_constraintTop_toTopOf="parent"
@@ -44,15 +34,6 @@
             app:layout_constraintStart_toStartOf="parent"
             android:visibility="gone"
             android:id="@+id/openGroupInvitationView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-
-        <include layout="@layout/view_document"
-            tools:visibility="gone"
-            app:layout_constraintTop_toBottomOf="@+id/bodyTextView"
-            app:layout_constraintStart_toStartOf="parent"
-            android:visibility="gone"
-            android:id="@+id/documentView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"/>
 
@@ -93,25 +74,42 @@
             app:constraint_referenced_ids="linkPreviewView,quoteView,voiceMessageView"/>
 
         <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/bodyTopBarrier"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:id="@+id/bodyTopBarrier"
-            app:constraint_referenced_ids="linkPreviewView,quoteView"
-            app:barrierDirection="bottom"/>
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="linkPreviewView,quoteView" />
 
         <org.thoughtcrime.securesms.components.emoji.EmojiTextView
+            android:id="@+id/bodyTextView"
             android:contentDescription="@string/AccessibilityId_message"
-            app:layout_constraintHorizontal_bias="0"
-            tools:visibility="visible"
-            android:visibility="gone"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:maxWidth="@dimen/max_text_width"
             android:paddingHorizontal="12dp"
             android:paddingVertical="@dimen/small_spacing"
-            android:id="@+id/bodyTextView"
+            android:visibility="gone"
+            tools:visibility="visible"
+            app:layout_constraintTop_toBottomOf="@+id/bodyTopBarrier"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <include layout="@layout/view_document"
+            android:id="@+id/documentView"
+            android:visibility="gone"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@+id/bodyTextView"
+            app:layout_constraintStart_toStartOf="parent"/>
+
+        <include layout="@layout/view_pending_attachment"
+            android:id="@+id/pending_attachment_view"
+            android:visibility="gone"
+            tools:visibility="gone"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@+id/bodyTextView"
+            app:layout_constraintStart_toStartOf="parent"/>
+
     </org.thoughtcrime.securesms.util.MessageBubbleView>
 
     <include layout="@layout/album_thumbnail_view"

--- a/app/src/main/res/layout/view_visible_message_content.xml
+++ b/app/src/main/res/layout/view_visible_message_content.xml
@@ -49,7 +49,7 @@
 
         <include layout="@layout/view_document"
             tools:visibility="gone"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/bodyTextView"
             app:layout_constraintStart_toStartOf="parent"
             android:visibility="gone"
             android:id="@+id/documentView"
@@ -104,7 +104,7 @@
             app:layout_constraintHorizontal_bias="0"
             tools:visibility="visible"
             android:visibility="gone"
-            app:layout_constraintTop_toBottomOf="@+id/documentView"
+            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             android:maxWidth="@dimen/max_text_width"
             android:paddingHorizontal="12dp"

--- a/app/src/main/res/layout/view_visible_message_content.xml
+++ b/app/src/main/res/layout/view_visible_message_content.xml
@@ -14,8 +14,8 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintHorizontal_bias="0"
-        app:layout_constraintEnd_toEndOf="parent"
-        >
+        app:layout_constraintEnd_toEndOf="parent" >
+
         <!-- Content that will only show on its own -->
         <include layout="@layout/view_deleted_message"
             app:layout_constraintTop_toTopOf="parent"
@@ -47,15 +47,6 @@
             android:id="@+id/quoteView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"/>
-
-        <include layout="@layout/view_voice_message"
-            app:layout_constraintTop_toBottomOf="@id/quoteView"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:visibility="gone"
-            android:id="@+id/voiceMessageView"
-            android:layout_width="160dp"
-            android:layout_height="36dp"/>
 
         <include layout="@layout/view_link_preview"
             app:layout_constraintTop_toBottomOf="@+id/quoteView"
@@ -100,6 +91,16 @@
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/bodyTextView"
             app:layout_constraintStart_toStartOf="parent"/>
+
+        <include layout="@layout/view_voice_message"
+
+            android:visibility="gone"
+            android:id="@+id/voiceMessageView"
+            android:layout_width="160dp"
+            android:layout_height="36dp"
+            app:layout_constraintTop_toBottomOf="@+id/bodyTextView"
+            app:layout_constraintStart_toStartOf="parent"/>
+
 
         <include layout="@layout/view_pending_attachment"
             android:id="@+id/pending_attachment_view"


### PR DESCRIPTION
Ticket: SES-2708

Details: If a document such as a PDF was sent from Session Desktop to Session Android, and the sent document also contained some text (for example, "Here's that PDF we were talking about") - then Session Android would not show the accompanying text, only the "DocumentView" (or the pending document view with "Tap to download document" if the receiving user had not agreed to accept file downloads at that time).

This PR fixes that issue so that any accompanying text is displayed above the incoming file attachment.

Note: Session Android cannot at present sent a document and some accompanying text at the same time. Adding a document such as a PDF discards any existing text and sends the file. If we wish the behaviour to be that we can send a document and some accompanying text in the same message then this should be raised as a separate ticket.