### PR TITLE
[SES-3119] - Unread count not cleared

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -1493,9 +1493,10 @@ open class Storage @Inject constructor(
             // this deletes all *from* thread, not deleting the actual thread
             smsDatabase.deleteMessagesFrom(threadID, fromUser.serialize())
             mmsDatabase.deleteMessagesFrom(threadID, fromUser.serialize())
+            threadDb.update(threadID, false)
         }
 
-        threadDb.update(threadID, false)
+        threadDb.setRead(threadID, true)
 
         return true
     }


### PR DESCRIPTION
Previous work on this "unread count not cleared when admin deletes group" was flawed and not working correctly.

The only way to clear the unread count seems to be set the `UNREAD_COUNT` column directly, which is what `threadDb.setRead` is doing.
