### PR TITLE
[SES-3153] - Fix crash when admin deletes our attachment

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
@@ -60,6 +60,7 @@ import org.thoughtcrime.securesms.groups.OpenGroupManager
 import org.thoughtcrime.securesms.home.UserDetailsBottomSheet
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
+import network.loki.messenger.libsession_util.getOrNull
 import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsignal.utilities.AccountId
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord
@@ -212,7 +213,7 @@ class VisibleMessageView : FrameLayout {
                     binding.moderatorIconImageView.isVisible = isModerator
                 } else if (thread.isGroupV2Recipient) {
                     val isAdmin = configFactory.withGroupConfigs(AccountId(thread.address.serialize())) {
-                        it.groupMembers.get(senderAccountID)?.admin == true
+                        it.groupMembers.getOrNull(senderAccountID)?.admin == true
                     }
 
                     binding.moderatorIconImageView.isVisible = isAdmin

--- a/app/src/main/java/org/thoughtcrime/securesms/database/LokiMessageDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/LokiMessageDatabase.kt
@@ -260,7 +260,7 @@ class LokiMessageDatabase(context: Context, helper: SQLCipherOpenHelper) : Datab
                          mms_hash_table.$serverHash, 
                          mms.${MmsSmsColumns.ID},
                          mms.${MmsSmsColumns.ADDRESS},
-                         mms.${MmsDatabase.MESSAGE_TYPE},
+                         mms.${MmsDatabase.MESSAGE_BOX},
                          false
                     FROM $mmsHashTable mms_hash_table
                     LEFT OUTER JOIN ${MmsDatabase.TABLE_NAME} mms ON mms_hash_table.${messageID} = mms.${MmsSmsColumns.ID}

--- a/libsession-util/src/main/java/network/loki/messenger/libsession_util/Config.kt
+++ b/libsession-util/src/main/java/network/loki/messenger/libsession_util/Config.kt
@@ -383,12 +383,26 @@ class GroupInfoConfig private constructor(pointer: Long): ConfigBase(pointer), M
 
 interface ReadableGroupMembersConfig: ReadableConfig {
     fun all(): List<GroupMember>
+
+    /**
+     * Returns the [GroupMember] for the given [pubKeyHex] or null if it doesn't exist.
+     * Note: exception will be thrown if the [pubKeyHex] is invalid. You can opt to use [getOrNull] instead
+     */
     fun get(pubKeyHex: String): GroupMember?
     fun status(groupMember: GroupMember): GroupMember.Status
 }
 
 fun ReadableGroupMembersConfig.allWithStatus(): Sequence<Pair<GroupMember, GroupMember.Status>> {
     return all().asSequence().map { it to status(it) }
+}
+
+/**
+ * Returns the [GroupMember] for the given [pubKeyHex] or null if it doesn't exist or is invalid
+ */
+fun ReadableGroupMembersConfig.getOrNull(pubKeyHex: String): GroupMember? {
+    return runCatching {
+        get(pubKeyHex)
+    }.getOrNull()
 }
 
 interface MutableGroupMembersConfig : ReadableGroupMembersConfig, MutableConfig {


### PR DESCRIPTION
The direct cause of the crash is that the `This message was deleted` message's sender  somehow  becomes the group itself.

Drilled down to the actual cause, it's due to the message's type has changed from "outgoing" to "incoming". When a message is outgoing, the "sender address" is the group's address itself. But if it becomes incoming, that address is then wrong (meaning somehow group has become the thing that sends message, which is totally wrong).

This PR does two things:
1. Correct the place where the flag flip actual happens (this is an oops: the right data to use on `MmsDatabase` should be `MESSAGE_BOX` rather than `MESSAGE_TYPE`)
2. Wraps the C++ exception so that we can handle this more nicely.
