### PR TITLE
Do not reuse placeholder drawable

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/ProfilePictureView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ProfilePictureView.kt
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.components
 
 import android.content.Context
+import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
@@ -59,13 +60,16 @@ class ProfilePictureView @JvmOverloads constructor(
     private val resourcePadding by lazy {
         context.resources.getDimensionPixelSize(R.dimen.normal_padding).toFloat()
     }
-    private val unknownRecipientDrawable by lazy { ResourceContactPhoto(R.drawable.ic_profile_default)
-        .asDrawable(context, ContactColors.UNKNOWN_COLOR.toConversationColor(context), false, resourcePadding) }
     private val unknownOpenGroupDrawable by lazy { ResourceContactPhoto(R.drawable.ic_notification)
         .asDrawable(context, ContactColors.UNKNOWN_COLOR.toConversationColor(context), false, resourcePadding) }
 
     constructor(context: Context, sender: Recipient): this(context) {
         update(sender)
+    }
+
+    private fun createUnknownRecipientDrawable(): Drawable {
+        return ResourceContactPhoto(R.drawable.ic_profile_default)
+            .asDrawable(context, ContactColors.UNKNOWN_COLOR.toConversationColor(context), false, resourcePadding)
     }
 
     fun update(recipient: Recipient) {
@@ -173,28 +177,28 @@ class ProfilePictureView @JvmOverloads constructor(
 
             if (signalProfilePicture != null && avatar != "0" && avatar != "") {
                 glide.load(signalProfilePicture)
-                    .placeholder(unknownRecipientDrawable)
+                    .placeholder(createUnknownRecipientDrawable())
                     .centerCrop()
                     .error(glide.load(placeholder))
                     .diskCacheStrategy(DiskCacheStrategy.NONE)
                     .circleCrop()
                     .into(imageView)
             } else if (recipient.isCommunityRecipient && recipient.groupAvatarId == null) {
-                glide.clear(imageView)
                 glide.load(unknownOpenGroupDrawable)
                     .centerCrop()
                     .circleCrop()
                     .into(imageView)
             } else {
                 glide.load(placeholder)
-                    .placeholder(unknownRecipientDrawable)
+                    .placeholder(createUnknownRecipientDrawable())
                     .centerCrop()
                     .circleCrop()
-                    .diskCacheStrategy(DiskCacheStrategy.NONE).circleCrop().into(imageView)
+                    .diskCacheStrategy(DiskCacheStrategy.NONE)
+                    .into(imageView)
             }
         } else {
-            glide.load(unknownRecipientDrawable)
-                .centerCrop()
+            glide.load(createUnknownRecipientDrawable())
+                .fitCenter()
                 .into(imageView)
         }
     }


### PR DESCRIPTION
This is to fix an issue where the `ProfilePictureView` may be reused by both single icon and multiple icon mode. If the view was in single icon mode and uses the placeholder image, the same placeholder image later re-used by the multiple icon mode, the placeholder image will be screwed up.

This PR makes sure the placeholder is a different one to avoid this issue.

FYI this is what it looks like to be reused:

![image](https://github.com/user-attachments/assets/8ca0b35a-6da3-4305-afea-cde59b7b25a1)
