### PR TITLE
Changes to use load_admin_key

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -18,7 +18,6 @@ import org.session.libsession.avatars.AvatarHelper
 import org.session.libsession.database.MessageDataProvider
 import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.BlindedIdMapping
-import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.calls.CallMessageType
 import org.session.libsession.messaging.contacts.Contact
 import org.session.libsession.messaging.jobs.AttachmentUploadJob

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -684,7 +684,8 @@ class GroupManagerV2Impl @Inject constructor(
                 .first()
         }
 
-        if (group.adminKey == null) {
+        val adminKey = group.adminKey
+        if (adminKey == null) {
             // Send an invite response to the group if we are invited as a regular member
             val inviteResponse = GroupUpdateInviteResponseMessage.newBuilder()
                 .setIsApproved(true)
@@ -700,6 +701,8 @@ class GroupManagerV2Impl @Inject constructor(
         } else {
             // If we are invited as admin, we can just update the group info ourselves
             configFactory.withMutableGroupConfigs(group.groupAccountId) { configs ->
+                configs.groupKeys.loadAdminKey(adminKey)
+
                 configs.groupMembers.get(key)?.let { member ->
                     configs.groupMembers.set(member.apply {
                         setPromotionAccepted()
@@ -778,9 +781,10 @@ class GroupManagerV2Impl @Inject constructor(
 
             // Update our promote state
             configFactory.withMutableGroupConfigs(
-                recreateConfigInstances = true,
                 groupId = groupId
             ) { configs ->
+                configs.groupKeys.loadAdminKey(adminKey)
+
                 configs.groupMembers.get(userAuth.accountId.hexString)?.let { member ->
                     member.setPromotionAccepted()
                     configs.groupMembers.set(member)

--- a/libsession-util/src/main/cpp/group_keys.cpp
+++ b/libsession-util/src/main/cpp/group_keys.cpp
@@ -314,3 +314,20 @@ Java_network_loki_messenger_libsession_1util_GroupKeysConfig_size(JNIEnv *env, j
     auto ptr = ptrToKeys(env, thiz);
     return ptr->size();
 }
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_network_loki_messenger_libsession_1util_GroupKeysConfig_loadAdminKey(JNIEnv *env, jobject thiz,
+                                                                          jbyteArray admin_key,
+                                                                          jlong info_ptr,
+                                                                          jlong members_ptr) {
+    std::lock_guard lock{util::util_mutex_};
+    auto ptr = ptrToKeys(env, thiz);
+    auto admin_key_ustring = util::ustring_from_bytes(env, admin_key);
+    auto info = reinterpret_cast<session::config::groups::Info*>(info_ptr);
+    auto members = reinterpret_cast<session::config::groups::Members*>(members_ptr);
+
+    jni_utils::run_catching_cxx_exception_or_throws<void>(env, [&] {
+        ptr->load_admin_key(admin_key_ustring, *info, *members);
+    });
+}

--- a/libsession-util/src/main/java/network/loki/messenger/libsession_util/Config.kt
+++ b/libsession-util/src/main/java/network/loki/messenger/libsession_util/Config.kt
@@ -464,6 +464,7 @@ interface ReadableGroupKeysConfig {
 interface MutableGroupKeysConfig : ReadableGroupKeysConfig {
     fun makeSubAccount(sessionId: AccountId, canWrite: Boolean = true, canDelete: Boolean = false): ByteArray
     fun loadKey(message: ByteArray, hash: String, timestampMs: Long): Boolean
+    fun loadAdminKey(adminKey: ByteArray)
 }
 
 class GroupKeysConfig private constructor(
@@ -516,6 +517,12 @@ class GroupKeysConfig private constructor(
     override fun loadKey(message: ByteArray, hash: String, timestampMs: Long): Boolean {
         return loadKey(message, hash, timestampMs, info.pointer, members.pointer)
     }
+
+    override fun loadAdminKey(adminKey: ByteArray) {
+        loadAdminKey(adminKey, info.pointer, members.pointer)
+    }
+
+    private external fun loadAdminKey(adminKey: ByteArray, infoPtr: Long, membersPtr: Long)
 
     external override fun needsRekey(): Boolean
     external override fun pendingKey(): ByteArray?

--- a/libsession/src/main/java/org/session/libsession/utilities/ConfigFactoryProtocol.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/ConfigFactoryProtocol.kt
@@ -54,7 +54,7 @@ interface ConfigFactoryProtocol {
     /**
      * @param recreateConfigInstances If true, the group configs will be recreated before calling the callback. This is useful when you have received an admin key or otherwise.
      */
-    fun <T> withMutableGroupConfigs(groupId: AccountId, recreateConfigInstances: Boolean = false, cb: (MutableGroupConfigs) -> T): T
+    fun <T> withMutableGroupConfigs(groupId: AccountId, cb: (MutableGroupConfigs) -> T): T
 
     fun conversationInConfig(publicKey: String?, groupPublicKey: String?, openGroupId: String?, visibleOnly: Boolean): Boolean
     fun canPerformChange(variant: String, publicKey: String, changeTimestampMs: Long): Boolean


### PR DESCRIPTION
Previously, when a member is promoted to admin, we recreate the group configs so that it loads the admin key. However there's a better way to do it by just calling `load_admin_key`...
