### PR TITLE
[SES-3319] - No promotion retry in the background

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -547,9 +547,11 @@ class GroupManagerV2Impl @Inject constructor(
 
             val promotionDeferred = members.associateWith { member ->
                 async {
-                    MessageSender.sendAndAwait(
+                    // The promotion message shouldn't be persisted to avoid being retried automatically
+                    MessageSender.sendNonDurably(
                         message = promoteMessage,
                         address = Address.fromSerialized(member.hexString),
+                        isSyncMessage = false,
                     )
                 }
             }

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -552,7 +552,7 @@ class GroupManagerV2Impl @Inject constructor(
                         message = promoteMessage,
                         address = Address.fromSerialized(member.hexString),
                         isSyncMessage = false,
-                    )
+                    ).await()
                 }
             }
 


### PR DESCRIPTION
Basically now we don't want the admin promotion to automatically retry, we need to go back to the non-durable version of `MessageSender.send` so that it doesn't get into the job system.