### PR TITLE
Fix OpenGroup blocking default dispatcher

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -1131,7 +1131,7 @@ open class Storage @Inject constructor(
         return groupDatabase.getAllGroups(includeInactive)
     }
 
-    override fun addOpenGroup(urlAsString: String): OpenGroupApi.RoomInfo? {
+    override suspend fun addOpenGroup(urlAsString: String): OpenGroupApi.RoomInfo? {
         return OpenGroupManager.addOpenGroup(urlAsString, context)
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/OpenGroupManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/OpenGroupManager.kt
@@ -14,6 +14,7 @@ import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.open_groups.OpenGroup
 import org.session.libsession.messaging.open_groups.OpenGroupApi
 import org.session.libsession.messaging.sending_receiving.pollers.OpenGroupPoller
+import org.session.libsession.snode.utilities.await
 import org.session.libsession.utilities.StringSubstitutionConstants.COMMUNITY_NAME_KEY
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
@@ -74,7 +75,7 @@ object OpenGroupManager {
     fun getCommunitiesWriteAccessFlow() = _communityWriteAccess.asStateFlow()
 
     @WorkerThread
-    fun add(server: String, room: String, publicKey: String, context: Context): Pair<Long,OpenGroupApi.RoomInfo?> {
+    suspend fun add(server: String, room: String, publicKey: String, context: Context): Pair<Long,OpenGroupApi.RoomInfo?> {
         val openGroupID = "$server.$room"
         val threadID = GroupManager.getOpenGroupThreadID(openGroupID, context)
         val storage = MessagingModuleConfiguration.shared.storage
@@ -90,7 +91,7 @@ object OpenGroupManager {
         // Store the public key
         storage.setOpenGroupPublicKey(server, publicKey)
         // Get capabilities & room info
-        val (capabilities, info) = OpenGroupApi.getCapabilitiesAndRoomInfo(room, server).get()
+        val (capabilities, info) = OpenGroupApi.getCapabilitiesAndRoomInfo(room, server).await()
         storage.setServerCapabilities(server, capabilities.capabilities)
         // Create the group locally if not available already
         if (threadID < 0) {
@@ -161,7 +162,7 @@ object OpenGroupManager {
     }
 
     @WorkerThread
-    fun addOpenGroup(urlAsString: String, context: Context): OpenGroupApi.RoomInfo? {
+    suspend fun addOpenGroup(urlAsString: String, context: Context): OpenGroupApi.RoomInfo? {
         val url = urlAsString.toHttpUrlOrNull() ?: return null
         val server = OpenGroup.getServer(urlAsString)
         val room = url.pathSegments.firstOrNull() ?: return null

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/ClearAllDataDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/ClearAllDataDialog.kt
@@ -20,6 +20,7 @@ import org.session.libsession.database.StorageProtocol
 import org.session.libsession.database.userAuth
 import org.session.libsession.messaging.open_groups.OpenGroupApi
 import org.session.libsession.snode.SnodeAPI
+import org.session.libsession.snode.utilities.await
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.ApplicationContext
 import org.thoughtcrime.securesms.createSessionDialog
@@ -145,9 +146,9 @@ class ClearAllDataDialog : DialogFragment() {
                     val deletionResultMap: Map<String, Boolean>? = try {
                         val openGroups = DatabaseComponent.get(requireContext()).lokiThreadDatabase().getAllOpenGroups()
                         openGroups.map { it.value.server }.toSet().forEach { server ->
-                            OpenGroupApi.deleteAllInboxMessages(server).get()
+                            OpenGroupApi.deleteAllInboxMessages(server).await()
                         }
-                        SnodeAPI.deleteAllMessages(checkNotNull(storage.userAuth)).get()
+                        SnodeAPI.deleteAllMessages(checkNotNull(storage.userAuth)).await()
                     } catch (e: Exception) {
                         Log.e(TAG, "Failed to delete network messages - offering user option to delete local data only.", e)
                         null

--- a/libsession/src/main/java/org/session/libsession/database/StorageProtocol.kt
+++ b/libsession/src/main/java/org/session/libsession/database/StorageProtocol.kt
@@ -80,7 +80,7 @@ interface StorageProtocol {
     fun getAllOpenGroups(): Map<Long, OpenGroup>
     fun updateOpenGroup(openGroup: OpenGroup)
     fun getOpenGroup(threadId: Long): OpenGroup?
-    fun addOpenGroup(urlAsString: String): OpenGroupApi.RoomInfo?
+    suspend fun addOpenGroup(urlAsString: String): OpenGroupApi.RoomInfo?
     fun onOpenGroupAdded(server: String, room: String)
     fun hasBackgroundGroupAddJob(groupJoinUrl: String): Boolean
     fun setOpenGroupServerMessageID(messageID: Long, serverID: Long, threadID: Long, isSms: Boolean)

--- a/libsession/src/main/java/org/session/libsession/messaging/jobs/GroupAvatarDownloadJob.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/jobs/GroupAvatarDownloadJob.kt
@@ -4,6 +4,7 @@ import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.open_groups.OpenGroupApi
 import org.session.libsession.messaging.utilities.Data
 import org.session.libsession.snode.SnodeAPI
+import org.session.libsession.snode.utilities.await
 import org.session.libsession.utilities.GroupUtil
 
 class GroupAvatarDownloadJob(val server: String, val room: String, val imageId: String?) : Job {
@@ -32,7 +33,7 @@ class GroupAvatarDownloadJob(val server: String, val room: String, val imageId: 
         }
 
         try {
-            val bytes = OpenGroupApi.downloadOpenGroupProfilePicture(server, room, imageId).get()
+            val bytes = OpenGroupApi.downloadOpenGroupProfilePicture(server, room, imageId).await()
 
             // Once the download is complete the imageId might no longer match, so we need to fetch it again just in case
             val postDownloadStoredImageId = storage.getOpenGroup(room, server)?.imageId

--- a/libsession/src/main/java/org/session/libsession/utilities/ProfilePictureUtilities.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/ProfilePictureUtilities.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.launch
 import okio.Buffer
 import org.session.libsession.avatars.AvatarHelper
 import org.session.libsession.messaging.file_server.FileServerApi
+import org.session.libsession.snode.utilities.await
 import org.session.libsession.utilities.Address.Companion.fromSerialized
 import org.session.libsession.utilities.TextSecurePreferences.Companion.getLastProfilePictureUpload
 import org.session.libsession.utilities.TextSecurePreferences.Companion.getLocalNumber
@@ -102,7 +103,7 @@ object ProfilePictureUtilities {
         // this can throw an error
         id = retryIfNeeded(4) {
             FileServerApi.upload(data)
-        }.get()
+        }.await()
 
         TextSecurePreferences.setLastProfilePictureUpload(context, Date().time)
         val url = "${FileServerApi.server}/file/$id"


### PR DESCRIPTION
There are a few places left that still doing `Future.get()` which blocks the default dispatcher. The default dispatcher has finite number of threads available so if they are blocked, other things can get blocked too.

This problem is very apparent in accounts with lots of communities. By changing the blocking behavior into `.await()` we can leverage the use of suspend function instead. Most of the changes already come from a coroutine context.
