### PR TITLE
SES-3111 - Improve overall networking bottleneck

### DIFF
--- a/libsession/src/main/java/org/session/libsession/snode/OnionRequestAPI.kt
+++ b/libsession/src/main/java/org/session/libsession/snode/OnionRequestAPI.kt
@@ -1,5 +1,6 @@
 package org.session.libsession.snode
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import nl.komponents.kovenant.Deferred

--- a/libsignal/src/main/java/org/session/libsignal/utilities/HTTP.kt
+++ b/libsignal/src/main/java/org/session/libsignal/utilities/HTTP.kt
@@ -149,7 +149,7 @@ object HTTP {
     }
 
     @Suppress("OPT_IN_USAGE")
-    private val httpCallDispatcher = Dispatchers.IO.limitedParallelism(3)
+    private val httpCallDispatcher = Dispatchers.IO.limitedParallelism(15)
 
     private suspend fun Call.await(): Response {
         return withContext(httpCallDispatcher) {


### PR DESCRIPTION
This PR:
1. Makse sure config system is able to handle notification pressure
2. Opens up the concurrency on network requests
