### PR TITLE
SES-2145 - Fix re-scroll to bottom after clicking on original message in a reply

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1803,7 +1803,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
 
             // ..otherwise, set the pending highlight target and trigger a scroll.
             // Note: We scroll slightly past the target highlight message position otherwise it looks
-            // a bit to close to the top of the screen.
+            // a bit too close to the top of the screen.
             pendingHighlightMessagePosition = targetMessagePosition
             val offsetPendingHighlightMessagePosition = max(0, targetMessagePosition - 1)
             binding.conversationRecyclerView.smoothScrollToPosition(offsetPendingHighlightMessagePosition)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -432,9 +432,6 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
     private val isScrolledToBottom: Boolean
         get() = binding.conversationRecyclerView.isScrolledToBottom
 
-    private val isScrolledToWithin30dpOfBottom: Boolean
-        get() = binding.conversationRecyclerView.isScrolledToWithin30dpOfBottom
-
     // When the user clicks on the original message in a reply then we scroll to and highlight that original
     // message. To do this we keep track of the replied-to message's location in the recycler view.
     private var pendingHighlightMessagePosition: Int? = null

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -436,13 +436,14 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
     // message. To do this we keep track of the replied-to message's location in the recycler view.
     private var pendingHighlightMessagePosition: Int? = null
 
-    // Used to target a specific message and scroll to it with some breathing room above (offset)
-    private var targetedScrollOffsetPx: Int = 0
+    // Used to target a specific message and scroll to it with some breathing room above (offset) for all messages but the first
+    private var currentTargetedScrollOffsetPx: Int = 0
+    private val nonFirstMessageOffsetPx by lazy { resources.getDimensionPixelSize(R.dimen.massive_spacing) * -1 }
     private val linearSmoothScroller by lazy {
         object : LinearSmoothScroller(binding.conversationRecyclerView.context) {
             override fun getVerticalSnapPreference(): Int = SNAP_TO_START
             override fun calculateDyToMakeVisible(view: View, snapPreference: Int): Int {
-                return super.calculateDyToMakeVisible(view, snapPreference) - targetedScrollOffsetPx
+                return super.calculateDyToMakeVisible(view, snapPreference) - currentTargetedScrollOffsetPx
             }
         }
     }
@@ -1812,7 +1813,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
             // Note: If the targeted message isn't the very first one then we scroll slightly past it to give it some breathing room.
             // Also: The offset must be negative to provide room above it.
             pendingHighlightMessagePosition = targetMessagePosition
