### PR TITLE
[SES-3200] - Offline control message improvement

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/ResendMessageUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/ResendMessageUtilities.kt
@@ -56,7 +56,7 @@ object ResendMessageUtilities {
         if (sentTimestamp != null && sender != null) {
             if (isResync) {
                 MessagingModuleConfiguration.shared.storage.markAsResyncing(sentTimestamp, sender)
-                MessageSender.send(message, Destination.from(recipient.address), isSyncMessage = true)
+                MessageSender.sendNonDuraly(message, Destination.from(recipient.address), isSyncMessage = true)
             } else {
                 MessagingModuleConfiguration.shared.storage.markAsSending(sentTimestamp, sender)
                 MessageSender.send(message, recipient.address)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/ResendMessageUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/ResendMessageUtilities.kt
@@ -56,7 +56,7 @@ object ResendMessageUtilities {
         if (sentTimestamp != null && sender != null) {
             if (isResync) {
                 MessagingModuleConfiguration.shared.storage.markAsResyncing(sentTimestamp, sender)
-                MessageSender.sendNonDuraly(message, Destination.from(recipient.address), isSyncMessage = true)
+                MessageSender.sendNonDurably(message, Destination.from(recipient.address), isSyncMessage = true)
             } else {
                 MessagingModuleConfiguration.shared.storage.markAsSending(sentTimestamp, sender)
                 MessageSender.send(message, recipient.address)

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/BaseGroupMembersViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/BaseGroupMembersViewModel.kt
@@ -101,8 +101,36 @@ abstract class BaseGroupMembersViewModel (
             status = status.takeIf { !isMyself }, // Status is only meant for other members
             highlightStatus = highlightStatus,
             showAsAdmin = member.isAdminOrBeingPromoted(status),
-            clickable = !isMyself
+            clickable = !isMyself,
+            statusLabel = getMemberLabel(status, context, amIAdmin),
         )
+    }
+
+    private fun getMemberLabel(status: GroupMember.Status, context: Context, amIAdmin: Boolean): String {
+        return when (status) {
+            GroupMember.Status.INVITE_FAILED -> context.getString(R.string.groupInviteFailed)
+            GroupMember.Status.INVITE_SENDING -> context.resources.getQuantityString(R.plurals.groupInviteSending, 1)
+            GroupMember.Status.INVITE_SENT -> context.getString(R.string.groupInviteSent)
+            GroupMember.Status.PROMOTION_FAILED -> context.getString(R.string.adminPromotionFailed)
+            GroupMember.Status.PROMOTION_SENDING -> context.resources.getQuantityString(R.plurals.adminSendingPromotion, 1)
+            GroupMember.Status.PROMOTION_SENT -> context.getString(R.string.adminPromotionSent)
+            GroupMember.Status.REMOVED,
+            GroupMember.Status.REMOVED_UNKNOWN,
+            GroupMember.Status.REMOVED_INCLUDING_MESSAGES -> {
+                if (amIAdmin) {
+                    context.getString(R.string.groupPendingRemoval)
+                } else {
+                    ""
+                }
+            }
+
+            GroupMember.Status.INVITE_UNKNOWN,
+            GroupMember.Status.INVITE_ACCEPTED,
+            GroupMember.Status.INVITE_NOT_SENT,
+            GroupMember.Status.PROMOTION_NOT_SENT,
+            GroupMember.Status.PROMOTION_UNKNOWN,
+            GroupMember.Status.PROMOTION_ACCEPTED -> ""
+        }
     }
 
     // Refer to notion doc for the sorting logic
@@ -150,37 +178,8 @@ data class GroupMemberState(
     val canResendPromotion: Boolean,
     val canRemove: Boolean,
     val canPromote: Boolean,
-    val clickable: Boolean
+    val clickable: Boolean,
+    val statusLabel: String,
 ) {
     val canEdit: Boolean get() = canRemove || canPromote || canResendInvite || canResendPromotion
-}
-
-// Function to get the label dynamically using the context
-fun GroupMemberState.getLabel(context: Context): String {
-    return when (this.status) {
-        GroupMember.Status.INVITE_FAILED -> context.getString(R.string.groupInviteFailed)
-        GroupMember.Status.INVITE_SENDING -> context.resources.getQuantityString(R.plurals.groupInviteSending, 1)
-        GroupMember.Status.INVITE_SENT -> context.getString(R.string.groupInviteSent)
-        GroupMember.Status.PROMOTION_FAILED -> context.getString(R.string.adminPromotionFailed)
-        GroupMember.Status.PROMOTION_SENDING -> context.resources.getQuantityString(R.plurals.adminSendingPromotion, 1)
-        GroupMember.Status.PROMOTION_SENT -> context.getString(R.string.adminPromotionSent)
-        GroupMember.Status.REMOVED,
-        GroupMember.Status.REMOVED_UNKNOWN,
-        GroupMember.Status.REMOVED_INCLUDING_MESSAGES -> {
-            if (this.showAsAdmin) {
-                context.getString(R.string.groupPendingRemoval)
-            } else {
-                ""
-            }
-        }
-
-        GroupMember.Status.INVITE_UNKNOWN,
-        GroupMember.Status.INVITE_ACCEPTED,
-        GroupMember.Status.INVITE_NOT_SENT,
-        GroupMember.Status.PROMOTION_NOT_SENT,
-        GroupMember.Status.PROMOTION_UNKNOWN,
-        GroupMember.Status.PROMOTION_ACCEPTED -> ""
-
-        null -> ""
-    }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -667,7 +667,7 @@ class GroupManagerV2Impl @Inject constructor(
                 .setInviteResponse(inviteResponse)
             val responseMessage = GroupUpdated(responseData.build(), profile = storage.getUserProfile())
             // this will fail the first couple of times :)
-            MessageSender.sendNonDuraly(
+            MessageSender.sendNonDurably(
                 responseMessage,
                 Destination.ClosedGroup(group.groupAccountId.hexString),
                 isSyncMessage = false

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/compose/EditGroupScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/compose/EditGroupScreen.kt
@@ -49,7 +49,6 @@ import org.session.libsession.utilities.StringSubstitutionConstants.NAME_KEY
 import org.session.libsignal.utilities.AccountId
 import org.thoughtcrime.securesms.groups.EditGroupViewModel
 import org.thoughtcrime.securesms.groups.GroupMemberState
-import org.thoughtcrime.securesms.groups.getLabel
 import org.thoughtcrime.securesms.ui.AlertDialog
 import org.thoughtcrime.securesms.ui.DialogButtonModel
 import org.thoughtcrime.securesms.ui.GetString
@@ -439,7 +438,7 @@ fun EditMemberItem(
     MemberItem(
         accountId = member.accountId,
         title = member.name,
-        subtitle = member.getLabel(LocalContext.current),
+        subtitle = member.statusLabel,
         subtitleColor = if (member.highlightStatus) {
             LocalColors.current.danger
         } else {
@@ -472,7 +471,8 @@ private fun EditGroupPreview3() {
             canResendInvite = false,
             canResendPromotion = false,
             showAsAdmin = false,
-            clickable = true
+            clickable = true,
+            statusLabel = "Invited"
         )
         val twoMember = GroupMemberState(
             accountId = AccountId("05abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1235"),
@@ -484,7 +484,8 @@ private fun EditGroupPreview3() {
             canResendInvite = false,
             canResendPromotion = false,
             showAsAdmin = true,
-            clickable = true
+            clickable = true,
+            statusLabel = "Promotion failed"
         )
         val threeMember = GroupMemberState(
             accountId = AccountId("05abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1236"),
@@ -496,7 +497,8 @@ private fun EditGroupPreview3() {
             canResendInvite = false,
             canResendPromotion = false,
             showAsAdmin = false,
-            clickable = true
+            clickable = true,
+            statusLabel = ""
         )
 
         val (editingName, setEditingName) = remember { mutableStateOf<String?>(null) }
@@ -547,7 +549,8 @@ private fun EditGroupPreview() {
             canResendInvite = false,
             canResendPromotion = false,
             showAsAdmin = false,
-            clickable = true
+            clickable = true,
+            statusLabel = "Invited"
         )
         val twoMember = GroupMemberState(
             accountId = AccountId("05abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1235"),
@@ -559,7 +562,8 @@ private fun EditGroupPreview() {
             canResendInvite = false,
             canResendPromotion = false,
             showAsAdmin = true,
-            clickable = true
+            clickable = true,
+            statusLabel = "Promotion failed"
         )
         val threeMember = GroupMemberState(
             accountId = AccountId("05abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1236"),
@@ -571,7 +575,8 @@ private fun EditGroupPreview() {
             canResendInvite = false,
             canResendPromotion = false,
             showAsAdmin = false,
-            clickable = true
+            clickable = true,
+            statusLabel = ""
         )
 
         val (editingName, setEditingName) = remember { mutableStateOf<String?>(null) }
@@ -622,7 +627,8 @@ private fun EditGroupEditNamePreview() {
             canResendInvite = false,
             canResendPromotion = false,
             showAsAdmin = false,
-            clickable = true
+            clickable = true,
+            statusLabel = "Invited"
         )
         val twoMember = GroupMemberState(
             accountId = AccountId("05abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1235"),
@@ -634,7 +640,8 @@ private fun EditGroupEditNamePreview() {
             canResendInvite = false,
             canResendPromotion = false,
             showAsAdmin = true,
-            clickable = true
+            clickable = true,
+            statusLabel = "Promotion failed"
         )
         val threeMember = GroupMemberState(
             accountId = AccountId("05abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1236"),
@@ -646,7 +653,8 @@ private fun EditGroupEditNamePreview() {
             canResendInvite = false,
             canResendPromotion = false,
             showAsAdmin = false,
-            clickable = true
+            clickable = true,
+            statusLabel = ""
         )
 
         EditGroup(

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/compose/GroupMembersScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/compose/GroupMembersScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -18,7 +17,6 @@ import network.loki.messenger.libsession_util.util.GroupMember
 import org.session.libsignal.utilities.AccountId
 import org.thoughtcrime.securesms.groups.GroupMemberState
 import org.thoughtcrime.securesms.groups.GroupMembersViewModel
-import org.thoughtcrime.securesms.groups.getLabel
 import org.thoughtcrime.securesms.ui.components.BackAppBar
 import org.thoughtcrime.securesms.ui.theme.LocalColors
 import org.thoughtcrime.securesms.ui.theme.PreviewTheme
@@ -43,7 +41,7 @@ fun GroupMembersScreen(
 @Composable
 fun GroupMembers(
     onBack: () -> Unit,
-    members: List<GroupMemberState>
+    members: List<GroupMemberState>,
 ) {
 
     Scaffold(
@@ -62,7 +60,7 @@ fun GroupMembers(
                     MemberItem(
                         accountId = member.accountId,
                         title = member.name,
-                        subtitle = member.getLabel(LocalContext.current),
+                        subtitle = member.statusLabel,
                         subtitleColor = if (member.highlightStatus) {
                             LocalColors.current.danger
                         } else {
@@ -91,7 +89,8 @@ private fun EditGroupPreview() {
             canResendInvite = false,
             canResendPromotion = false,
             showAsAdmin = false,
-            clickable = true
+            clickable = true,
+            statusLabel = "Invited"
         )
         val twoMember = GroupMemberState(
             accountId = AccountId("05abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1235"),
@@ -103,7 +102,8 @@ private fun EditGroupPreview() {
             canResendInvite = false,
             canResendPromotion = false,
             showAsAdmin = true,
-            clickable = true
+            clickable = true,
+            statusLabel = "Promotion failed"
         )
         val threeMember = GroupMemberState(
             accountId = AccountId("05abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1236"),
@@ -115,7 +115,8 @@ private fun EditGroupPreview() {
             canResendInvite = false,
             canResendPromotion = false,
             showAsAdmin = false,
-            clickable = true
+            clickable = true,
+            statusLabel = ""
         )
 
         GroupMembers(

--- a/app/src/main/java/org/thoughtcrime/securesms/repository/ConversationRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/repository/ConversationRepository.kt
@@ -416,7 +416,7 @@ class DefaultConversationRepository @Inject constructor(
                 )
             } else {
                 val message = MessageRequestResponse(true)
-                MessageSender.sendNonDuraly(
+                MessageSender.sendNonDurably(
                     message = message,
                     destination = Destination.from(recipient.address),
                     isSyncMessage = recipient.isLocalNumber

--- a/app/src/main/java/org/thoughtcrime/securesms/repository/ConversationRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/repository/ConversationRepository.kt
@@ -416,7 +416,7 @@ class DefaultConversationRepository @Inject constructor(
                 )
             } else {
                 val message = MessageRequestResponse(true)
-                MessageSender.send(
+                MessageSender.sendNonDuraly(
                     message = message,
                     destination = Destination.from(recipient.address),
                     isSyncMessage = recipient.isLocalNumber

--- a/libsession/src/main/java/org/session/libsession/messaging/jobs/AttachmentUploadJob.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/jobs/AttachmentUploadJob.kt
@@ -139,7 +139,8 @@ class AttachmentUploadJob(val attachmentID: Long, val threadID: String, val mess
                     destination.whisperTo,
                     destination.whisperMods,
                     destination.fileIds + uploadResult.id.toString()
-                )
+                ),
+                statusCallback = it.statusCallback
             )
             updatedJob.id = it.id
             updatedJob.delegate = it.delegate

--- a/libsession/src/main/java/org/session/libsession/messaging/jobs/InviteContactsJob.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/jobs/InviteContactsJob.kt
@@ -76,7 +76,7 @@ class InviteContactsJob(val groupSessionId: String, val memberSessionIds: Array<
                             sentTimestamp = timestamp
                         }
 
-                        MessageSender.sendNonDuraly(update, Destination.Contact(memberSessionId), false)
+                        MessageSender.sendNonDurably(update, Destination.Contact(memberSessionId), false)
                             .await()
                     }
                 }

--- a/libsession/src/main/java/org/session/libsession/messaging/jobs/InviteContactsJob.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/jobs/InviteContactsJob.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
-import org.session.libsession.R
 import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.groups.GroupInviteException
 import org.session.libsession.messaging.messages.Destination
@@ -18,11 +17,7 @@ import org.session.libsession.messaging.utilities.MessageAuthentication.buildGro
 import org.session.libsession.messaging.utilities.SodiumUtilities
 import org.session.libsession.snode.SnodeAPI
 import org.session.libsession.snode.utilities.await
-import org.session.libsession.utilities.StringSubstitutionConstants.GROUP_NAME_KEY
-import org.session.libsession.utilities.StringSubstitutionConstants.NAME_KEY
-import org.session.libsession.utilities.StringSubstitutionConstants.OTHER_NAME_KEY
 import org.session.libsession.utilities.getGroup
-import org.session.libsession.utilities.truncateIdForDisplay
 import org.session.libsignal.protos.SignalServiceProtos.DataMessage.GroupUpdateInviteMessage
 import org.session.libsignal.protos.SignalServiceProtos.DataMessage.GroupUpdateMessage
 import org.session.libsignal.utilities.AccountId
@@ -81,7 +76,7 @@ class InviteContactsJob(val groupSessionId: String, val memberSessionIds: Array<
                             sentTimestamp = timestamp
                         }
 
-                        MessageSender.send(update, Destination.Contact(memberSessionId), false)
+                        MessageSender.sendNonDuraly(update, Destination.Contact(memberSessionId), false)
                             .await()
                     }
                 }

--- a/libsession/src/main/java/org/session/libsession/messaging/jobs/MessageSendJob.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/jobs/MessageSendJob.kt
@@ -3,10 +3,10 @@ package org.session.libsession.messaging.jobs
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
+import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.withTimeout
 import org.session.libsession.messaging.MessagingModuleConfiguration
@@ -23,7 +23,7 @@ import org.session.libsignal.utilities.AccountId
 import org.session.libsignal.utilities.HTTP
 import org.session.libsignal.utilities.Log
 
-class MessageSendJob(val message: Message, val destination: Destination) : Job {
+class MessageSendJob(val message: Message, val destination: Destination, val statusCallback: SendChannel<Result<Unit>>?) : Job {
 
     object AwaitingAttachmentUploadException : Exception("Awaiting attachment upload.")
 
@@ -91,18 +91,25 @@ class MessageSendJob(val message: Message, val destination: Destination) : Job {
                         .waitForGroupEncryptionKeys(AccountId(destination.publicKey))
                 }
 
-                MessageSender.send(this@MessageSendJob.message, destination, isSync).await()
+                MessageSender.sendNonDuraly(this@MessageSendJob.message, destination, isSync).await()
             }
 
             this.handleSuccess(dispatcherName)
+            statusCallback?.trySend(Result.success(Unit))
         } catch (e: HTTP.HTTPRequestFailedException) {
             if (e.statusCode == 429) { this.handlePermanentFailure(dispatcherName, e) }
             else { this.handleFailure(dispatcherName, e) }
+
+            statusCallback?.trySend(Result.failure(e))
         } catch (e: MessageSender.Error) {
             if (!e.isRetryable) { this.handlePermanentFailure(dispatcherName, e) }
             else { this.handleFailure(dispatcherName, e) }
+
+            statusCallback?.trySend(Result.failure(e))
         } catch (e: Exception) {
             this.handleFailure(dispatcherName, e)
+
+            statusCallback?.trySend(Result.failure(e))
         }
     }
 
@@ -191,7 +198,7 @@ class MessageSendJob(val message: Message, val destination: Destination) : Job {
             }
             destinationInput.close()
             // Return
-            return MessageSendJob(message, destination)
+            return MessageSendJob(message, destination, statusCallback = null)
         }
     }
 }

--- a/libsession/src/main/java/org/session/libsession/messaging/jobs/MessageSendJob.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/jobs/MessageSendJob.kt
@@ -91,7 +91,7 @@ class MessageSendJob(val message: Message, val destination: Destination, val sta
                         .waitForGroupEncryptionKeys(AccountId(destination.publicKey))
                 }
 
-                MessageSender.sendNonDuraly(this@MessageSendJob.message, destination, isSync).await()
+                MessageSender.sendNonDurably(this@MessageSendJob.message, destination, isSync).await()
             }
 
             this.handleSuccess(dispatcherName)

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
@@ -2,9 +2,10 @@ package org.session.libsession.messaging.sending_receiving
 
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
-import network.loki.messenger.libsession_util.ConfigBase.Companion.PRIORITY_HIDDEN
 import network.loki.messenger.libsession_util.ConfigBase.Companion.PRIORITY_VISIBLE
 import network.loki.messenger.libsession_util.util.ExpiryMode
 import nl.komponents.kovenant.Promise
@@ -30,24 +31,20 @@ import org.session.libsession.messaging.open_groups.OpenGroupApi.Capability
 import org.session.libsession.messaging.open_groups.OpenGroupMessage
 import org.session.libsession.messaging.utilities.MessageWrapper
 import org.session.libsession.messaging.utilities.SodiumUtilities
-import org.session.libsession.snode.RawResponsePromise
 import org.session.libsession.snode.SnodeAPI
 import org.session.libsession.snode.SnodeAPI.nowWithOffset
 import org.session.libsession.snode.SnodeMessage
 import org.session.libsession.snode.SnodeModule
 import org.session.libsession.snode.utilities.asyncPromise
-import org.session.libsession.snode.utilities.await
 import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.Device
 import org.session.libsession.utilities.GroupUtil
 import org.session.libsession.utilities.SSKEnvironment
-import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.crypto.PushTransportDetails
 import org.session.libsignal.protos.SignalServiceProtos
 import org.session.libsignal.utilities.AccountId
 import org.session.libsignal.utilities.Base64
 import org.session.libsignal.utilities.IdPrefix
-import org.session.libsignal.utilities.Log
 import org.session.libsignal.utilities.Namespace
 import org.session.libsignal.utilities.defaultRequiresAuth
 import org.session.libsignal.utilities.hasNamespaces
@@ -80,7 +77,7 @@ object MessageSender {
     }
 
     // Convenience
-    fun send(message: Message, destination: Destination, isSyncMessage: Boolean): Promise<Unit, Exception> {
+    fun sendNonDuraly(message: Message, destination: Destination, isSyncMessage: Boolean): Promise<Unit, Exception> {
         if (message is VisibleMessage) MessagingModuleConfiguration.shared.lastSentTimestampCache.submitTimestamp(message.threadID!!, message.sentTimestamp!!)
         return if (destination is Destination.LegacyOpenGroup || destination is Destination.OpenGroup || destination is Destination.OpenGroupInbox) {
             sendToOpenGroupDestination(destination, message)
@@ -548,12 +545,12 @@ object MessageSender {
     }
 
     @JvmStatic
-    fun send(message: Message, address: Address) {
+    fun send(message: Message, address: Address, statusCallback: SendChannel<Result<Unit>>? = null) {
         val threadID = MessagingModuleConfiguration.shared.storage.getThreadId(address)
         threadID?.let(message::applyExpiryMode)
         message.threadID = threadID
         val destination = Destination.from(address)
-        val job = MessageSendJob(message, destination)
+        val job = MessageSendJob(message, destination, statusCallback)
         JobQueue.shared.add(job)
 
         // if we are sending a 'Note to Self' make sure it is not hidden
@@ -563,6 +560,12 @@ object MessageSender {
                 it.userProfile.setNtsPriority(PRIORITY_VISIBLE)
             }
         }
+    }
+
+    suspend fun sendAndAwait(message: Message, address: Address): Result<Unit> {
+        val resultChannel = Channel<Result<Unit>>()
+        send(message, address, resultChannel)
+        return resultChannel.receive()
     }
 
     fun sendNonDurably(message: VisibleMessage, attachments: List<SignalAttachment>, address: Address, isSyncMessage: Boolean): Promise<Unit, Exception> {
@@ -575,7 +578,7 @@ object MessageSender {
         val threadID = MessagingModuleConfiguration.shared.storage.getThreadId(address)
         message.threadID = threadID
         val destination = Destination.from(address)
-        return send(message, destination, isSyncMessage)
+        return sendNonDuraly(message, destination, isSyncMessage)
     }
 
     // Closed groups

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
@@ -77,7 +77,7 @@ object MessageSender {
     }
 
     // Convenience
-    fun sendNonDuraly(message: Message, destination: Destination, isSyncMessage: Boolean): Promise<Unit, Exception> {
+    fun sendNonDurably(message: Message, destination: Destination, isSyncMessage: Boolean): Promise<Unit, Exception> {
         if (message is VisibleMessage) MessagingModuleConfiguration.shared.lastSentTimestampCache.submitTimestamp(message.threadID!!, message.sentTimestamp!!)
         return if (destination is Destination.LegacyOpenGroup || destination is Destination.OpenGroup || destination is Destination.OpenGroupInbox) {
             sendToOpenGroupDestination(destination, message)
@@ -579,7 +579,7 @@ object MessageSender {
         val threadID = MessagingModuleConfiguration.shared.storage.getThreadId(address)
         message.threadID = threadID
         val destination = Destination.from(address)
-        return sendNonDuraly(message, destination, isSyncMessage)
+        return sendNonDurably(message, destination, isSyncMessage)
     }
 
     // Closed groups

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
@@ -545,6 +545,7 @@ object MessageSender {
     }
 
     @JvmStatic
+    @JvmOverloads
     fun send(message: Message, address: Address, statusCallback: SendChannel<Result<Unit>>? = null) {
         val threadID = MessagingModuleConfiguration.shared.storage.getThreadId(address)
         threadID?.let(message::applyExpiryMode)
@@ -562,10 +563,10 @@ object MessageSender {
         }
     }
 
-    suspend fun sendAndAwait(message: Message, address: Address): Result<Unit> {
+    suspend fun sendAndAwait(message: Message, address: Address) {
         val resultChannel = Channel<Result<Unit>>()
         send(message, address, resultChannel)
-        return resultChannel.receive()
+        resultChannel.receive().getOrThrow()
     }
 
     fun sendNonDurably(message: VisibleMessage, attachments: List<SignalAttachment>, address: Address, isSyncMessage: Boolean): Promise<Unit, Exception> {

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSenderClosedGroupHandler.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSenderClosedGroupHandler.kt
@@ -6,11 +6,9 @@ import com.google.protobuf.ByteString
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.Channel
 import nl.komponents.kovenant.Promise
-import nl.komponents.kovenant.deferred
 import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.jobs.GroupLeavingJob
 import org.session.libsession.messaging.jobs.JobQueue
-import org.session.libsession.messaging.jobs.MessageSendJob
 import org.session.libsession.messaging.messages.control.ClosedGroupControlMessage
 import org.session.libsession.messaging.sending_receiving.MessageSender.Error
 import org.session.libsession.messaging.sending_receiving.notifications.PushRegistryV1
@@ -22,14 +20,12 @@ import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.Address.Companion.fromSerialized
 import org.session.libsession.utilities.Device
 import org.session.libsession.utilities.GroupUtil
-import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.crypto.ecc.Curve
 import org.session.libsignal.crypto.ecc.ECKeyPair
 import org.session.libsignal.messages.SignalServiceGroup
 import org.session.libsignal.protos.SignalServiceProtos
 import org.session.libsignal.utilities.Hex
 import org.session.libsignal.utilities.Log
-import org.session.libsignal.utilities.ThreadUtils
 import org.session.libsignal.utilities.guava.Optional
 import org.session.libsignal.utilities.hexEncodedPublicKey
 import org.session.libsignal.utilities.removingIdPrefixIfNeeded
@@ -85,7 +81,8 @@ fun MessageSender.create(
             val closedGroupControlMessage = ClosedGroupControlMessage(closedGroupUpdateKind, groupID)
             closedGroupControlMessage.sentTimestamp = sentTime
             try {
-                sendNonDurably(closedGroupControlMessage, Address.fromSerialized(member), member == ourPubKey).await()
+                sendNonDurably(closedGroupControlMessage, fromSerialized(member), member == ourPubKey)
+                    .await()
             } catch (e: Exception) {
                 // We failed to properly create the group so delete it's associated data (in the past
                 // we didn't create this data until the messages successfully sent but this resulted


### PR DESCRIPTION
This PR includes a series of improvement:

1. Renamed `MessageSender.sendXXX` methods to reflect what they do more accurately
2. Almost all group control messages are now sent through the job system so they can survive the offline (and retry)
3. Add a result callback into `MessageSendJob` so we can track how they these jobs' status
4. Fix a bug in displaying member status: whether the `Pending removal` is shown or not **DOES NOT** depend on whether that person is admin, rather, it's dependent on whether **I** am an admin.
