### PR TITLE
[SES-3352] - Create group as a rollback-able process

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigUploader.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigUploader.kt
@@ -229,25 +229,25 @@ class ConfigUploader @Inject constructor(
         val auth = OwnedSwarmAuth.ofClosedGroup(groupId, adminKey)
 
         // Spawn the config pushing concurrently
-        val membersConfigHashTask = membersPush?.let {
+        val membersConfigHashTask = membersPush?.let { push ->
             async {
-                membersPush!! to pushConfig(
+                push to pushConfig(
                     auth,
                     snode,
-                    membersPush!!,
+                    push,
                     Namespace.CLOSED_GROUP_MEMBERS()
                 )
             }
         }
 
-        val infoConfigHashTask = infoPush?.let {
+        val infoConfigHashTask = infoPush?.let { push ->
             async {
-                infoPush!! to pushConfig(auth, snode, infoPush!!, Namespace.CLOSED_GROUP_INFO())
+                push to pushConfig(auth, snode, push, Namespace.CLOSED_GROUP_INFO())
             }
         }
 
         // Keys push is different: it doesn't have the delete call so we don't call pushConfig
-        val keysPushResult = keysPush?.let {
+        val keysPushResult = keysPush?.let { push ->
             SnodeAPI.sendBatchRequest(
                 snode = snode,
                 publicKey = auth.accountId.hexString,
@@ -255,7 +255,7 @@ class ConfigUploader @Inject constructor(
                     Namespace.ENCRYPTION_KEYS(),
                     SnodeMessage(
                         auth.accountId.hexString,
-                        Base64.encodeBytes(keysPush!!),
+                        Base64.encodeBytes(push),
                         SnodeMessage.CONFIG_TTL,
                         clock.currentTimeMills(),
                     ),

--- a/libsession/src/main/java/org/session/libsession/utilities/ConfigFactoryProtocol.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/ConfigFactoryProtocol.kt
@@ -38,6 +38,20 @@ interface ConfigFactoryProtocol {
     fun <T> withGroupConfigs(groupId: AccountId, cb: (GroupConfigs) -> T): T
 
     /**
+     * Create a new group config instance. Note this does not save the group configs to the database.
+     */
+    fun createGroupConfigs(groupId: AccountId, adminKey: ByteArray): MutableGroupConfigs
+
+    /**
+     * Save the group configs to the database and the factory.
+     *
+     * **Note:** This will overwrite the existing group configs. Normally you don't want to use
+     * this function, instead use [withMutableGroupConfigs] to modify the group configs. This
+     * function is only useful when you just created a new group and want to save the configs.
+     */
+    fun saveGroupConfigs(groupId: AccountId, groupConfigs: MutableGroupConfigs)
+
+    /**
      * @param recreateConfigInstances If true, the group configs will be recreated before calling the callback. This is useful when you have received an admin key or otherwise.
      */
     fun <T> withMutableGroupConfigs(groupId: AccountId, recreateConfigInstances: Boolean = false, cb: (MutableGroupConfigs) -> T): T


### PR DESCRIPTION
Previously in the group creation process, the creation will write to the config immediately so even if the user is offline, the creation succeeds. But it creates UX issue while offline. To align this behavior with other platform, this PR:

1. Pulled out some of the config pushing process so that it can be done manually.
2. Only when the config pushing process completes successfully, we proceed to update our configs

This PR also fixes an issue where the first control message sent by the group admin is lost: due to thread not created promptly.
