### PR TITLE
[SES-2960] - Fix issues on group leaving control messages 

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/ControlMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/ControlMessageView.kt
@@ -213,12 +213,6 @@ class ControlMessageView : LinearLayout {
                     }
                 }
             }
-            message.isGroupUpdateMessage -> {
-                val updateMessageData: UpdateMessageData? = UpdateMessageData.fromJSON(message.body)
-                if (updateMessageData?.isGroupErrorQuitKind() == true) {
-                    binding.textView.setTextColor(context.getColorFromAttr(R.attr.danger))
-                }
-            }
         }
 
         binding.textView.isGone = message.isCallLog

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -501,6 +501,8 @@ class GroupManagerV2Impl @Inject constructor(
                 } catch (e: Exception) {
                     storage.insertGroupInfoErrorQuit(groupId)
                     throw e
+                } finally {
+                    storage.deleteGroupInfoMessages(groupId, UpdateMessageData.Kind.GroupLeaving::class.java)
                 }
             }
         }


### PR DESCRIPTION
This PR fixes:

1. Color polluting on "Failed to leave XX" message. Some remnant code that renders a control message red but forgets to set it back. However this code is not longer in used as the message itself comes formatted.
2. "Leaving" control message need to be removed upon failure.
