### PR TITLE
fix/voice message upload duration ONLY

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1962,6 +1962,12 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
     @Deprecated("Deprecated in Java")
     override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
         super.onActivityResult(requestCode, resultCode, intent)
+
+        // If we are sending a media file then we'll reset the voice message duration string
+        // to an intermediate value for use during transmission because we will not have the
+        // final audio duration until the file has been entirely processed.
+        resetLastRecordedVoiceMessageDurationString()
+
         val mediaPreppedListener = object : ListenableFuture.Listener<Boolean> {
 
             override fun onSuccess(result: Boolean?) {
@@ -2062,7 +2068,8 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
             }
             audioRecorder.startRecording(callback)
 
-            stopAudioHandler.postDelayed(stopVoiceMessageRecordingTask, 300000) // Limit voice messages to 5 minute each
+            // Limit voice messages to 5 minute each
+            stopAudioHandler.postDelayed(stopVoiceMessageRecordingTask, 5.minutes.inWholeMilliseconds)
         } else {
             Permissions.with(this)
                 .request(Manifest.permission.RECORD_AUDIO)
@@ -2113,7 +2120,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
         // exits before transmitting the audio!
         inputBar.voiceRecorderState = VoiceRecorderState.Idle
 
-        // Generate a filename from the current time such as: "VoiceMessage_2025-01-08-152733.aac"
+        // Generate a filename from the current time such as: "Session-VoiceMessage_2025-01-08-152733.aac"
         val voiceMessageFilename = FilenameUtils.constructNewVoiceMessageFilename(applicationContext)
 
         // Voice message too short? Warn with toast instead of sending.
@@ -2134,16 +2141,31 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
         future.addListener(object : ListenableFuture.Listener<Pair<Uri, Long>> {
 
             override fun onSuccess(result: Pair<Uri, Long>) {
-                val audioSlide = AudioSlide(this@ConversationActivityV2, result.first, voiceMessageFilename, result.second, MediaTypes.AUDIO_AAC, true)
+                val uri = result.first
+                val dataSizeBytes = result.second
+                val audioSlide = AudioSlide(this@ConversationActivityV2, uri, voiceMessageFilename, dataSizeBytes, MediaTypes.AUDIO_AAC, true)
+
                 val slideDeck = SlideDeck()
                 slideDeck.addSlide(audioSlide)
-                sendAttachments(slideDeck.asAttachments(), null)
+                sendAttachments(slideDeck.asAttachments(), body = null)
             }
 
             override fun onFailure(e: ExecutionException) {
                 Toast.makeText(this@ConversationActivityV2, R.string.audioUnableToRecord, Toast.LENGTH_LONG).show()
             }
         })
+    }
+
+    // During the interim phase while we upload a voice message we use the duration from the recording view
+    fun getLastRecordedVoiceMessageDurationString() = binding.inputBarRecordingView.recordingViewDurationTextView.text
+
+    // Because VoiceMessageViews are shared between any uploaded audio and voice messages, we need to reset the last recorded
+    // audio duration so that in the case of uploading an audio file (for which we will NOT know the duration until processing
+    // is complete) then we show a placeholder duration rather than the duration of the last recorded voice message, wwhich
+    // would be incorrect for the uploaded audio. This is the absolute best we can do until processing of the audio file
+    // is complete, at which point the duration is set to the actual determined value.
+    fun resetLastRecordedVoiceMessageDurationString() {
+        binding.inputBarRecordingView.recordingViewDurationTextView.text = "--:--"
     }
 
     override fun cancelVoiceMessage() {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBarRecordingView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBarRecordingView.kt
@@ -39,6 +39,7 @@ class InputBarRecordingView : RelativeLayout {
     private var pulseAnimation: ValueAnimator? = null
     var delegate: InputBarRecordingViewDelegate? = null
     private var timerJob: Job? = null
+    private var voiceMessageDurationMS: Long = 0L
 
     val lockView: LinearLayout
         get() = binding.lockView
@@ -51,6 +52,9 @@ class InputBarRecordingView : RelativeLayout {
 
     val recordButtonOverlay: RelativeLayout
         get() = binding.recordButtonOverlay
+
+    val recordingViewDurationTextView: TextView
+        get() = binding.recordingViewDurationTextView
 
     constructor(context: Context) : super(context) { initialize() }
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs) { initialize() }
@@ -104,8 +108,19 @@ class InputBarRecordingView : RelativeLayout {
         timerJob?.cancel()
         timerJob = scope.launch {
             while (isActive) {
-                val duration = (Date().time - startTimestamp) / 1000L
-                binding.recordingViewDurationTextView.text = android.text.format.DateUtils.formatElapsedTime(duration)
+                voiceMessageDurationMS = (Date().time - startTimestamp)
+                val durationInSeconds = voiceMessageDurationMS / 1000L
+
+                // Format the duration as minutes:seconds, using only the amount of digits for minutes as required
+                // (e.g., "3:21" rather than "03:21". Voice messages have a 5 minute maximum length so we never need
+                // more than a single digit to represent minutes.
+                val formattedDuration = String.format(
+                    "%d:%02d",
+                    durationInSeconds / 60, // Minutes
+                    durationInSeconds % 60  // Seconds
+                )
+                binding.recordingViewDurationTextView.text = formattedDuration
+
                 delay(500)
             }
         }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VoiceMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VoiceMessageView.kt
@@ -3,15 +3,16 @@ package org.thoughtcrime.securesms.conversation.v2.messages
 import android.content.Context
 import android.graphics.Canvas
 import android.util.AttributeSet
-import android.view.View
 import android.widget.RelativeLayout
 import androidx.core.view.isVisible
 import dagger.hilt.android.AndroidEntryPoint
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ViewVoiceMessageBinding
 import org.session.libsession.messaging.sending_receiving.attachments.DatabaseAttachment
+import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.audio.AudioSlidePlayer
 import org.thoughtcrime.securesms.components.CornerMask
+import org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2
 import org.thoughtcrime.securesms.conversation.v2.utilities.MessageBubbleUtilities
 import org.thoughtcrime.securesms.database.AttachmentDatabase
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord
@@ -21,72 +22,85 @@ import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 
 @AndroidEntryPoint
-class VoiceMessageView : RelativeLayout, AudioSlidePlayer.Listener {
+class VoiceMessageView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : RelativeLayout(context, attrs, defStyleAttr), AudioSlidePlayer.Listener {
+    private val TAG = "VoiceMessageView"
 
+    private val conversationActivityV2: ConversationActivityV2? =
+        (context as? ConversationActivityV2)
+
+    init {
+        if (conversationActivityV2 == null) {
+            Log.e(TAG, "VoiceMessageView must be used in ConversationActivityV2")
+        }
+    }
     @Inject lateinit var attachmentDb: AttachmentDatabase
 
     private val binding: ViewVoiceMessageBinding by lazy { ViewVoiceMessageBinding.bind(this) }
     private val cornerMask by lazy { CornerMask(this) }
+
     private var isPlaying = false
-    set(value) {
-        field = value
-        renderIcon()
-    }
+        set(value) {
+            field = value
+            renderIcon()
+        }
+
     private var progress = 0.0
-    private var duration = 0L
+    private var durationMS = 0L
     private var player: AudioSlidePlayer? = null
     var delegate: VisibleMessageViewDelegate? = null
     var indexInAdapter = -1
 
-    // region Lifecycle
-    constructor(context: Context) : super(context)
-    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
-    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
-
-    override fun onFinishInflate() {
-        super.onFinishInflate()
-        binding.voiceMessageViewDurationTextView.text = String.format("%01d:%02d",
-            TimeUnit.MILLISECONDS.toMinutes(0),
-            TimeUnit.MILLISECONDS.toSeconds(0))
-    }
-
-    // endregion
-
     // region Updating
     fun bind(message: MmsMessageRecord, isStartOfMessageCluster: Boolean, isEndOfMessageCluster: Boolean) {
-        val audio = message.slideDeck.audioSlide!!
-        binding.voiceMessageViewLoader.isVisible = audio.isInProgress
+        val audioSlide = message.slideDeck.audioSlide!!
+
+        binding.voiceMessageViewLoader.isVisible = audioSlide.isInProgress
         val cornerRadii = MessageBubbleUtilities.calculateRadii(context, isStartOfMessageCluster, isEndOfMessageCluster, message.isOutgoing)
         cornerMask.setTopLeftRadius(cornerRadii[0])
         cornerMask.setTopRightRadius(cornerRadii[1])
         cornerMask.setBottomRightRadius(cornerRadii[2])
         cornerMask.setBottomLeftRadius(cornerRadii[3])
 
-        // only process audio if downloaded
-        if (audio.isPendingDownload || audio.isInProgress) {
+        // Obtain and set the last voice message duration (taken from the InputBarRecordingView) to use as an interim
+        // value while the file is being processed. Should this VoiceMessageView be an audio file rather than a voice
+        // message then the duration string will be "--:--" to indicate that we do not know the audio duration until
+        // processing completes and that information is available from the audio extras, below.
+        binding.voiceMessageViewDurationTextView.text = conversationActivityV2?.getLastRecordedVoiceMessageDurationString()
+
+        // On initial upload (and while processing audio) we will exit at this point and then return when processing is complete
+        if (audioSlide.isPendingDownload || audioSlide.isInProgress) {
             this.player = null
             return
         }
 
-        val player = AudioSlidePlayer.createFor(context.applicationContext, audio, this)
+        val player = AudioSlidePlayer.createFor(context.applicationContext, audioSlide, this)
         this.player = player
 
-        (audio.asAttachment() as? DatabaseAttachment)?.let { attachment ->
+        // This sets the final duration of the uploaded voice message
+        (audioSlide.asAttachment() as? DatabaseAttachment)?.let { attachment ->
             attachmentDb.getAttachmentAudioExtras(attachment.attachmentId)?.let { audioExtras ->
+
+                // This section sets the final formatted voice message duration
                 if (audioExtras.durationMs > 0) {
-                    duration = audioExtras.durationMs
-                    binding.voiceMessageViewDurationTextView.visibility = View.VISIBLE
-                    binding.voiceMessageViewDurationTextView.text = String.format("%01d:%02d",
-                            TimeUnit.MILLISECONDS.toMinutes(audioExtras.durationMs),
-                            TimeUnit.MILLISECONDS.toSeconds(audioExtras.durationMs) % 60)
+                    durationMS = audioExtras.durationMs
+                    val formattedVoiceMessageDuration = String.format("%01d:%02d", TimeUnit.MILLISECONDS.toMinutes(durationMS), TimeUnit.MILLISECONDS.toSeconds(durationMS) % 60)
+                    binding.voiceMessageViewDurationTextView.text = formattedVoiceMessageDuration
+                } else {
+                    Log.w(TAG, "For some reason audioExtras.durationMs was NOT greater than zero!")
+                    binding.voiceMessageViewDurationTextView.text = "--:--"
                 }
+
+                binding.voiceMessageViewDurationTextView.visibility = VISIBLE
             }
         }
     }
 
-    override fun onPlayerStart(player: AudioSlidePlayer) {
-        isPlaying = true
-    }
+    override fun onPlayerStart(player: AudioSlidePlayer) { isPlaying = true  }
+    override fun onPlayerStop(player: AudioSlidePlayer)  { isPlaying = false }
 
     override fun onPlayerProgress(player: AudioSlidePlayer, progress: Double, unused: Long) {
         if (progress == 1.0) {
@@ -101,15 +115,11 @@ class VoiceMessageView : RelativeLayout, AudioSlidePlayer.Listener {
     private fun handleProgressChanged(progress: Double) {
         this.progress = progress
         binding.voiceMessageViewDurationTextView.text = String.format("%01d:%02d",
-            TimeUnit.MILLISECONDS.toMinutes(duration - (progress * duration.toDouble()).roundToLong()),
-            TimeUnit.MILLISECONDS.toSeconds(duration - (progress * duration.toDouble()).roundToLong()) % 60)
+            TimeUnit.MILLISECONDS.toMinutes(durationMS - (progress * durationMS.toDouble()).roundToLong()),
+            TimeUnit.MILLISECONDS.toSeconds(durationMS - (progress * durationMS.toDouble()).roundToLong()) % 60)
         val layoutParams = binding.progressView.layoutParams as RelativeLayout.LayoutParams
         layoutParams.width = (width.toFloat() * progress.toFloat()).roundToInt()
         binding.progressView.layoutParams = layoutParams
-    }
-
-    override fun onPlayerStop(player: AudioSlidePlayer) {
-        isPlaying = false
     }
 
     override fun dispatchDraw(canvas: Canvas) {
@@ -136,8 +146,11 @@ class VoiceMessageView : RelativeLayout, AudioSlidePlayer.Listener {
     }
 
     fun handleDoubleTap() {
-        val player = this.player ?: return
-        player.playbackSpeed = if (player.playbackSpeed == 1.0f) 1.5f else 1.0f
+        if (this.player == null) {
+            Log.w(TAG, "Could not get player to adjust voice message playback speed.")
+            return
+        }
+        this.player?.playbackSpeed = if (this.player?.playbackSpeed == 1f) 1.5f else 1f
     }
     // endregion
 }


### PR DESCRIPTION
Ticket: SES-1716

Fixes:
- Displays correct voice message duration during upload rather than "00:00". 
- Works correctly when alternating transmission of voice messages and audio attachments (both of these use the same VoiceMessageView class). In the case of audio attachments, which we do not have a pre-existing duration for until file processing completes, a placeholder value of "--:--" is displayed until we know the true audio duration.