### PR TITLE
Relying on the flag for voice notes and ignoring empty file names as …

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
@@ -38,7 +38,6 @@ import org.session.libsignal.crypto.ecc.DjbECPublicKey
 import org.session.libsignal.crypto.ecc.ECKeyPair
 import org.session.libsignal.utilities.AccountId
 import org.session.libsignal.utilities.Log
-import org.thoughtcrime.securesms.database.MmsDatabase
 import org.thoughtcrime.securesms.database.MmsSmsDatabase
 import org.thoughtcrime.securesms.database.RecipientDatabase
 import org.thoughtcrime.securesms.database.ThreadDatabase
@@ -64,7 +63,6 @@ class ConfigToDatabaseSync @Inject constructor(
     private val storage: StorageProtocol,
     private val threadDatabase: ThreadDatabase,
     private val recipientDatabase: RecipientDatabase,
-    private val mmsDatabase: MmsDatabase,
     private val pollerFactory: PollerFactory,
     private val clock: SnodeClock,
     private val profileManager: ProfileManager,

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/attachments/Attachment.java
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/attachments/Attachment.java
@@ -120,9 +120,7 @@ public abstract class Attachment {
   }
 
   public boolean isVoiceNote() {
-    // A missing file name is the legacy way to determine if an audio attachment is
-    // a voice note vs. other arbitrary audio attachments.
-    return voiceNote || getFileName() == null || getFileName().isEmpty();
+    return voiceNote;
   }
 
   public int getWidth() {


### PR DESCRIPTION
[SES-3212](https://github.com/oxen-io/session-android/pull/1709) - We shouldn't rely on empty filenames directly in attachments as we cannot guarantee these are for audio only. The isVoiceNote flag is now old enough to be reliable.