### PR TITLE
SES-3053 Send only the first 32 bytes of admin key as promotion message

### DIFF
--- a/libsession-util/src/main/java/network/loki/messenger/libsession_util/util/GroupInfo.kt
+++ b/libsession-util/src/main/java/network/loki/messenger/libsession_util/util/GroupInfo.kt
@@ -17,7 +17,6 @@ sealed class GroupInfo {
         val destroyed: Boolean,
         val joinedAtSecs: Long
     ): GroupInfo() {
-
         init {
             require(adminKey == null || adminKey.isNotEmpty()) {
                 "Admin key must be non-empty if present"
@@ -29,6 +28,17 @@ sealed class GroupInfo {
         }
 
         fun hasAdminKey() = adminKey != null
+
+        companion object {
+            /**
+             * Generate the group's admin key(64 bytes) from seed (32 bytes, normally used
+             * in group promotions).
+             *
+             * Use of JvmStatic makes the JNI signature less esoteric.
+             */
+            @JvmStatic
+            external fun adminKeyFromSeed(seed: ByteArray): ByteArray
+        }
     }
 
     data class LegacyGroupInfo(


### PR DESCRIPTION
The key we put into promotion message is wrong, it's supposed to be only the first 32 bytes of the admin key (called a seed). When a member receives promotion, they need to construct the full admin key from the seed.