### PR TITLE
[SES-3238] - Fix unable to leave group on home screen

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationMenuHelper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationMenuHelper.kt
@@ -386,11 +386,11 @@ object ConversationMenuHelper {
                             "Invalid group public key"
                         }
                         try {
-                            channel.send(GroupLeavingStatus.Leaving)
+                            channel.trySend(GroupLeavingStatus.Leaving)
                             MessageSender.leave(groupPublicKey)
-                            channel.send(GroupLeavingStatus.Left)
+                            channel.trySend(GroupLeavingStatus.Left)
                         } catch (e: Exception) {
-                            channel.send(GroupLeavingStatus.Error)
+                            channel.trySend(GroupLeavingStatus.Error)
                             throw e
                         }
                     }
@@ -413,11 +413,11 @@ object ConversationMenuHelper {
                     storage = storage,
                     doLeave = {
                         try {
-                            channel.send(GroupLeavingStatus.Leaving)
+                            channel.trySend(GroupLeavingStatus.Leaving)
                             groupManager.leaveGroup(accountId)
-                            channel.send(GroupLeavingStatus.Left)
+                            channel.trySend(GroupLeavingStatus.Left)
                         } catch (e: Exception) {
-                            channel.send(GroupLeavingStatus.Error)
+                            channel.trySend(GroupLeavingStatus.Error)
                             throw e
                         }
                     }


### PR DESCRIPTION
This PR fixes an incorrect usage of sendChannel: when there's no one caring about the channel the `send` will get blocked. Because now home screen no longer listens for the
group status update (it's updated through control message now), the leaving process gets blocked trying to send the state through the channel. Changing it to `trySend` so that
it doesn't block.
