### PR TITLE
[SES-3251] - Add recreate group UI and show/hide thread/message options accordingly

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -990,6 +990,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
                 thread = recipient,
                 context = this,
                 configFactory = configFactory,
+                deprecationManager = viewModel.legacyGroupDeprecationManager
             )
         }
         maybeUpdateToolbar(recipient)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -509,7 +509,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
                 setUpSearchResultObserver()
                 scrollToFirstUnreadMessageIfNeeded()
                 setUpOutdatedClientBanner()
-                setUpLegacyGroupBanner()
+                setUpLegacyGroupUI()
 
                 if (author != null && messageTimestamp >= 0 && targetPosition >= 0) {
                     binding.conversationRecyclerView.scrollToPosition(targetPosition)
@@ -829,7 +829,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
         }
     }
 
-    private fun setUpLegacyGroupBanner() {
+    private fun setUpLegacyGroupUI() {
         lifecycleScope.launch {
             viewModel.legacyGroupBanner
                 .collectLatest { banner ->
@@ -860,6 +860,17 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
                         }
                     }
                 }
+        }
+
+        lifecycleScope.launch {
+            viewModel.showRecreateGroupButton
+                .collectLatest { show ->
+                    binding.recreateGroupButtonContainer.isVisible = show
+                }
+        }
+
+        binding.recreateGroupButton.setOnClickListener {
+            viewModel.onCommand(ConversationViewModel.Commands.RecreateGroup)
         }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -543,6 +543,22 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
         }
 
         setupMentionView()
