### PR TITLE
[SES-2997] - Show "xxx is invited" upon group creation

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -189,7 +189,7 @@ class GroupManagerV2Impl @Inject constructor(
             )
 
             // Also send a group update message
-            sendGroupUpdateForAddingMembers(groupId, adminKey, members, insertLocally = false)
+            sendGroupUpdateForAddingMembers(groupId, adminKey, members)
 
             recipient
         } catch (e: Exception) {
@@ -300,7 +300,7 @@ class GroupManagerV2Impl @Inject constructor(
         )
 
         // Send a group update message to the group telling members someone has been invited
-        sendGroupUpdateForAddingMembers(group, adminKey, newMembers, insertLocally = true)
+        sendGroupUpdateForAddingMembers(group, adminKey, newMembers)
     }
 
     /**
@@ -310,7 +310,6 @@ class GroupManagerV2Impl @Inject constructor(
         group: AccountId,
         adminKey: ByteArray,
         newMembers: Collection<AccountId>,
-        insertLocally: Boolean
     ) {
         val timestamp = clock.currentTimeMills()
         val signature = SodiumUtilities.sign(
@@ -330,9 +329,7 @@ class GroupManagerV2Impl @Inject constructor(
         ).apply { this.sentTimestamp = timestamp }
         MessageSender.send(updatedMessage, Destination.ClosedGroup(group.hexString), false)
 
-        if (insertLocally) {
-            storage.insertGroupInfoChange(updatedMessage, group)
-        }
+        storage.insertGroupInfoChange(updatedMessage, group)
     }
 
     override suspend fun removeMembers(


### PR DESCRIPTION
Rule has changed that when an admin creates a group, they should also see the invitation. Preivously the rule was to show the empty convo state.

With this rule change the logic has become simpler so we always have that invitation message.
