### PR TITLE
[SES-3340] - Update user config whenever group name changes

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
@@ -191,6 +191,13 @@ class ConfigToDatabaseSync @Inject constructor(
         recipientDatabase.setProfileName(recipient, groupInfoConfig.name)
         profileManager.setName(context, recipient, groupInfoConfig.name.orEmpty())
 
+        // Also update the name in the user groups config
+        configFactory.withMutableUserConfigs { configs ->
+            configs.userGroups.getClosedGroup(groupInfoConfig.id.hexString)?.let { group ->
+                configs.userGroups.set(group.copy(name = groupInfoConfig.name.orEmpty()))
+            }
+        }
+
         if (groupInfoConfig.destroyed) {
             handleDestroyedGroup(threadId = threadId)
         } else {


### PR DESCRIPTION
We have mulitple places that try to sync the group name to local database using different sources. So the group name can come from group configs, it can also come from the user groups config. The source-of-truth is the group config so whenever that updates, also updates the user groups config so they can keep in sync.
