### PR TITLE
[SES-3154] - Fix group admin unable to delete message with attachments

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/LokiMessageDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/LokiMessageDatabase.kt
@@ -288,10 +288,11 @@ class LokiMessageDatabase(context: Context, helper: SQLCipherOpenHelper) : Datab
         return result
     }
 
-    fun getMessageServerHash(messageID: Long, mms: Boolean): String? = getMessageTables(mms).firstNotNullOfOrNull {
-        databaseHelper.readableDatabase.get(it, "${Companion.messageID} = ?", arrayOf(messageID.toString())) { cursor ->
-            cursor.getString(serverHash)
-        }
+    fun getMessageServerHash(messageID: Long, mms: Boolean): String? {
+        return databaseHelper.readableDatabase.get(
+            getMessageTable(mms),
+            "${Companion.messageID} = ?",
+            arrayOf(messageID.toString())) { cursor -> cursor.getString(serverHash) }
     }
 
     fun setMessageServerHash(messageID: Long, mms: Boolean, serverHash: String) {
@@ -306,9 +307,7 @@ class LokiMessageDatabase(context: Context, helper: SQLCipherOpenHelper) : Datab
     }
 
     fun deleteMessageServerHash(messageID: Long, mms: Boolean) {
-        getMessageTables(mms).firstOrNull {
-            databaseHelper.writableDatabase.delete(it, "${Companion.messageID} = ?", arrayOf(messageID.toString())) > 0
-        }
+        databaseHelper.writableDatabase.delete(getMessageTable(mms), "${Companion.messageID} = ?", arrayOf(messageID.toString()))
     }
 
     fun deleteMessageServerHashes(messageIDs: List<Long>, mms: Boolean) {
@@ -347,10 +346,6 @@ class LokiMessageDatabase(context: Context, helper: SQLCipherOpenHelper) : Datab
             groupInviteTable, "$threadID = ?", arrayOf(groupThreadId.toString())
         )
     }
-    private fun getMessageTables(mms: Boolean) = sequenceOf(
-        getMessageTable(mms),
-        messageHashTable
-    )
 
     private fun getMessageTable(mms: Boolean) = if (mms) mmsHashTable else smsHashTable
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -467,7 +467,11 @@ open class Storage @Inject constructor(
         }
         message.serverHash?.let { serverHash ->
             messageID?.let { id ->
-                lokiMessageDatabase.setMessageServerHash(id, message.isMediaMessage(), serverHash)
+                // When a message with attachment is received, we don't immediately have
+                // attachments attached in the messages, but it's a mms from the db's perspective
+                // nonetheless.
+                val isMms = message.isMediaMessage() || attachments.isNotEmpty()
+                lokiMessageDatabase.setMessageServerHash(id, isMms, serverHash)
             }
         }
         return messageID


### PR DESCRIPTION
The direct cause is: __No server hash is found for the messages to be deleted__
The root cause is: __when receiving messages with attachments, we wrongly regard it as a plain text message hence inserting the hash into a wrong table__

This PR also gets rid of the use of the `loki_message_hash_table`
