### PR TITLE
Delete a group directly if it's already destroyed

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationMenuHelper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationMenuHelper.kt
@@ -414,7 +414,7 @@ object ConversationMenuHelper {
                     doLeave = {
                         try {
                             channel.send(GroupLeavingStatus.Leaving)
-                            groupManager.leaveGroup(accountId, true)
+                            groupManager.leaveGroup(accountId)
                             channel.send(GroupLeavingStatus.Left)
                         } catch (e: Exception) {
                             channel.send(GroupLeavingStatus.Error)

--- a/libsession/src/main/java/org/session/libsession/messaging/groups/GroupManagerV2.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/groups/GroupManagerV2.kt
@@ -43,10 +43,7 @@ interface GroupManagerV2 {
     )
 
     suspend fun handleMemberLeftMessage(memberId: AccountId, group: AccountId)
-
-    suspend fun leaveGroup(groupId:
-                           AccountId, deleteOnLeave: Boolean)
-
+    suspend fun leaveGroup(groupId: AccountId)
     suspend fun promoteMember(group: AccountId, members: List<AccountId>)
 
     suspend fun handleInvitation(


### PR DESCRIPTION
This PR fixes an issue where all admins have left the group, making the group in a "destroyed" state, the user is then unable to delete the group due to error gettings keys.

This PR then bypass all the swarm related operations and delete the conversation directly. Also tidy up the unused flag.
