### PR TITLE
[SES-3202] - Fix group unable to poll when accepting invitation

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -638,6 +638,14 @@ class GroupManagerV2Impl @Inject constructor(
             "Our account ID is not available"
         }
 
+        // Clear the invited flag of the group in the config
+        configFactory.withMutableUserConfigs { configs ->
+            configs.userGroups.set(group.copy(
+                invited = false,
+                joinedAtSecs = TimeUnit.MILLISECONDS.toSeconds(clock.currentTimeMills())
+            ))
+        }
+
         val poller = checkNotNull(pollerFactory.pollerFor(group.groupAccountId)) { "Unable to start a poller for groups " }
         poller.start()
 
@@ -648,13 +656,6 @@ class GroupManagerV2Impl @Inject constructor(
             poller.state.filterIsInstance<ClosedGroupPoller.StartedState>()
                 .filter { it.hadAtLeastOneSuccessfulPoll }
                 .first()
-        }
-        // Clear the invited flag of the group in the config
-        configFactory.withMutableUserConfigs { configs ->
-            configs.userGroups.set(group.copy(
-                invited = false,
-                joinedAtSecs = TimeUnit.MILLISECONDS.toSeconds(clock.currentTimeMills())
-            ))
         }
 
         if (group.adminKey == null) {


### PR DESCRIPTION
The problem is the poller is unable to start when the group doesn't have the approriate state in the config. This PR adjusts the order so that the config is updated first, then start the poller.
