### PR TITLE
Add a group scope to limit group work concurrency

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/ConfigFactory.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/ConfigFactory.kt
@@ -554,7 +554,7 @@ private fun MutableUserGroupsConfig.initFrom(storage: StorageProtocol) {
 
 private fun MutableConversationVolatileConfig.initFrom(storage: StorageProtocol, threadDb: ThreadDatabase) {
     threadDb.approvedConversationList.use { cursor ->
-        val reader = threadDb.readerFor(cursor)
+        val reader = threadDb.readerFor(cursor, false)
         var current = reader.next
         while (current != null) {
             val recipient = current.recipient

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/SessionUtilModule.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/SessionUtilModule.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.groups.GroupManagerV2
+import org.session.libsession.messaging.groups.GroupScope
 import org.session.libsession.snode.SnodeClock
 import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsignal.database.LokiAPIDatabaseProtocol
@@ -59,4 +60,8 @@ object SessionUtilModule {
     @Provides
     @Singleton
     fun provideSnodeClock() = SnodeClock()
+
+    @Provides
+    @Singleton
+    fun provideGroupScope() = GroupScope()
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/handler/DestroyedGroupSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/handler/DestroyedGroupSync.kt
@@ -8,6 +8,7 @@ import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsession.utilities.ConfigUpdateNotification
 import org.session.libsession.utilities.waitUntilGroupConfigsPushed
 import org.session.libsignal.utilities.Log
+import org.session.libsession.messaging.groups.GroupScope
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -18,6 +19,7 @@ import javax.inject.Singleton
 @Singleton
 class DestroyedGroupSync @Inject constructor(
     private val configFactory: ConfigFactoryProtocol,
+    private val groupScope: GroupScope,
 ) {
     private var job: Job? = null
 
@@ -35,15 +37,17 @@ class DestroyedGroupSync @Inject constructor(
                     Log.d("DestroyedGroupSync", "Group is destroyed: $isDestroyed")
 
                     if (isDestroyed) {
-                        // If there's un-pushed group config updates, wait until they are pushed.
-                        // This is important, as the pushing process might need to access the UserGroupConfig,
-                        // if we delete the UserGroupConfig before the pushing process, the pushing
-                        // process will fail.
-                        configFactory.waitUntilGroupConfigsPushed(update.groupId)
+                        groupScope.launch(update.groupId, "DestroyedGroupSync") {
+                            // If there's un-pushed group config updates, wait until they are pushed.
+                            // This is important, as the pushing process might need to access the UserGroupConfig,
+                            // if we delete the UserGroupConfig before the pushing process, the pushing
+                            // process will fail.
+                            configFactory.waitUntilGroupConfigsPushed(update.groupId)
 
-                        configFactory.withMutableUserConfigs { configs ->
-                            configs.userGroups.getClosedGroup(update.groupId.hexString)?.let { group ->
-                                configs.userGroups.set(group.copy(destroyed = true))
+                            configFactory.withMutableUserConfigs { configs ->
+                                configs.userGroups.getClosedGroup(update.groupId.hexString)?.let { group ->
+                                    configs.userGroups.set(group.copy(destroyed = true))
+                                }
                             }
                         }
                     }

--- a/libsession/src/main/java/org/session/libsession/messaging/MessagingModuleConfiguration.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/MessagingModuleConfiguration.kt
@@ -5,6 +5,7 @@ import com.goterl.lazysodium.utils.KeyPair
 import org.session.libsession.database.MessageDataProvider
 import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.groups.GroupManagerV2
+import org.session.libsession.messaging.groups.GroupScope
 import org.session.libsession.messaging.notifications.TokenFetcher
 import org.session.libsession.snode.OwnedSwarmAuth
 import org.session.libsession.snode.SnodeClock

--- a/libsession/src/main/java/org/session/libsession/messaging/groups/GroupScope.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/groups/GroupScope.kt
@@ -1,0 +1,109 @@
+package org.session.libsession.messaging.groups
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.session.libsignal.utilities.AccountId
+import org.session.libsignal.utilities.Log
+import java.util.concurrent.atomic.AtomicLong
+
+private const val TAG = "GroupScope"
+
+/**
+ * A coroutine utility that limit the tasks into a group to be executed sequentially.
+ *
+ * This is useful for tasks that are related to group management, where the order of execution is important.
+ * It's probably harmful if you apply the scope on message retrieval, as normally the message retriveal
+ * doesn't have any order requirement and it will likly slow down usual group operations.
+ */
+class GroupScope(private val scope: CoroutineScope = GlobalScope) {
+    private val tasksByGroupId = hashMapOf<AccountId, ArrayDeque<Task<*>>>()
+
+    /**
+     * Launch a coroutine in a group context. The coroutine will be executed sequentially
+     * in the order they are launched, and the next coroutine will not be started until the previous one is completed.
+     * Each group has their own queue of tasks so they won't block each other.
+     *
+     * @groupId The group id that the coroutine belongs to.
+     * @debugName A debug name for the coroutine.
+     * @block The coroutine block.
+     */
+    fun launch(groupId: AccountId, debugName: String, block: suspend () -> Unit) : Job {
+        return async(groupId, debugName) { block() }
+    }
+
+    /**
+     * Launch a coroutine in the given group scope and wait for it to complete.
+     *
+     * See [launch] for more details.
+     */
+    suspend fun <T> launchAndWait(groupId: AccountId, debugName: String, block: suspend () -> T): T {
+        return async(groupId, debugName, block).await()
+    }
+
+    /**
+     * Launch a coroutine in the given group scope and return a deferred result.
+     *
+     * See [launch] for more details.
+     */
+    fun <T> async(groupId: AccountId, debugName: String, block: suspend () -> T) : Deferred<T> {
+        val completion = CompletableDeferred<T>()
+
+        synchronized(tasksByGroupId) {
+            val tasks = tasksByGroupId.getOrPut(groupId) { ArrayDeque() }
+
+            val task = Task(groupId, debugName, block, completion)
+            tasks.addLast(task)
+
+            Log.d(TAG, "Added $task to queue, queue size: ${tasks.size}")
+
+            // If this is the first task in the queue, start it directly (otherwise the next will be started by the previous task)
+            if (tasks.size == 1) {
+                scope.launch {
+                    task.run()
+                }
+            }
+        }
+
+        return completion
+    }
+
+    private val taskIdSeq = AtomicLong(0)
+
+    private inner class Task<T>(val groupId: AccountId, val debugName: String, val block: suspend () -> T, val completion: CompletableDeferred<T>) {
+        private val id = taskIdSeq.getAndIncrement()
+
+        suspend fun run() {
+            Log.d(TAG, "Task started: $this")
+            try {
+                completion.complete(block())
+            } catch (e: Throwable) {
+                completion.completeExceptionally(e)
+            } finally {
+                Log.d(TAG, "Task completed: $this")
+                // Remove self from the queue and start the next task
+                synchronized(tasksByGroupId) {
+                    val tasks = tasksByGroupId[groupId]
+                    require(tasks != null && tasks.firstOrNull() == this) { "Task is not the first in the queue: $this" }
+                    tasks.removeFirst()
+
+                    if (tasks.isEmpty()) {
+                        tasksByGroupId.remove(groupId)
+                    } else {
+                        val nextTask = tasks.first()
+                        scope.launch {
+                            nextTask.run()
+                        }
+                    }
+                }
+            }
+        }
+
+        override fun toString(): String {
+            return "Task($debugName, id=$id)"
+        }
+    }
+}

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
@@ -260,7 +260,7 @@ object MessageSender {
                         SnodeAPI.sendMessage(
                             auth = groupAuth,
                             message = snodeMessage,
-                            namespace = namespace
+                            namespace = namespace,
                         )
                     }
                 } else {

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/ClosedGroupPoller.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/ClosedGroupPoller.kt
@@ -238,6 +238,13 @@ class ClosedGroupPoller(
                 saveLastMessageHash(snode, infoMessage, Namespace.CLOSED_GROUP_INFO())
                 saveLastMessageHash(snode, membersMessage, Namespace.CLOSED_GROUP_MEMBERS())
 
+                // As soon as we have handled config messages, the polling count as successful,
+                // as normally the outside world really only cares about configs.
+                val currentState = state.value as? StartedState
+                if (currentState != null && !currentState.hadAtLeastOneSuccessfulPoll) {
+                    mutableState.value = currentState.copy(hadAtLeastOneSuccessfulPoll = true)
+                }
+
                 val regularMessages = groupMessageRetrieval.await()
                 handleMessages(regularMessages, snode)
             }
@@ -266,12 +273,6 @@ class ClosedGroupPoller(
                     addSuppressed(errors[index])
                 }
             }
-        }
-
-        // Update the state to indicate that we had at least one successful poll
-        val currentState = state.value as? StartedState
-        if (currentState != null && !currentState.hadAtLeastOneSuccessfulPoll) {
-            mutableState.value = currentState.copy(hadAtLeastOneSuccessfulPoll = true)
         }
     }
 


### PR DESCRIPTION
This PR adds a coroutine utility class called `GroupScope`, to try to limit the async tasks that are specific to a particular group are made sure to run in serial.

This is different from a single thread executor, as this has nothing to do with thread: it means that the concurrency limit is applied on a logical task, for example, even though handling group invite consists of multiple async steps, while a group is handling invite, anything else will be queued waiting for the invitation's async steps complete. This allows for a more reliable operation on groups so that you can't sneak in a group removal during a group invitation.
