### PR TITLE
[SES-3300] - More place to hide message/convo actions based on deprecated state

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactSelectionListFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactSelectionListFragment.kt
@@ -12,11 +12,18 @@ import network.loki.messenger.databinding.ContactSelectionListFragmentBinding
 import org.session.libsession.utilities.recipients.Recipient
 import org.session.libsignal.utilities.Log
 import com.bumptech.glide.Glide
+import dagger.hilt.android.AndroidEntryPoint
+import org.session.libsession.messaging.groups.LegacyGroupDeprecationManager
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class ContactSelectionListFragment : Fragment(), LoaderManager.LoaderCallbacks<List<ContactSelectionListItem>>, ContactClickListener {
     private lateinit var binding: ContactSelectionListFragmentBinding
     private var cursorFilter: String? = null
     var onContactSelectedListener: OnContactSelectedListener? = null
+
+    @Inject
+    lateinit var deprecationManager: LegacyGroupDeprecationManager
 
     private val multiSelect: Boolean by lazy {
         requireActivity().intent.getBooleanExtra(MULTI_SELECT, false)
@@ -71,9 +78,12 @@ class ContactSelectionListFragment : Fragment(), LoaderManager.LoaderCallbacks<L
     }
 
     override fun onCreateLoader(id: Int, args: Bundle?): Loader<List<ContactSelectionListItem>> {
-        return ContactSelectionListLoader(requireActivity(),
-            requireActivity().intent.getIntExtra(DISPLAY_MODE, ContactsCursorLoader.DisplayMode.FLAG_ALL),
-            cursorFilter)
+        return ContactSelectionListLoader(
+            context = requireActivity(),
+            mode = requireActivity().intent.getIntExtra(DISPLAY_MODE, ContactsCursorLoader.DisplayMode.FLAG_ALL),
+            filter = cursorFilter,
+            deprecationManager = deprecationManager
+        )
     }
 
     override fun onLoadFinished(loader: Loader<List<ContactSelectionListItem>>, items: List<ContactSelectionListItem>) {

--- a/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactSelectionListLoader.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactSelectionListLoader.kt
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.contacts
 
 import android.content.Context
 import network.loki.messenger.R
+import org.session.libsession.messaging.groups.LegacyGroupDeprecationManager
 import org.thoughtcrime.securesms.util.ContactUtilities
 import org.session.libsession.utilities.recipients.Recipient
 import org.thoughtcrime.securesms.util.AsyncLoader
@@ -11,7 +12,12 @@ sealed class ContactSelectionListItem {
     class Contact(val recipient: Recipient) : ContactSelectionListItem()
 }
 
-class ContactSelectionListLoader(context: Context, val mode: Int, val filter: String?) : AsyncLoader<List<ContactSelectionListItem>>(context) {
+class ContactSelectionListLoader(
+    context: Context,
+    val mode: Int,
+    val filter: String?,
+    private val deprecationManager: LegacyGroupDeprecationManager,
+) : AsyncLoader<List<ContactSelectionListItem>>(context) {
 
     object DisplayMode {
         const val FLAG_CONTACTS = 1
@@ -51,7 +57,11 @@ class ContactSelectionListLoader(context: Context, val mode: Int, val filter: St
     }
 
     private fun getGroups(contacts: List<Recipient>): List<ContactSelectionListItem> {
-        return getItems(contacts, context.getString(R.string.conversationsGroups)) { it.address.isGroup }
+        return getItems(contacts, context.getString(R.string.conversationsGroups)) {
+            val isDeprecatedLegacyGroup = it.isLegacyGroupRecipient &&
+                    deprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+            it.address.isGroup && !isDeprecatedLegacyGroup
+        }
     }
 
     private fun getCommunities(contacts: List<Recipient>): List<ContactSelectionListItem> {

--- a/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactSelectionListLoader.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactSelectionListLoader.kt
@@ -59,7 +59,7 @@ class ContactSelectionListLoader(
     private fun getGroups(contacts: List<Recipient>): List<ContactSelectionListItem> {
         return getItems(contacts, context.getString(R.string.conversationsGroups)) {
             val isDeprecatedLegacyGroup = it.isLegacyGroupRecipient &&
-                    deprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+                    deprecationManager.isDeprecated
             it.address.isGroup && !isDeprecatedLegacyGroup
         }
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -985,7 +985,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
 
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
         val recipient = viewModel.recipient ?: return false
-        if (!viewModel.isMessageRequestThread) {
+        if (viewModel.showOptionsMenu) {
             ConversationMenuHelper.onPrepareOptionsMenu(
                 menu = menu,
                 inflater = menuInflater,

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1396,7 +1396,12 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
 
     private fun onDeselect(message: MessageRecord, position: Int, actionMode: ActionMode) {
         adapter.toggleSelection(message, position)
-        val actionModeCallback = ConversationActionModeCallback(adapter, viewModel.threadId, this)
+        val actionModeCallback = ConversationActionModeCallback(
+            adapter = adapter,
+            threadID = viewModel.threadId,
+            context = this,
+            deprecationManager = viewModel.legacyGroupDeprecationManager
+        )
         actionModeCallback.delegate = this
         actionModeCallback.updateActionModeMenu(actionMode.menu)
         if (adapter.selectedItems.isEmpty()) {
@@ -1415,7 +1420,12 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
     // `position` is the adapter position; not the visual position
     private fun selectMessage(message: MessageRecord, position: Int) {
         val actionMode = this.actionMode
-        val actionModeCallback = ConversationActionModeCallback(adapter, viewModel.threadId, this)
+        val actionModeCallback = ConversationActionModeCallback(
+            adapter = adapter,
+            threadID = viewModel.threadId,
+            context = this,
+            deprecationManager = viewModel.legacyGroupDeprecationManager
+        )
         actionModeCallback.delegate = this
         searchViewItem?.collapseActionView()
         if (actionMode == null) { // Nothing should be selected if this is the case

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1784,9 +1784,9 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
         } else {
             smsDb.getMessageRecord(messageId.id)
         }
-        if (userWasSender) {
+        if (userWasSender && viewModel.canRemoveReaction) {
             sendEmojiRemoval(emoji, message)
-        } else {
+        } else if (!userWasSender && viewModel.canReactToMessages) {
             sendEmojiReaction(emoji, message)
         }
     }
@@ -1797,7 +1797,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
                 val userPublicKey = textSecurePreferences.getLocalNumber() ?: return@let false
                 OpenGroupManager.isUserModerator(this, openGroup.id, userPublicKey, viewModel.blindedPublicKey)
             } ?: false
-            val fragment = ReactionsDialogFragment.create(messageId, isUserModerator, emoji)
+            val fragment = ReactionsDialogFragment.create(messageId, isUserModerator, emoji, viewModel.canRemoveReaction)
             fragment.show(supportFragmentManager, null)
         }
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
@@ -273,7 +273,7 @@ class ConversationReactionOverlay : FrameLayout {
 
         val isDeprecatedLegacyGroup =
             recipient?.isLegacyGroupRecipient == true &&
-                deprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+                deprecationManager.isDeprecated
         foregroundView.isVisible = !isDeprecatedLegacyGroup
         backgroundView.isVisible = !isDeprecatedLegacyGroup
         foregroundView.x = scrubberX
@@ -567,7 +567,7 @@ class ConversationReactionOverlay : FrameLayout {
 
 
         val isDeprecatedLegacyGroup = recipient.isLegacyGroupRecipient &&
-                deprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+                deprecationManager.isDeprecated
 
         // Reply
         val canWrite = openGroup == null || openGroup.canWrite

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -202,8 +202,7 @@ class ConversationViewModel(
                 return false
             }
 
-            val isDeprecatedLegacyGroup = recipient?.isLegacyGroupRecipient == true &&
-                    legacyGroupDeprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+            val isDeprecatedLegacyGroup = recipient?.isLegacyGroupRecipient == true && legacyGroupDeprecationManager.isDeprecated
             return !isDeprecatedLegacyGroup
         }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -196,6 +196,17 @@ class ConversationViewModel(
             return !recipient.isLocalNumber && !recipient.isLegacyGroupRecipient && !recipient.isCommunityRecipient && !recipient.isApproved
         }
 
+    val showOptionsMenu: Boolean
+        get() {
+            if (isMessageRequestThread) {
+                return false
+            }
+
+            val isDeprecatedLegacyGroup = recipient?.isLegacyGroupRecipient == true &&
+                    legacyGroupDeprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+            return !isDeprecatedLegacyGroup
+        }
+
     val canReactToMessages: Boolean
         // allow reactions if the open group is null (normal conversations) or the open group's capabilities include reactions
         get() = (openGroup == null || OpenGroupApi.Capability.REACTIONS.name.lowercase() in serverCapabilities)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -202,13 +202,19 @@ class ConversationViewModel(
                 return false
             }
 
-            val isDeprecatedLegacyGroup = recipient?.isLegacyGroupRecipient == true && legacyGroupDeprecationManager.isDeprecated
             return !isDeprecatedLegacyGroup
         }
+
+    private val isDeprecatedLegacyGroup: Boolean
+        get() = recipient?.isLegacyGroupRecipient == true && legacyGroupDeprecationManager.isDeprecated
 
     val canReactToMessages: Boolean
         // allow reactions if the open group is null (normal conversations) or the open group's capabilities include reactions
         get() = (openGroup == null || OpenGroupApi.Capability.REACTIONS.name.lowercase() in serverCapabilities)
+                && !isDeprecatedLegacyGroup
+
+    val canRemoveReaction: Boolean
+        get() = canReactToMessages
 
     val legacyGroupBanner: StateFlow<CharSequence?> = combine(
         legacyGroupDeprecationManager.deprecationState,

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
@@ -135,7 +135,7 @@ class MessageDetailActivity : PassphraseRequiredActionBarActivity() {
             onReply = if (state.canReply) { { setResultAndFinish(ON_REPLY) } } else null,
             onResend = state.error?.let { { setResultAndFinish(ON_RESEND) } },
             onSave = if(canSave) { { setResultAndFinish(ON_SAVE) } } else null,
-            onDelete = { setResultAndFinish(ON_DELETE) },
+            onDelete = if (state.canDelete) { { setResultAndFinish(ON_DELETE) } } else null,
             onCopy = { setResultAndFinish(ON_COPY) },
             onClickImage = { viewModel.onClickImage(it) },
             onAttachmentNeedsDownload = viewModel::onAttachmentNeedsDownload,
@@ -158,7 +158,7 @@ fun MessageDetails(
     onReply: (() -> Unit)? = null,
     onResend: (() -> Unit)? = null,
     onSave: (() -> Unit)? = null,
-    onDelete: () -> Unit = {},
+    onDelete: (() -> Unit)? = null,
     onCopy: () -> Unit = {},
     onClickImage: (Int) -> Unit = {},
     onAttachmentNeedsDownload: (DatabaseAttachment) -> Unit = { _ -> }
@@ -242,7 +242,7 @@ fun CellButtons(
     onReply: (() -> Unit)? = null,
     onResend: (() -> Unit)? = null,
     onSave: (() -> Unit)? = null,
-    onDelete: () -> Unit,
+    onDelete: (() -> Unit)? = null,
     onCopy: () -> Unit
 ) {
     Cell(modifier = Modifier.padding(horizontal = LocalDimensions.current.spacing)) {
@@ -281,12 +281,14 @@ fun CellButtons(
                 Divider()
             }
 
-            LargeItemButton(
-                R.string.delete,
-                R.drawable.ic_delete,
-                colors = dangerButtonColors(),
-                onClick = onDelete
-            )
+            onDelete?.let {
+                LargeItemButton(
+                    R.string.delete,
+                    R.drawable.ic_delete,
+                    colors = dangerButtonColors(),
+                    onClick = it
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
@@ -79,7 +79,7 @@ class MessageDetailsViewModel @Inject constructor(
 
                 val recipient = threadDb.getRecipientForThreadId(threadId)!!
                 val isDeprecatedLegacyGroup = recipient.isLegacyGroupRecipient &&
-                        deprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+                        deprecationManager.isDeprecated
 
                 MessageDetailsState(
                     attachments = slides.map(::Attachment),

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import network.loki.messenger.R
+import org.session.libsession.messaging.groups.LegacyGroupDeprecationManager
 import org.session.libsession.messaging.jobs.AttachmentDownloadJob
 import org.session.libsession.messaging.jobs.JobQueue
 import org.session.libsession.messaging.sending_receiving.attachments.AttachmentTransferProgress
@@ -42,6 +43,7 @@ class MessageDetailsViewModel @Inject constructor(
     private val mmsSmsDatabase: MmsSmsDatabase,
     private val threadDb: ThreadDatabase,
     private val repository: ConversationRepository,
+    private val deprecationManager: LegacyGroupDeprecationManager,
 ) : ViewModel() {
 
     private var job: Job? = null
@@ -75,6 +77,10 @@ class MessageDetailsViewModel @Inject constructor(
             state.value = record.run {
                 val slides = mmsRecord?.slideDeck?.slides ?: emptyList()
 
+                val recipient = threadDb.getRecipientForThreadId(threadId)!!
+                val isDeprecatedLegacyGroup = recipient.isLegacyGroupRecipient &&
+                        deprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+
                 MessageDetailsState(
                     attachments = slides.map(::Attachment),
                     record = record,
@@ -83,7 +89,8 @@ class MessageDetailsViewModel @Inject constructor(
                     error = lokiMessageDatabase.getErrorMessage(id)?.let { TitledText(R.string.theError, it) },
                     senderInfo = individualRecipient.run { name?.let { TitledText(it, address.serialize()) } },
                     sender = individualRecipient,
-                    thread = threadDb.getRecipientForThreadId(threadId)!!,
+                    thread = recipient,
+                    readOnly = isDeprecatedLegacyGroup,
                 )
             }
         }
@@ -156,9 +163,11 @@ data class MessageDetailsState(
     val senderInfo: TitledText? = null,
     val sender: Recipient? = null,
     val thread: Recipient? = null,
+    val readOnly: Boolean = false,
 ) {
     val fromTitle = GetString(R.string.from)
-    val canReply = record?.isOpenGroupInvitation != true
+    val canReply: Boolean get() = !readOnly && record?.isOpenGroupInvitation != true
+    val canDelete: Boolean get() = !readOnly
 }
 
 data class Attachment(

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationActionModeCallback.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationActionModeCallback.kt
@@ -47,7 +47,7 @@ class ConversationActionModeCallback(
             ?.let { AccountId(IdPrefix.BLINDED, it) }?.hexString
 
         val isDeprecatedLegacyGroup = thread.isLegacyGroupRecipient &&
-                deprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+                deprecationManager.isDeprecated
 
         // Embedded function
         fun userCanBanSelectedUsers(): Boolean {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationActionModeCallback.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationActionModeCallback.kt
@@ -6,6 +6,7 @@ import android.view.Menu
 import android.view.MenuItem
 import network.loki.messenger.R
 import org.session.libsession.messaging.MessagingModuleConfiguration
+import org.session.libsession.messaging.groups.LegacyGroupDeprecationManager
 import org.session.libsession.messaging.utilities.SodiumUtilities
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.utilities.IdPrefix
@@ -16,8 +17,12 @@ import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
 import org.thoughtcrime.securesms.groups.OpenGroupManager
 
-class ConversationActionModeCallback(private val adapter: ConversationAdapter, private val threadID: Long,
-    private val context: Context) : ActionMode.Callback {
+class ConversationActionModeCallback(
+    private val adapter: ConversationAdapter,
+    private val threadID: Long,
+    private val context: Context,
+    private val deprecationManager: LegacyGroupDeprecationManager,
+    ) : ActionMode.Callback {
     var delegate: ConversationActionModeCallbackDelegate? = null
 
     override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
@@ -41,6 +46,9 @@ class ConversationActionModeCallback(private val adapter: ConversationAdapter, p
         val blindedPublicKey = openGroup?.publicKey?.let { SodiumUtilities.blindedKeyPair(it, edKeyPair)?.publicKey?.asBytes }
             ?.let { AccountId(IdPrefix.BLINDED, it) }?.hexString
 
+        val isDeprecatedLegacyGroup = thread.isLegacyGroupRecipient &&
+                deprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+
         // Embedded function
         fun userCanBanSelectedUsers(): Boolean {
             if (openGroup == null) { return false }
@@ -54,28 +62,28 @@ class ConversationActionModeCallback(private val adapter: ConversationAdapter, p
 
 
         // Delete message
-        menu.findItem(R.id.menu_context_delete_message).isVisible = true // can always delete since delete logic will be handled by the VM
+        menu.findItem(R.id.menu_context_delete_message).isVisible = !isDeprecatedLegacyGroup // can always delete since delete logic will be handled by the VM
         // Ban user
-        menu.findItem(R.id.menu_context_ban_user).isVisible = userCanBanSelectedUsers()
+        menu.findItem(R.id.menu_context_ban_user).isVisible = userCanBanSelectedUsers() && !isDeprecatedLegacyGroup
         // Ban and delete all
-        menu.findItem(R.id.menu_context_ban_and_delete_all).isVisible = userCanBanSelectedUsers()
+        menu.findItem(R.id.menu_context_ban_and_delete_all).isVisible = userCanBanSelectedUsers() && !isDeprecatedLegacyGroup
         // Copy message text
         menu.findItem(R.id.menu_context_copy).isVisible = !containsControlMessage && hasText
         // Copy Account ID
         menu.findItem(R.id.menu_context_copy_public_key).isVisible =
              (thread.isGroupOrCommunityRecipient && !thread.isCommunityRecipient && selectedItems.size == 1 && firstMessage.individualRecipient.address.toString() != userPublicKey)
         // Message detail
-        menu.findItem(R.id.menu_message_details).isVisible = selectedItems.size == 1
+        menu.findItem(R.id.menu_message_details).isVisible = selectedItems.size == 1 && !isDeprecatedLegacyGroup
         // Resend
-        menu.findItem(R.id.menu_context_resend).isVisible = (selectedItems.size == 1 && firstMessage.isFailed)
+        menu.findItem(R.id.menu_context_resend).isVisible = (selectedItems.size == 1 && firstMessage.isFailed) && !isDeprecatedLegacyGroup
         // Resync
-        menu.findItem(R.id.menu_context_resync).isVisible = (selectedItems.size == 1 && firstMessage.isSyncFailed)
+        menu.findItem(R.id.menu_context_resync).isVisible = (selectedItems.size == 1 && firstMessage.isSyncFailed) && !isDeprecatedLegacyGroup
         // Save media
         menu.findItem(R.id.menu_context_save_attachment).isVisible = (selectedItems.size == 1
             && firstMessage.isMms && (firstMessage as MediaMmsMessageRecord).containsMediaSlide())
         // Reply
         menu.findItem(R.id.menu_context_reply).isVisible =
-            (selectedItems.size == 1 && !firstMessage.isPending && !firstMessage.isFailed && !firstMessage.isOpenGroupInvitation)
+            (!isDeprecatedLegacyGroup && selectedItems.size == 1 && !firstMessage.isPending && !firstMessage.isFailed && !firstMessage.isOpenGroupInvitation)
     }
 
     override fun onPrepareActionMode(mode: ActionMode?, menu: Menu): Boolean {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationMenuHelper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationMenuHelper.kt
@@ -74,7 +74,7 @@ object ConversationMenuHelper {
         deprecationManager: LegacyGroupDeprecationManager,
     ) {
         val isDeprecatedLegacyGroup = thread.isLegacyGroupRecipient &&
-                deprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+                deprecationManager.isDeprecated
 
         // Prepare
         menu.clear()

--- a/app/src/main/java/org/thoughtcrime/securesms/home/ConversationOptionsBottomSheet.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/ConversationOptionsBottomSheet.kt
@@ -84,7 +84,7 @@ class ConversationOptionsBottomSheet(private val parentContext: Context) : Botto
         }
 
         val isDeprecatedLegacyGroup = recipient.isLegacyGroupRecipient &&
-                deprecationManager.deprecationState.value == LegacyGroupDeprecationManager.DeprecationState.DEPRECATED
+                deprecationManager.isDeprecated
 
         binding.copyConversationId.isVisible = !recipient.isGroupOrCommunityRecipient
                 && !recipient.isLocalNumber

--- a/app/src/main/java/org/thoughtcrime/securesms/reactions/ReactionRecipientsAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/reactions/ReactionRecipientsAdapter.java
@@ -36,9 +36,11 @@ final class ReactionRecipientsAdapter extends RecyclerView.Adapter<ReactionRecip
   private MessageId messageId;
   private boolean isUserModerator;
   private EmojiCount emojiData;
+  private final boolean canRemove;
 
-  public ReactionRecipientsAdapter(ReactionViewPagerAdapter.Listener callback) {
+  public ReactionRecipientsAdapter(ReactionViewPagerAdapter.Listener callback, boolean canRemove) {
     this.callback = callback;
+      this.canRemove = canRemove;
   }
 
   public void updateData(MessageId messageId, EmojiCount newData, boolean isUserModerator) {
@@ -70,7 +72,7 @@ final class ReactionRecipientsAdapter extends RecyclerView.Adapter<ReactionRecip
       case FOOTER_TYPE:
         return new FooterViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.reactions_bottom_sheet_dialog_fragment_recycler_footer, parent, false));
       default:
-        return new RecipientViewHolder(callback, LayoutInflater.from(parent.getContext()).inflate(R.layout.reactions_bottom_sheet_dialog_fragment_recipient_item, parent, false));
+        return new RecipientViewHolder(callback, LayoutInflater.from(parent.getContext()).inflate(R.layout.reactions_bottom_sheet_dialog_fragment_recipient_item, parent, false), canRemove);
     }
   }
 
@@ -137,10 +139,12 @@ final class ReactionRecipientsAdapter extends RecyclerView.Adapter<ReactionRecip
     private final ProfilePictureView avatar;
     private final TextView recipient;
     private final ImageView remove;
+    private final boolean canRemove;
 
-    public RecipientViewHolder(ReactionViewPagerAdapter.Listener callback, @NonNull View itemView) {
+    public RecipientViewHolder(ReactionViewPagerAdapter.Listener callback, @NonNull View itemView, boolean canRemove) {
       super(itemView);
       this.callback = callback;
+        this.canRemove = canRemove;
       avatar = itemView.findViewById(R.id.reactions_bottom_view_avatar);
       recipient = itemView.findViewById(R.id.reactions_bottom_view_recipient_name);
       remove = itemView.findViewById(R.id.reactions_bottom_view_recipient_remove);
@@ -156,7 +160,7 @@ final class ReactionRecipientsAdapter extends RecyclerView.Adapter<ReactionRecip
 
       if (reaction.getSender().isLocalNumber()) {
         this.recipient.setText(R.string.you);
-        this.remove.setVisibility(View.VISIBLE);
+        this.remove.setVisibility(canRemove ? View.VISIBLE : View.GONE);
       } else {
         String name = reaction.getSender().getName();
         if (name == null){

--- a/app/src/main/java/org/thoughtcrime/securesms/reactions/ReactionViewPagerAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/reactions/ReactionViewPagerAdapter.java
@@ -28,9 +28,12 @@ class ReactionViewPagerAdapter extends ListAdapter<EmojiCount, ReactionViewPager
   private MessageId messageId = null;
   private boolean isUserModerator = false;
 
-  protected ReactionViewPagerAdapter(Listener callback) {
+  private final boolean canRemove;
+
+  protected ReactionViewPagerAdapter(Listener callback, boolean canRemove) {
     super(new AlwaysChangedDiffUtil<>());
     this.callback = callback;
+    this.canRemove = canRemove;
   }
 
   public void setIsUserModerator(boolean isUserModerator) {
@@ -59,7 +62,7 @@ class ReactionViewPagerAdapter extends ListAdapter<EmojiCount, ReactionViewPager
   @Override
   public @NonNull ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
     return new ViewHolder(callback,
-            LayoutInflater.from(parent.getContext()).inflate(R.layout.reactions_bottom_sheet_dialog_fragment_recycler, parent, false));
+            LayoutInflater.from(parent.getContext()).inflate(R.layout.reactions_bottom_sheet_dialog_fragment_recycler, parent, false), canRemove);
   }
 
   @Override
@@ -89,9 +92,9 @@ class ReactionViewPagerAdapter extends ListAdapter<EmojiCount, ReactionViewPager
     private final RecyclerView              recycler;
     private final ReactionRecipientsAdapter adapter;
 
-    public ViewHolder(Listener callback, @NonNull View itemView) {
+    public ViewHolder(Listener callback, @NonNull View itemView, boolean canRemove) {
       super(itemView);
-      adapter = new ReactionRecipientsAdapter(callback);
+      adapter = new ReactionRecipientsAdapter(callback, canRemove);
       recycler = itemView.findViewById(R.id.reactions_bottom_view_recipient_recycler);
 
       ViewGroup.LayoutParams params = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,

--- a/app/src/main/java/org/thoughtcrime/securesms/reactions/ReactionsDialogFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/reactions/ReactionsDialogFragment.java
@@ -20,8 +20,6 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 
-import org.session.libsession.utilities.ThemeUtil;
-import org.session.libsignal.utilities.Log;
 import org.thoughtcrime.securesms.components.emoji.EmojiImageView;
 import org.thoughtcrime.securesms.database.model.MessageId;
 import org.thoughtcrime.securesms.util.LifecycleDisposable;
@@ -37,6 +35,7 @@ public final class ReactionsDialogFragment extends BottomSheetDialogFragment imp
   private static final String ARGS_IS_MMS     = "reactions.args.is.mms";
   private static final String ARGS_IS_MODERATOR = "reactions.args.is.moderator";
   private static final String ARGS_EMOJI = "reactions.args.emoji";
+  private static final String ARGS_CAN_REMOVE = "reactions.args.can.remove";
 
   private ViewPager2                recipientPagerView;
   private ReactionViewPagerAdapter  recipientsAdapter;
@@ -44,7 +43,7 @@ public final class ReactionsDialogFragment extends BottomSheetDialogFragment imp
 
   private final LifecycleDisposable disposables = new LifecycleDisposable();
 
-  public static DialogFragment create(MessageId messageId, boolean isUserModerator, @Nullable String emoji) {
+  public static DialogFragment create(MessageId messageId, boolean isUserModerator, @Nullable String emoji, boolean canRemove) {
     Bundle         args     = new Bundle();
     DialogFragment fragment = new ReactionsDialogFragment();
 
@@ -52,6 +51,7 @@ public final class ReactionsDialogFragment extends BottomSheetDialogFragment imp
     args.putBoolean(ARGS_IS_MMS, messageId.isMms());
     args.putBoolean(ARGS_IS_MODERATOR, isUserModerator);
     args.putString(ARGS_EMOJI, emoji);
+    args.putBoolean(ARGS_CAN_REMOVE, canRemove);
 
     fragment.setArguments(args);
 
@@ -138,7 +138,7 @@ public final class ReactionsDialogFragment extends BottomSheetDialogFragment imp
   }
 
   private void setUpRecipientsRecyclerView() {
-    recipientsAdapter = new ReactionViewPagerAdapter(this);
+    recipientsAdapter = new ReactionViewPagerAdapter(this, requireArguments().getBoolean(ARGS_CAN_REMOVE));
     recipientPagerView.setAdapter(recipientsAdapter);
   }
 

--- a/libsession/src/main/java/org/session/libsession/messaging/groups/LegacyGroupDeprecationManager.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/groups/LegacyGroupDeprecationManager.kt
@@ -72,6 +72,8 @@ class LegacyGroupDeprecationManager(private val prefs: TextSecurePreferences)  {
             initialValue = mutableDeprecationStateOverride.value ?: DeprecationState.NOT_DEPRECATING
         )
 
+    val isDeprecated: Boolean get() = deprecationState.value == DeprecationState.DEPRECATED
+
     fun overrideDeprecationState(deprecationState: DeprecationState?) {
         mutableDeprecationStateOverride.value = deprecationState
         prefs.deprecationStateOverride = deprecationState?.name


### PR DESCRIPTION
This PR adds logic to hide "write" actions for legacy group in these places:
1. Showing an image in the message (so you can't delete an image from legacy group)
2. Showing destination to share stuff into (so read-only legacy groups shouldn't be in them)
3. Message details (so you can't delete it from there)
4. Long press message context (so you can't delete from there)
5. Convo screen (so you can't invoke menu options at all for legacy group)
6. Removing/adding reaction

Also tidy up the code around checking deprecated state.