### PR TITLE
[SES-2924] - Fix incorrect version of "you were removed" used

### DIFF
--- a/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
@@ -255,11 +255,10 @@ object UpdateMessageBuilder {
                         }
                     }
                     UpdateMessageData.MemberUpdateType.REMOVED -> {
+
                         when {
                             number == 1 && containsUser -> Phrase.from(context,
-                                R.string.groupRemovedYou)
-                                .put(GROUP_NAME_KEY, updateData.groupName)
-                                .format()
+                                R.string.groupRemovedYouGeneral).format()
                             number == 1 -> Phrase.from(context,
                                 R.string.groupRemoved)
                                 .put(NAME_KEY, context.youOrSender(updateData.sessionIds.first()))


### PR DESCRIPTION
Basically in a conversation where you can see you were removed from the group in the past, you are supposed to see "You were removed from the group".

But if you are just kicked and not invited back, the status showing on the thread should say "You were removed from [group_name]".

We have been always using the second version for all the place, this PR hence only corrects the first case.
