### PR TITLE
Fix a clock drift when the device is in deep sleep

### DIFF
--- a/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
+++ b/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
@@ -596,7 +596,7 @@ object SnodeAPI {
         val request: SnodeBatchRequestInfo,
         val responseType: Class<*>,
         val callback: SendChannel<Result<Any>>,
-        val requestTime: Long = SystemClock.uptimeMillis(),
+        val requestTime: Long = SystemClock.elapsedRealtime(),
     )
 
     private val batchedRequestsSender: SendChannel<RequestInfo>
@@ -627,7 +627,7 @@ object SnodeAPI {
                         val earliestBatch = batches.minBy { it.value.first().requestTime }
                         val deadline = earliestBatch.value.first().requestTime + batchWindowMills
                         onTimeout(
-                            timeMillis = (deadline - SystemClock.uptimeMillis()).coerceAtLeast(0)
+                            timeMillis = (deadline - SystemClock.elapsedRealtime()).coerceAtLeast(0)
                         ) {
                             batches.remove(earliestBatch.key)
                         }

--- a/libsession/src/main/java/org/session/libsession/snode/SnodeClock.kt
+++ b/libsession/src/main/java/org/session/libsession/snode/SnodeClock.kt
@@ -31,10 +31,10 @@ class SnodeClock() {
             while (true) {
                 try {
                     val node = SnodeAPI.getRandomSnode().await()
-                    val requestStarted = SystemClock.uptimeMillis()
+                    val requestStarted = SystemClock.elapsedRealtime()
 
                     var networkTime = SnodeAPI.getNetworkTime(node).await().second
-                    val requestEnded = SystemClock.uptimeMillis()
+                    val requestEnded = SystemClock.elapsedRealtime()
 
                     // Adjust the network time to account for the time it took to make the request
                     // so that the network time equals to the time when the request was started
@@ -81,7 +81,7 @@ class SnodeClock() {
         val networkTime: Long,
     ) {
         fun now(): Long {
-            val elapsed = SystemClock.uptimeMillis() - systemUptime
+            val elapsed = SystemClock.elapsedRealtime() - systemUptime
             return networkTime + elapsed
         }
     }


### PR DESCRIPTION
This is due to a wrong clock source is used for the `SnodeClock`. 