-            targetedScrollOffsetPx = if (targetMessagePosition > 0) resources.getDimensionPixelSize(R.dimen.massive_spacing) * -1 else 0
+            currentTargetedScrollOffsetPx = if (targetMessagePosition > 0) nonFirstMessageOffsetPx else 0
             linearSmoothScroller.targetPosition = targetMessagePosition
             (binding.conversationRecyclerView.layoutManager as? LinearLayoutManager)?.startSmoothScroll(linearSmoothScroller)
             

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
@@ -13,6 +13,8 @@ import androidx.core.util.set
 import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.bumptech.glide.RequestManager
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.math.min
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -28,8 +30,6 @@ import org.thoughtcrime.securesms.conversation.v2.messages.VisibleMessageViewDel
 import org.thoughtcrime.securesms.database.CursorRecyclerViewAdapter
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
-import java.util.concurrent.atomic.AtomicLong
-import kotlin.math.min
 
 class ConversationAdapter(
     context: Context,
@@ -73,9 +73,7 @@ class ConversationAdapter(
     }
 
     @WorkerThread
-    private fun getSenderInfo(sender: String): Contact? {
-        return contactDB.getContactWithAccountID(sender)
-    }
+    private fun getSenderInfo(sender: String): Contact? = contactDB.getContactWithAccountID(sender)
 
     sealed class ViewType(val rawValue: Int) {
         object Visible : ViewType(0)
@@ -193,9 +191,7 @@ class ConversationAdapter(
         super.onItemViewRecycled(viewHolder)
     }
 
-    private fun getMessage(cursor: Cursor): MessageRecord? {
-        return messageDB.readerFor(cursor).current
-    }
+    private fun getMessage(cursor: Cursor): MessageRecord? = messageDB.readerFor(cursor).current
 
     private fun getMessageBefore(position: Int, cursor: Cursor): MessageRecord? {
         // The message that's visually before the current one is actually after the current

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBar.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBar.kt
@@ -15,6 +15,7 @@ import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import com.bumptech.glide.RequestManager
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ViewInputBarBinding
 import org.session.libsession.messaging.sending_receiving.link_preview.LinkPreview
@@ -26,7 +27,6 @@ import org.thoughtcrime.securesms.conversation.v2.messages.QuoteView
 import org.thoughtcrime.securesms.conversation.v2.messages.QuoteViewDelegate
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord
-import com.bumptech.glide.RequestManager
 import org.thoughtcrime.securesms.util.addTextChangedListener
 import org.thoughtcrime.securesms.util.contains
 
@@ -112,12 +112,14 @@ class InputBar @JvmOverloads constructor(
 
                 when (event.action) {
                     MotionEvent.ACTION_DOWN -> {
+
                         // Only start spinning up the voice recorder if we're not already recording, setting up, or tearing down
                         if (voiceRecorderState == VoiceRecorderState.Idle) {
                             startRecordingVoiceMessage()
                         }
                     }
                     MotionEvent.ACTION_UP -> {
+
                         // Handle the pointer up event appropriately, whether that's to keep recording if recording was locked
                         // on, or finishing recording if just hold-to-record.
                         delegate?.onMicrophoneButtonUp(event)
@@ -172,7 +174,10 @@ class InputBar @JvmOverloads constructor(
 
     private fun toggleAttachmentOptions() { delegate?.toggleAttachmentOptions() }
 
-    private fun startRecordingVoiceMessage() { delegate?.startRecordingVoiceMessage() }
+
+    private fun startRecordingVoiceMessage() {
+        delegate?.startRecordingVoiceMessage()
+    }
 
     fun draftQuote(thread: Recipient, message: MessageRecord, glide: RequestManager) {
         quoteView?.let(binding.inputBarAdditionalContentContainer::removeView)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBarButton.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBarButton.kt
@@ -5,7 +5,6 @@ import android.animation.ValueAnimator
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.PointF
-import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.AttributeSet
@@ -153,7 +152,7 @@ class InputBarButton : RelativeLayout {
         longPressCallback?.let { gestureHandler.removeCallbacks(it) }
         val newLongPressCallback = Runnable { onLongPress?.invoke() }
         this.longPressCallback = newLongPressCallback
-        gestureHandler.postDelayed(newLongPressCallback, InputBarButton.longPressDurationThreshold)
+        gestureHandler.postDelayed(newLongPressCallback, longPressDurationThreshold)
         onDownTimestamp = Date().time
     }
 
@@ -170,7 +169,7 @@ class InputBarButton : RelativeLayout {
     private fun onUp(event: MotionEvent) {
         onUp?.invoke(event)
         collapse()
-        if ((Date().time - onDownTimestamp) < InputBarButton.longPressDurationThreshold) {
+        if ((Date().time - onDownTimestamp) < longPressDurationThreshold) {
             longPressCallback?.let { gestureHandler.removeCallbacks(it) }
             onPress?.invoke()
         }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBarRecordingView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBarRecordingView.kt
@@ -70,13 +70,14 @@ class InputBarRecordingView : RelativeLayout {
         binding.inputBarMiddleContentContainer.alpha = 1.0f
         binding.lockView.alpha = 1.0f
         isVisible = true
-        alpha = 0.0f
-        val animation = ValueAnimator.ofObject(FloatEvaluator(), 0.0f, 1.0f)
-        animation.duration = 250L
-        animation.addUpdateListener { animator ->
-            alpha = animator.animatedValue as Float
-        }
-        animation.start()
+
+        animate().cancel()
+        animate()
+            .alpha(1f)
+            .setDuration(VoiceRecorderConstants.SHOW_HIDE_VOICE_UI_DURATION_MS)
+            .withEndAction(null)
+            .start()
+
         animateDotView()
         pulse()
         animateLockViewUp()
@@ -84,18 +85,17 @@ class InputBarRecordingView : RelativeLayout {
     }
 
     fun hide() {
-        alpha = 1.0f
-        val animation = ValueAnimator.ofObject(FloatEvaluator(), 1.0f, 0.0f)
-        animation.duration = VoiceRecorderConstants.SHOW_HIDE_VOICE_UI_DURATION_MS
-        animation.addUpdateListener { animator ->
-            alpha = animator.animatedValue as Float
-            if (animator.animatedFraction == 1.0f) {
+        animate().cancel()
+        animate()
+            .alpha(0f)
+            .setDuration(VoiceRecorderConstants.SHOW_HIDE_VOICE_UI_DURATION_MS)
+            .withEndAction {
                 isVisible = false
                 dotViewAnimation?.repeatCount = 0
                 pulseAnimation?.removeAllUpdateListeners()
             }
-        }
-        animation.start()
+            .start()
+
         delegate?.handleVoiceMessageUIHidden()
         stopTimer()
     }
@@ -110,7 +110,7 @@ class InputBarRecordingView : RelativeLayout {
                 val durationMS = (Date().time - startTimestamp)
                 binding.recordingViewDurationTextView.text = MediaUtil.getFormattedVoiceMessageDuration(durationMS)
 
-                delay(500)
+                delay(500) // Update the voice message duration timer value every half a second
             }
         }
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageViewDelegate.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageViewDelegate.kt
@@ -3,13 +3,8 @@ package org.thoughtcrime.securesms.conversation.v2.messages
 import org.thoughtcrime.securesms.database.model.MessageId
 
 interface VisibleMessageViewDelegate {
-
     fun playVoiceMessageAtIndexIfPossible(indexInAdapter: Int)
-
     fun scrollToMessageIfPossible(timestamp: Long)
-
     fun onReactionClicked(emoji: String, messageId: MessageId, userWasSender: Boolean)
-
     fun onReactionLongClicked(messageId: MessageId, emoji: String?)
-
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/BaseGroupMembersViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/BaseGroupMembersViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.assisted.AssistedFactory
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.EnumSet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -21,8 +22,6 @@ import org.session.libsession.database.StorageProtocol
 import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsession.utilities.ConfigUpdateNotification
 import org.session.libsignal.utilities.AccountId
-import java.util.EnumSet
-
 
 abstract class BaseGroupMembersViewModel (
     private val groupId: AccountId,

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaRepository.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaRepository.java
@@ -101,8 +101,6 @@ class MediaRepository {
 
         return mediaFolders;
     }
-
-
     @WorkerThread
     private @NonNull FolderResult getFolders(@NonNull Context context, @NonNull Uri contentUri) {
         Uri globalThumbnail = null;
@@ -152,7 +150,6 @@ class MediaRepository {
 
         return new FolderResult(globalThumbnail, thumbnailTimestamp, folders);
     }
-
     @WorkerThread
     private @NonNull List<Media> getMediaInBucket(@NonNull Context context, @NonNull String bucketId) {
         List<Media> images = getMediaInBucket(context, bucketId, Images.Media.EXTERNAL_CONTENT_URI, true);
@@ -165,7 +162,6 @@ class MediaRepository {
 
         return media;
     }
-
     @WorkerThread
     private @NonNull List<Media> getMediaInBucket(@NonNull Context context, @NonNull String bucketId, @NonNull Uri contentUri, boolean isImage) {
         List<Media> media         = new LinkedList<>();
@@ -204,7 +200,6 @@ class MediaRepository {
 
         return media;
     }
-
     @WorkerThread
     private List<Media> getPopulatedMedia(@NonNull Context context, @NonNull List<Media> media) {
         return Stream.of(media).map(m -> {
@@ -260,7 +255,6 @@ class MediaRepository {
 
         return new Media(media.getUri(), media.getFilename(), media.getMimeType(), media.getDate(), width, height, size, media.getBucketId(), media.getCaption());
     }
-
     private Media getContentResolverPopulatedMedia(@NonNull Context context, @NonNull Media media) throws IOException {
         int  width  = media.getWidth();
         int  height = media.getHeight();
@@ -363,7 +357,6 @@ class MediaRepository {
             return latestTimestamp;
         }
     }
-
 
     interface Callback<E> {
         void onComplete(@NonNull E result);

--- a/app/src/main/java/org/thoughtcrime/securesms/util/GlowView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/GlowView.kt
@@ -11,8 +11,8 @@ import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import androidx.annotation.ColorInt
-import network.loki.messenger.R
 import kotlin.math.roundToInt
+import network.loki.messenger.R
 
 interface GlowView {
     var mainColor: Int


### PR DESCRIPTION
**Ticket:**
SES-2145

**Adjustments:**
1.) Prevent re-scroll to bottom of conversation after clicking on the message snippet of the original message in a reply. We now smooth scroll to the original message to match iOS behaviour rather than performing an instant scroll which left the recycler view immediately in `SCROLL_STATE_IDLE` and allowed the scroll-to-last-message functionality to be triggered.

2.) Added highlight on successful scroll to original "replied-to" message to match iOS behaviour.

3.) Converted a few methods into expression-bodied equivalents as I came across them as there's no reason not to save some vertical real-estate when we can.

**Potential test steps:**
1.) Reply to a message which is on-screen then click the original message snippet in your reply - original message is highlighted without scrolling.

2.) Reply to a message which is off-screen then click the original message snippet in your reply - we scroll to the original message and highlight it when we get there.