### PR TITLE
Reset last hash on promotion

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -760,7 +760,6 @@ class GroupManagerV2Impl @Inject constructor(
 
             // Remove lastHash so we can receive all the messages in the past
             lokiAPIDatabase.clearLastMessageHashes(groupId.hexString)
-            lokiAPIDatabase.clearReceivedMessageHashValues(groupId.hexString)
         }
 
         // Delete the promotion message remotely

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -757,6 +757,10 @@ class GroupManagerV2Impl @Inject constructor(
                     configs.groupMembers.set(member)
                 }
             }
+
+            // Remove lastHash so we can receive all the messages in the past
+            lokiAPIDatabase.clearLastMessageHashes(groupId.hexString)
+            lokiAPIDatabase.clearReceivedMessageHashValues(groupId.hexString)
         }
 
         // Delete the promotion message remotely

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
@@ -154,7 +154,14 @@ class Poller(
         val namespace = forConfig.namespace
         val processed = if (!messages.isNullOrEmpty()) {
             SnodeAPI.updateLastMessageHashValueIfPossible(snode, userPublicKey, messages, namespace)
-            SnodeAPI.removeDuplicates(userPublicKey, messages, namespace, true).mapNotNull { rawMessageAsJSON ->
+            SnodeAPI.removeDuplicates(
+                publicKey = userPublicKey,
+                messages = messages,
+                messageHashGetter = { (it as? Map<*, *>)?.get("hash") as? String },
+                namespace = namespace,
+                updateStoredHashes = true
+            ).mapNotNull { rawMessageAsJSON ->
+                rawMessageAsJSON as Map<*, *> // removeDuplicates should have ensured this is always a map
                 val hashValue = rawMessageAsJSON["hash"] as? String ?: return@mapNotNull null
                 val b64EncodedBody = rawMessageAsJSON["data"] as? String ?: return@mapNotNull null
                 val timestamp = rawMessageAsJSON["t"] as? Long ?: SnodeAPI.nowWithOffset

--- a/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
+++ b/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
@@ -1021,16 +1021,16 @@ object SnodeAPI {
                 val hash = messageHashGetter(message)
                 if (hash == null) {
                     Log.d("Loki", "Missing hash value for message: ${message?.prettifiedDescription()}.")
-                    return@filter false
+                    return@filter true
                 }
 
-                val isDuplicate = hashValues.add(hash)
+                val isNew = hashValues.add(hash)
 
-                if (isDuplicate) {
+                if (!isNew) {
                     Log.d("Loki", "Duplicate message hash: $hash.")
                 }
 
-                isDuplicate
+                isNew
             }
             .also {
                 if (updateStoredHashes && it.isNotEmpty()) {

--- a/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
+++ b/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
@@ -1021,7 +1021,7 @@ object SnodeAPI {
                 val hash = messageHashGetter(message)
                 if (hash == null) {
                     Log.d("Loki", "Missing hash value for message: ${message?.prettifiedDescription()}.")
-                    return@filter true
+                    return@filter false
                 }
 
                 val isNew = hashValues.add(hash)

--- a/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
+++ b/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
@@ -12,14 +12,11 @@ import com.goterl.lazysodium.utils.Key
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
-import com.goterl.lazysodium.utils.KeyPair
-import kotlinx.coroutines.coroutineScope
 import nl.komponents.kovenant.Promise
 import nl.komponents.kovenant.all
 import nl.komponents.kovenant.functional.bind
@@ -986,7 +983,13 @@ object SnodeAPI {
     fun parseRawMessagesResponse(rawResponse: RawResponse, snode: Snode, publicKey: String, namespace: Int = 0, updateLatestHash: Boolean = true, updateStoredHashes: Boolean = true, decrypt: ((ByteArray) -> Pair<ByteArray, AccountId>?)? = null): List<Pair<SignalServiceProtos.Envelope, String?>> =
         (rawResponse["messages"] as? List<*>)?.let { messages ->
             if (updateLatestHash) updateLastMessageHashValueIfPossible(snode, publicKey, messages, namespace)
-            parseEnvelopes(removeDuplicates(publicKey, messages, namespace, updateStoredHashes), decrypt)
+            removeDuplicates(
+                publicKey = publicKey,
+                messages = parseEnvelopes(messages, decrypt),
+                messageHashGetter = { it.second },
+                namespace = namespace,
+                updateStoredHashes = updateStoredHashes
+            )
         } ?: listOf()
 
     fun updateLastMessageHashValueIfPossible(snode: Snode, publicKey: String, rawMessages: List<*>, namespace: Int) {
@@ -1005,17 +1008,35 @@ object SnodeAPI {
      * database#setReceivedMessageHashValues is only called here.
      */
     @Synchronized
-    fun removeDuplicates(publicKey: String, rawMessages: List<*>, namespace: Int, updateStoredHashes: Boolean): List<Map<*, *>> {
+    fun <M> removeDuplicates(
+        publicKey: String,
+        messages: List<M>,
+        messageHashGetter: (M) -> String?,
+        namespace: Int,
+        updateStoredHashes: Boolean
+    ): List<M> {
         val hashValues = database.getReceivedMessageHashValues(publicKey, namespace)?.toMutableSet() ?: mutableSetOf()
-        return rawMessages.filterIsInstance<Map<*, *>>().filter { rawMessage ->
-            val hash = rawMessage["hash"] as? String
-            hash ?: Log.d("Loki", "Missing hash value for message: ${rawMessage.prettifiedDescription()}.")
-            hash?.let(hashValues::add) == true
-        }.also {
-            if (updateStoredHashes && it.isNotEmpty()) {
-                database.setReceivedMessageHashValues(publicKey, hashValues, namespace)
+        return messages
+            .filter { message ->
+                val hash = messageHashGetter(message)
+                if (hash == null) {
+                    Log.d("Loki", "Missing hash value for message: ${message?.prettifiedDescription()}.")
+                    return@filter false
+                }
+
+                val isDuplicate = hashValues.add(hash)
+
+                if (isDuplicate) {
+                    Log.d("Loki", "Duplicate message hash: $hash.")
+                }
+
+                isDuplicate
             }
-        }
+            .also {
+                if (updateStoredHashes && it.isNotEmpty()) {
+                    database.setReceivedMessageHashValues(publicKey, hashValues, namespace)
+                }
+            }
     }
 
     private fun parseEnvelopes(rawMessages: List<*>, decrypt: ((ByteArray)->Pair<ByteArray, AccountId>?)?): List<Pair<SignalServiceProtos.Envelope, String?>> {


### PR DESCRIPTION
In groupsv2, whenever a member gets promoted to admin, they should reset the "lastHash" on the poller so that they receive all the historic messages.

However, this PR also includes another change in du-duplication logic, the reason being: previously, when a message is received, our app checks if this message has been received before, then decrypt it. The order of the logic here prevents us from receiving all the historic messages, as the historic messages received before were actually marked as received, despite being unable to decrypted. So even when we are promoted and receive the messages from beginning but these messages are wrongfully treated as duplicates.

This PR hence includes a change of the order: the messages will be decrypted first, then being looked at if they are duplicates.