+        setupUiEventsObserver()
+    }
+
+    private fun setupUiEventsObserver() {
+        lifecycleScope.launch {
+            viewModel.uiEvents.collect { event ->
+                when (event) {
+                    is ConversationUiEvent.NavigateToConversation -> {
+                        finish()
+                        startActivity(Intent(this@ConversationActivityV2, ConversationActivityV2::class.java)
+                            .putExtra(THREAD_ID, event.threadId)
+                        )
+                    }
+                }
+            }
+        }
     }
 
     private fun setupMentionView() {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -859,12 +859,15 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
                                 // we need to add the inline icon
                                 val drawable = ContextCompat.getDrawable(this@ConversationActivityV2, R.drawable.ic_external)!!
                                 val imageSize = toPx(10, resources)
-                                val imagePaddingTop = toPx(4, resources)
+                                val imagePadding = toPx(4, resources)
                                 drawable.setBounds(0, 0, imageSize, imageSize)
                                 drawable.setTint(getColorFromAttr(R.attr.message_sent_text_color))
 
                                 setSpan(
-                                    PaddedImageSpan(drawable, ImageSpan.ALIGN_BASELINE, imagePaddingTop),
+                                    PaddedImageSpan(drawable, ImageSpan.ALIGN_BASELINE,
+                                        paddingStart = imagePadding,
+                                        paddingTop = imagePadding
+                                    ),
                                     length - 1,
                                     length,
                                     Spannable.SPAN_EXCLUSIVE_EXCLUSIVE

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
@@ -375,6 +375,12 @@ class ConversationReactionOverlay : FrameLayout {
         updateBoundsOnLayoutChanged()
     }
 
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+
+        hide()
+    }
+
     private fun updateBoundsOnLayoutChanged() {
         backgroundView.getGlobalVisibleRect(emojiStripViewBounds)
         emojiViews[0].getGlobalVisibleRect(emojiViewGlobalRect)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
@@ -33,19 +33,23 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import network.loki.messenger.R
 import org.session.libsession.LocalisedTimeUtil.toShortTwoPartString
+import org.session.libsession.messaging.groups.LegacyGroupDeprecationManager
 import org.session.libsession.snode.SnodeAPI
 import org.session.libsession.utilities.StringSubstitutionConstants.TIME_LARGE_KEY
+import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsession.utilities.TextSecurePreferences.Companion.getLocalNumber
 import org.session.libsession.utilities.ThemeUtil
+import org.session.libsession.utilities.recipients.Recipient
 import org.thoughtcrime.securesms.components.emoji.EmojiImageView
 import org.thoughtcrime.securesms.components.emoji.RecentEmojiPageModel
 import org.thoughtcrime.securesms.components.menu.ActionItem
 import org.thoughtcrime.securesms.conversation.v2.menus.ConversationMenuItemHelper.userCanBanSelectedUsers
+import org.thoughtcrime.securesms.database.LokiThreadDatabase
 import org.thoughtcrime.securesms.database.MmsSmsDatabase
+import org.thoughtcrime.securesms.database.ThreadDatabase
 import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.database.model.ReactionRecord
-import org.thoughtcrime.securesms.dependencies.DatabaseComponent.Companion.get
 import org.thoughtcrime.securesms.repository.ConversationRepository
 import org.thoughtcrime.securesms.util.AnimationCompleteListener
 import org.thoughtcrime.securesms.util.DateUtils
@@ -95,6 +99,11 @@ class ConversationReactionOverlay : FrameLayout {
 
     @Inject lateinit var mmsSmsDatabase: MmsSmsDatabase
     @Inject lateinit var repository: ConversationRepository
+    @Inject lateinit var lokiThreadDatabase: LokiThreadDatabase
+    @Inject lateinit var threadDatabase: ThreadDatabase
+    @Inject lateinit var textSecurePreferences: TextSecurePreferences
+    @Inject lateinit var deprecationManager: LegacyGroupDeprecationManager
+
     private val scope = CoroutineScope(Dispatchers.Default)
     private var job: Job? = null
 
@@ -163,7 +172,8 @@ class ConversationReactionOverlay : FrameLayout {
     private fun showAfterLayout(messageRecord: MessageRecord,
                                 lastSeenDownPoint: PointF,
                                 isMessageOnLeft: Boolean) {
-        val contextMenu = ConversationContextMenu(dropdownAnchor, getMenuActionItems(messageRecord))
+        val recipient = threadDatabase.getRecipientForThreadId(messageRecord.threadId)
+        val contextMenu = ConversationContextMenu(dropdownAnchor, recipient?.let { getMenuActionItems(messageRecord, it) }.orEmpty())
         this.contextMenu = contextMenu
         var endX = if (isMessageOnLeft) scrubberHorizontalMargin.toFloat() else selectedConversationModel.bubbleX - conversationItem.width + selectedConversationModel.bubbleWidth
         var endY = selectedConversationModel.bubbleY - statusBarHeight
@@ -260,6 +270,12 @@ class ConversationReactionOverlay : FrameLayout {
         } else {
             (width - scrubberWidth - scrubberHorizontalMargin).toFloat()
         }
+
+        val isLegacyGroupAndDeprecated =
+            recipient?.isLegacyGroupRecipient == true &&
+                deprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+        foregroundView.isVisible = !isLegacyGroupAndDeprecated
+        backgroundView.isVisible = !isLegacyGroupAndDeprecated
         foregroundView.x = scrubberX
         foregroundView.y = reactionBarBackgroundY + reactionBarHeight / 2f - foregroundView.height / 2f
         backgroundView.x = scrubberX
@@ -521,16 +537,14 @@ class ConversationReactionOverlay : FrameLayout {
             .firstOrNull()
             ?.let(ReactionRecord::emoji)
 
-    private fun getMenuActionItems(message: MessageRecord): List<ActionItem> {
+    private fun getMenuActionItems(message: MessageRecord, recipient: Recipient): List<ActionItem> {
         val items: MutableList<ActionItem> = ArrayList()
 
         // Prepare
         val containsControlMessage = message.isUpdate
         val hasText = !message.body.isEmpty()
-        val openGroup = get(context).lokiThreadDatabase().getOpenGroupChat(message.threadId)
-        val recipient = get(context).threadDatabase().getRecipientForThreadId(message.threadId)
-                ?: return emptyList()
-        val userPublicKey = getLocalNumber(context)!!
+        val openGroup = lokiThreadDatabase.getOpenGroupChat(message.threadId)
+        val userPublicKey = textSecurePreferences.getLocalNumber()!!
 
         // control messages and "marked as deleted" messages can only delete
         val isDeleteOnly = message.isDeleted || message.isControlMessage
@@ -544,9 +558,15 @@ class ConversationReactionOverlay : FrameLayout {
                 R.string.AccessibilityId_select
             )
         }
+
+
+        val isLegacyGroup = recipient.isLegacyGroupRecipient
+        val isLegacyGroupDeprecated = deprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+
         // Reply
         val canWrite = openGroup == null || openGroup.canWrite
-        if (canWrite && !message.isPending && !message.isFailed && !message.isOpenGroupInvitation && !isDeleteOnly) {
+        if (canWrite && !message.isPending && !message.isFailed && !message.isOpenGroupInvitation && !isDeleteOnly
+            && !(isLegacyGroup && isLegacyGroupDeprecated)) {
             items += ActionItem(R.attr.menu_reply_icon, R.string.reply, { handleActionItemClicked(Action.REPLY) }, R.string.AccessibilityId_reply)
         }
         // Copy message text
@@ -558,14 +578,23 @@ class ConversationReactionOverlay : FrameLayout {
             items += ActionItem(R.attr.menu_copy_icon, R.string.accountIDCopy, { handleActionItemClicked(Action.COPY_ACCOUNT_ID) })
         }
         // Delete message
-        items += ActionItem(R.attr.menu_trash_icon, R.string.delete, { handleActionItemClicked(Action.DELETE) },
-            R.string.AccessibilityId_deleteMessage, message.subtitle, ThemeUtil.getThemedColor(context, R.attr.danger))
+        if (!(isLegacyGroup && isLegacyGroupDeprecated)) {
+            items += ActionItem(
+                R.attr.menu_trash_icon,
+                R.string.delete,
+                { handleActionItemClicked(Action.DELETE) },
+                R.string.AccessibilityId_deleteMessage,
+                message.subtitle,
+                ThemeUtil.getThemedColor(context, R.attr.danger)
+            )
+        }
+
         // Ban user
-        if (userCanBanSelectedUsers(context, message, openGroup, userPublicKey, blindedPublicKey) && !isDeleteOnly) {
+        if (userCanBanSelectedUsers(context, message, openGroup, userPublicKey, blindedPublicKey) && !isDeleteOnly && !(isLegacyGroup && isLegacyGroupDeprecated)) {
             items += ActionItem(R.attr.menu_block_icon, R.string.banUser, { handleActionItemClicked(Action.BAN_USER) })
         }
         // Ban and delete all
-        if (userCanBanSelectedUsers(context, message, openGroup, userPublicKey, blindedPublicKey) && !isDeleteOnly) {
+        if (userCanBanSelectedUsers(context, message, openGroup, userPublicKey, blindedPublicKey) && !isDeleteOnly && !(isLegacyGroup && isLegacyGroupDeprecated)) {
             items += ActionItem(R.attr.menu_trash_icon, R.string.banDeleteAll, { handleActionItemClicked(Action.BAN_AND_DELETE_ALL) })
         }
         // Message detail
@@ -576,11 +605,11 @@ class ConversationReactionOverlay : FrameLayout {
                 { handleActionItemClicked(Action.VIEW_INFO) })
         }
         // Resend
-        if (message.isFailed) {
+        if (message.isFailed && !(isLegacyGroup && isLegacyGroupDeprecated)) {
             items += ActionItem(R.attr.menu_reply_icon, R.string.resend, { handleActionItemClicked(Action.RESEND) })
         }
         // Resync
-        if (message.isSyncFailed) {
+        if (message.isSyncFailed && !(isLegacyGroup && isLegacyGroupDeprecated)) {
             items += ActionItem(R.attr.menu_reply_icon, R.string.resync, { handleActionItemClicked(Action.RESYNC) })
         }
         // Save media..

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.conversation.v2
 
 import android.app.Application
 import android.content.Context
+import android.content.Intent
 import android.view.MenuItem
 import android.widget.Toast
 import androidx.annotation.StringRes
@@ -14,10 +15,11 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -31,6 +33,7 @@ import network.loki.messenger.R
 import org.session.libsession.database.MessageDataProvider
 import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.groups.GroupManagerV2
+import org.session.libsession.messaging.groups.LegacyGroupDeprecationManager
 import org.session.libsession.messaging.messages.ExpirationConfiguration
 import org.session.libsession.messaging.open_groups.OpenGroup
 import org.session.libsession.messaging.open_groups.OpenGroupApi
@@ -58,7 +61,6 @@ import org.thoughtcrime.securesms.database.model.MessageId
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord
 import org.thoughtcrime.securesms.dependencies.ConfigFactory
-import org.session.libsession.messaging.groups.LegacyGroupDeprecationManager
 import org.thoughtcrime.securesms.groups.OpenGroupManager
 import org.thoughtcrime.securesms.mms.AudioSlide
 import org.thoughtcrime.securesms.repository.ConversationRepository
@@ -88,6 +90,9 @@ class ConversationViewModel(
 
     private val _uiState = MutableStateFlow(ConversationUiState())
     val uiState: StateFlow<ConversationUiState> get() = _uiState
+
+    private val _uiEvents = MutableSharedFlow<ConversationUiEvent>(extraBufferCapacity = 1)
+    val uiEvents: SharedFlow<ConversationUiEvent> get() = _uiEvents
 
     private val _dialogsState = MutableStateFlow(DialogsState())
     val dialogsState: StateFlow<DialogsState> = _dialogsState
@@ -954,7 +959,34 @@ class ConversationViewModel(
             }
 
             Commands.RecreateGroup -> {
+                _dialogsState.update {
+                    it.copy(recreateGroupConfirm = true)
+                }
+            }
 
+            Commands.HideRecreateGroupConfirm -> {
+                _dialogsState.update {
+                    it.copy(recreateGroupConfirm = false)
+                }
+            }
+
+            Commands.ConfirmRecreateGroup -> {
+                _dialogsState.update {
+                    it.copy(
+                        recreateGroupConfirm = false,
+                        recreateGroupData = recipient?.address?.serialize()?.let { addr -> RecreateGroupDialogData(legacyGroupId = addr) }
+                    )
+                }
+            }
+
+            Commands.HideRecreateGroup -> {
+                _dialogsState.update {
+                    it.copy(recreateGroupData = null)
+                }
+            }
+
+            is Commands.NavigateToConversation -> {
+                _uiEvents.tryEmit(ConversationUiEvent.NavigateToConversation(command.threadId))
             }
         }
     }
@@ -1063,7 +1095,13 @@ class ConversationViewModel(
     data class DialogsState(
         val openLinkDialogUrl: String? = null,
         val clearAllEmoji: ClearAllEmoji? = null,
-        val deleteEveryone: DeleteForEveryoneDialogData? = null
+        val deleteEveryone: DeleteForEveryoneDialogData? = null,
+        val recreateGroupConfirm: Boolean = false,
+        val recreateGroupData: RecreateGroupDialogData? = null,
+    )
+
+    data class RecreateGroupDialogData(
+        val legacyGroupId: String,
     )
 
     data class DeleteForEveryoneDialogData(
@@ -1092,6 +1130,10 @@ class ConversationViewModel(
         data class MarkAsDeletedForEveryone(val data: DeleteForEveryoneDialogData): Commands
 
         data object RecreateGroup : Commands
+        data object ConfirmRecreateGroup : Commands
+        data object HideRecreateGroupConfirm : Commands
+        data object HideRecreateGroup : Commands
+        data class NavigateToConversation(val threadId: Long) : Commands
     }
 }
 
@@ -1105,6 +1147,10 @@ data class ConversationUiState(
     val enableInputMediaControls: Boolean = true,
     val showLoader: Boolean = false,
 )
+
+sealed interface ConversationUiEvent {
+    data class NavigateToConversation(val threadId: Long) : ConversationUiEvent
+}
 
 sealed interface MessageRequestUiState {
     data object Invisible : MessageRequestUiState

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -66,7 +66,6 @@ import org.thoughtcrime.securesms.util.DateUtils
 import java.time.ZoneId
 import java.util.UUID
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class ConversationViewModel(
     val threadId: Long,
     val edKeyPair: KeyPair?,
@@ -218,6 +217,10 @@ class ConversationViewModel(
         }
     }.stateIn(viewModelScope, SharingStarted.Lazily, null)
 
+    val showRecreateGroupButton: StateFlow<Boolean> = isAdmin
+        .map { admin ->
+            admin && recipient?.isLegacyGroupRecipient == true
+        }.stateIn(viewModelScope, SharingStarted.Lazily, false)
 
     private val attachmentDownloadHandler = AttachmentDownloadHandler(
         storage = storage,
@@ -949,6 +952,10 @@ class ConversationViewModel(
             is Commands.ClearEmoji -> {
                 clearEmoji(command.emoji, command.messageId)
             }
+
+            Commands.RecreateGroup -> {
+
+            }
         }
     }
 
@@ -1073,16 +1080,18 @@ class ConversationViewModel(
         val messageId: MessageId
     )
 
-    sealed class Commands {
-        data class ShowOpenUrlDialog(val url: String?) : Commands()
+    sealed interface Commands {
+        data class ShowOpenUrlDialog(val url: String?) : Commands
 
-        data class ClearEmoji(val emoji:String, val messageId: MessageId) : Commands()
+        data class ClearEmoji(val emoji:String, val messageId: MessageId) : Commands
 
-        data object HideDeleteEveryoneDialog : Commands()
-        data object HideClearEmoji : Commands()
+        data object HideDeleteEveryoneDialog : Commands
+        data object HideClearEmoji : Commands
 
-        data class MarkAsDeletedLocally(val messages: Set<MessageRecord>): Commands()
-        data class MarkAsDeletedForEveryone(val data: DeleteForEveryoneDialogData): Commands()
+        data class MarkAsDeletedLocally(val messages: Set<MessageRecord>): Commands
+        data class MarkAsDeletedForEveryone(val data: DeleteForEveryoneDialogData): Commands
+
+        data object RecreateGroup : Commands
     }
 }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -82,7 +82,7 @@ class ConversationViewModel(
     private val textSecurePreferences: TextSecurePreferences,
     private val configFactory: ConfigFactory,
     private val groupManagerV2: GroupManagerV2,
-    private val legacyGroupDeprecationManager: LegacyGroupDeprecationManager,
+    val legacyGroupDeprecationManager: LegacyGroupDeprecationManager,
 ) : ViewModel() {
 
     val showSendAfterApprovalText: Boolean

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/CreateGroupFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/CreateGroupFragment.kt
@@ -33,7 +33,8 @@ class CreateGroupFragment : Fragment() {
                             )
                         },
                         onBack = delegate::onDialogBackPressed,
-                        onClose = delegate::onDialogClosePressed
+                        onClose = delegate::onDialogClosePressed,
+                        fromLegacyGroupId = null,
                     )
                 }
             }

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/CreateGroupViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/CreateGroupViewModel.kt
@@ -3,6 +3,9 @@ package org.thoughtcrime.securesms.groups
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -15,17 +18,21 @@ import kotlinx.coroutines.withContext
 import network.loki.messenger.R
 import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.groups.GroupManagerV2
+import org.session.libsignal.utilities.AccountId
 import org.thoughtcrime.securesms.conversation.v2.utilities.TextUtilities.textSizeInBytes
+import org.thoughtcrime.securesms.database.GroupDatabase
 import org.thoughtcrime.securesms.dependencies.ConfigFactory
 import javax.inject.Inject
 
 
-@HiltViewModel
-class CreateGroupViewModel @Inject constructor(
+@HiltViewModel(assistedFactory = CreateGroupViewModel.Factory::class)
+class CreateGroupViewModel @AssistedInject constructor(
     configFactory: ConfigFactory,
     @ApplicationContext private val appContext: Context,
     private val storage: StorageProtocol,
     private val groupManagerV2: GroupManagerV2,
+    groupDatabase: GroupDatabase,
+    @Assisted createFromLegacyGroupId: String?,
 ): ViewModel() {
     // Child view model to handle contact selection logic
     val selectContactsViewModel = SelectContactsViewModel(
@@ -50,6 +57,29 @@ class CreateGroupViewModel @Inject constructor(
     // Events
     private val mutableEvents = MutableSharedFlow<CreateGroupEvent>()
     val events: SharedFlow<CreateGroupEvent> get() = mutableEvents
+
+    init {
+        createFromLegacyGroupId?.let { id ->
+            mutableIsLoading.value = true
+            viewModelScope.launch {
+                try {
+                    groupDatabase.getGroup(id).orNull()?.let { group ->
+                        mutableGroupName.value = group.title
+                        val myPublicKey = storage.getUserPublicKey()
+
+                        selectContactsViewModel.selectAccountIDs(
+                            group.members
+                                .asSequence()
+                                .filter { it.serialize() != myPublicKey }
+                                .mapTo(mutableSetOf()) { AccountId(it.serialize()) }
+                        )
+                    }
+                } finally {
+                    mutableIsLoading.value = false
+                }
+            }
+        }
+    }
 
     fun onCreateClicked() {
         viewModelScope.launch {
@@ -103,6 +133,11 @@ class CreateGroupViewModel @Inject constructor(
         mutableGroupName.value = name
 
         mutableGroupNameError.value = ""
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(createFromLegacyGroupId: String?): CreateGroupViewModel
     }
 }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/SelectContactsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/SelectContactsViewModel.kt
@@ -35,7 +35,7 @@ class SelectContactsViewModel @AssistedInject constructor(
     private val configFactory: ConfigFactory,
     @ApplicationContext private val appContext: Context,
     @Assisted private val excludingAccountIDs: Set<AccountId>,
-    @Assisted private val scope: CoroutineScope
+    @Assisted private val scope: CoroutineScope,
 ) : ViewModel() {
     // Input: The search query
     private val mutableSearchQuery = MutableStateFlow("")
@@ -112,6 +112,10 @@ class SelectContactsViewModel @AssistedInject constructor(
             newSet.add(accountID)
         }
         mutableSelectedContactAccountIDs.value = newSet
+    }
+
+    fun selectAccountIDs(accountIDs: Set<AccountId>) {
+        mutableSelectedContactAccountIDs.value += accountIDs
     }
 
     @AssistedFactory

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/compose/CreateGroupScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/compose/CreateGroupScreen.kt
@@ -50,11 +50,15 @@ import org.thoughtcrime.securesms.ui.theme.PreviewTheme
 
 @Composable
 fun CreateGroupScreen(
+    fromLegacyGroupId: String?,
     onNavigateToConversationScreen: (threadID: Long) -> Unit,
     onBack: () -> Unit,
     onClose: () -> Unit,
 ) {
-    val viewModel: CreateGroupViewModel = hiltViewModel()
+    val viewModel = hiltViewModel<CreateGroupViewModel, CreateGroupViewModel.Factory> { factory ->
+        factory.create(fromLegacyGroupId)
+    }
+
     val context = LocalContext.current
 
     LaunchedEffect(viewModel) {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/PaddedImageSpan.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/PaddedImageSpan.kt
@@ -8,7 +8,8 @@ import android.text.style.ImageSpan
 class PaddedImageSpan(
     drawable: Drawable,
     verticalAlignment: Int,
-    private val paddingTop: Int
+    private val paddingTop: Int,
+    private val paddingStart: Int
 ) : ImageSpan(drawable, verticalAlignment) {
 
     override fun draw(
@@ -25,10 +26,11 @@ class PaddedImageSpan(
         val drawable = drawable
         canvas.save()
 
-        // Adjust the image's vertical position by adding the top padding
+        // Adjust the image's top and start with padding
+        val transX = x + paddingStart
         val transY = top + paddingTop
 
-        canvas.translate(x, transY.toFloat())
+        canvas.translate(transX, transY.toFloat())
         drawable.draw(canvas)
         canvas.restore()
     }

--- a/app/src/main/res/layout/activity_conversation_v2.xml
+++ b/app/src/main/res/layout/activity_conversation_v2.xml
@@ -60,7 +60,7 @@
         android:layout_height="wrap_content"
         tools:layout_height="60dp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/messageRequestBar"
+        app:layout_constraintTop_toBottomOf="@+id/recreateGroupButtonContainer"
         app:layout_constraintBottom_toBottomOf="parent"
         />
 
@@ -306,7 +306,7 @@
         android:id="@+id/messageRequestBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@+id/inputBar"
+        app:layout_constraintBottom_toTopOf="@+id/recreateGroupButtonContainer"
         app:layout_constraintTop_toBottomOf="@+id/textSendAfterApproval"
         android:layout_marginBottom="@dimen/large_spacing"
         android:orientation="vertical"
@@ -365,6 +365,26 @@
         </LinearLayout>
 
     </LinearLayout>
+
+    <FrameLayout
+        android:id="@+id/recreateGroupButtonContainer"
+        app:layout_constraintBottom_toTopOf="@+id/inputBar"
+        app:layout_constraintTop_toBottomOf="@+id/messageRequestBar"
+        android:padding="@dimen/medium_spacing"
+        android:visibility="gone"
+        tools:visibility="visible"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <Button
+            android:id="@+id/recreateGroupButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            style="@style/Widget.Session.Button.Common.ProminentOutline"
+            android:contentDescription="@string/AccessibilityId_messageRequestsAccept"
+            android:text="@string/recreateGroup" />
+
+    </FrameLayout>
 
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/dialog_open_url"


### PR DESCRIPTION
This PR is Part II work of SES-3251: 
1. Add a button, a confirmation dialog and create group dialog for re-create a legacy group
2. Show/hide options for threads/messages according to deprecation state

![Screenshot_20250207_102710](https://github.com/user-attachments/assets/885ee47e-282b-47a0-9c97-4a09404fb084)
![Screenshot_20250207_102733](https://github.com/user-attachments/assets/d8d996da-7a87-42c6-b51c-5e86dea470a3)
![Screenshot_20250207_102743](https://github.com/user-attachments/assets/26b6d7cf-abfd-4e77-9ed9-a37893f8812b)
![Screenshot_20250207_102755](https://github.com/user-attachments/assets/2b986fc0-3dfa-441d-a662-9d8b3fefc6af)
