### PR TITLE
Fix/SES-1789 Message info for send and receive

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
@@ -214,10 +214,8 @@ fun CellMetadata(
                 verticalArrangement = Arrangement.spacedBy(LocalDimensions.current.smallSpacing)
             ) {
                 // Show the sent details if we're the sender of the message, otherwise show the received details
-                sender?.let {
-                    if (sent != null)     { TitledText(sent) }
-                    if (received != null) { TitledText(received) }
-                }
+                if (sent     != null) { TitledText(sent)     }
+                if (received != null) { TitledText(received) }
 
                 TitledErrorText(error)
                 senderInfo?.let {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
@@ -209,10 +209,6 @@ fun MessageDetails(
 fun CellMetadata(
     state: MessageDetailsState,
 ) {
-    val context = LocalContext.current
-    val messageOriginatorAddress = TextSecurePreferences.getLocalNumber(context)
-    Log.w("ACL", "local address is: " + messageOriginatorAddress)
-
     state.apply {
         if (listOfNotNull(sent, received, error, senderInfo).isEmpty()) return
         Cell(modifier = Modifier.padding(horizontal = LocalDimensions.current.spacing)) {
@@ -220,29 +216,10 @@ fun CellMetadata(
                 modifier = Modifier.padding(LocalDimensions.current.spacing),
                 verticalArrangement = Arrangement.spacedBy(LocalDimensions.current.smallSpacing)
             ) {
-                // If we're the sender of the message we show the sent timestamp, otherwise we show the received timestamp
-
-                //senderInfo.
-
-
-
-                sender?.let { recipient ->
-
-                    val messageRecipientAddress = recipient.address.toString()
-                    val weSentThisMessage = messageOriginatorAddress == messageRecipientAddress
-
-
-                    Log.w("ACL", "recipient address is: " + recipient.address.toString())
-                    Log.w("ACL", "sender info text is: " + senderInfo?.text)
-                    Log.w("ACL", "sender info component2 is: " + senderInfo?.component2())
-
-                    if (weSentThisMessage) {
-                        Log.w("ACL", "We think WE sent this message - showing sent block!")
-                        TitledText(sent)
-                    } else {
-                        Log.w("ACL", "We think they sent this message - showing received block!")
-                        TitledText(received)
-                    }
+                // Show the sent details if we're the sender of the message, otherwise show the received details
+                sender?.let {
+                    if (sent != null)     { TitledText(sent) }
+                    if (received != null) { TitledText(received) }
                 }
 
                 TitledErrorText(error)
@@ -514,12 +491,14 @@ fun TitledText(
 ) {
     titledText?.apply {
         TitledView(title, modifier) {
-            Text(
-                text,
-                style = style,
-                color = color,
-                modifier = Modifier.fillMaxWidth()
-            )
+            if (text != null) {
+                Text(
+                    text,
+                    style = style,
+                    color = color,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -54,13 +53,12 @@ import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlinx.coroutines.launch
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ViewVisibleMessageContentBinding
 import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.sending_receiving.attachments.DatabaseAttachment
-import org.session.libsession.utilities.TextSecurePreferences
-import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.MediaPreviewActivity.getPreviewIntent
 import org.thoughtcrime.securesms.ScreenLockActionBarActivity
 import org.thoughtcrime.securesms.ui.Avatar
@@ -83,7 +81,6 @@ import org.thoughtcrime.securesms.ui.theme.blackAlpha40
 import org.thoughtcrime.securesms.ui.theme.bold
 import org.thoughtcrime.securesms.ui.theme.dangerButtonColors
 import org.thoughtcrime.securesms.ui.theme.monospace
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class MessageDetailActivity : ScreenLockActionBarActivity() {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
@@ -59,6 +59,8 @@ import network.loki.messenger.R
 import network.loki.messenger.databinding.ViewVisibleMessageContentBinding
 import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.sending_receiving.attachments.DatabaseAttachment
+import org.session.libsession.utilities.TextSecurePreferences
+import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.MediaPreviewActivity.getPreviewIntent
 import org.thoughtcrime.securesms.ScreenLockActionBarActivity
 import org.thoughtcrime.securesms.ui.Avatar
@@ -207,6 +209,10 @@ fun MessageDetails(
 fun CellMetadata(
     state: MessageDetailsState,
 ) {
+    val context = LocalContext.current
+    val messageOriginatorAddress = TextSecurePreferences.getLocalNumber(context)
+    Log.w("ACL", "local address is: " + messageOriginatorAddress)
+
     state.apply {
         if (listOfNotNull(sent, received, error, senderInfo).isEmpty()) return
         Cell(modifier = Modifier.padding(horizontal = LocalDimensions.current.spacing)) {
@@ -214,8 +220,31 @@ fun CellMetadata(
                 modifier = Modifier.padding(LocalDimensions.current.spacing),
                 verticalArrangement = Arrangement.spacedBy(LocalDimensions.current.smallSpacing)
             ) {
-                TitledText(sent)
-                TitledText(received)
+                // If we're the sender of the message we show the sent timestamp, otherwise we show the received timestamp
+
+                //senderInfo.
+
+
+
+                sender?.let { recipient ->
+
+                    val messageRecipientAddress = recipient.address.toString()
+                    val weSentThisMessage = messageOriginatorAddress == messageRecipientAddress
+
+
+                    Log.w("ACL", "recipient address is: " + recipient.address.toString())
+                    Log.w("ACL", "sender info text is: " + senderInfo?.text)
+                    Log.w("ACL", "sender info component2 is: " + senderInfo?.component2())
+
+                    if (weSentThisMessage) {
+                        Log.w("ACL", "We think WE sent this message - showing sent block!")
+                        TitledText(sent)
+                    } else {
+                        Log.w("ACL", "We think they sent this message - showing received block!")
+                        TitledText(received)
+                    }
+                }
+
                 TitledErrorText(error)
                 senderInfo?.let {
                     TitledView(state.fromTitle) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
@@ -23,6 +23,7 @@ import org.session.libsession.messaging.sending_receiving.attachments.Attachment
 import org.session.libsession.messaging.sending_receiving.attachments.DatabaseAttachment
 import org.session.libsession.utilities.Util
 import org.session.libsession.utilities.recipients.Recipient
+import org.thoughtcrime.securesms.ApplicationContext
 import org.thoughtcrime.securesms.MediaPreviewArgs
 import org.thoughtcrime.securesms.database.AttachmentDatabase
 import org.thoughtcrime.securesms.database.LokiMessageDatabase
@@ -35,9 +36,6 @@ import org.thoughtcrime.securesms.mms.Slide
 import org.thoughtcrime.securesms.repository.ConversationRepository
 import org.thoughtcrime.securesms.ui.GetString
 import org.thoughtcrime.securesms.ui.TitledText
-
-import org.session.libsignal.utilities.Log
-import org.thoughtcrime.securesms.ApplicationContext
 
 @HiltViewModel
 class MessageDetailsViewModel @Inject constructor(
@@ -71,9 +69,6 @@ class MessageDetailsViewModel @Inject constructor(
             }
 
             val mmsRecord = messageRecord as? MmsMessageRecord
-
-            // We'll say that message that is outgoing but has not yet been sent is sending
-            //val isCurrentlySending = !messageRecord.isOutgoing && !messageRecord.isSent
 
             job = viewModelScope.launch {
                 repository.changes(messageRecord.threadId)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
@@ -7,6 +7,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import kotlin.text.Typography.ellipsis
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -92,7 +93,7 @@ class MessageDetailsViewModel @Inject constructor(
 
                     // Set the "Sent" message info TitledText appropriately
                     sent = if (messageRecord.isSending && errorString == null) {
-                        val sendingWithEllipsisString = context.getString(R.string.sending) + "..."
+                        val sendingWithEllipsisString = context.getString(R.string.sending) + ellipsis // e.g., "Sending…"
                         TitledText(sendingWithEllipsisString, null)
                     } else if (messageRecord.isSent && errorString == null) {
                         dateReceived.let(::Date).toString().let { TitledText(R.string.sent, it) }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
@@ -83,28 +83,31 @@ class MessageDetailsViewModel @Inject constructor(
                 val isDeprecatedLegacyGroup = recipient.isLegacyGroupRecipient &&
                                               deprecationManager.isDeprecated
 
+
+                val errorString = lokiMessageDatabase.getErrorMessage(id)
+
                 MessageDetailsState(
                     attachments = slides.map(::Attachment),
                     record = messageRecord,
 
                     // Set the "Sent" message info TitledText appropriately
-                    sent = if (messageRecord.isSending) {
+                    sent = if (messageRecord.isSending && errorString == null) {
                         val sendingWithEllipsisString = context.getString(R.string.sending) + "..."
                         TitledText(sendingWithEllipsisString, null)
-                    } else if (messageRecord.isSent) {
+                    } else if (messageRecord.isSent && errorString == null) {
                         dateReceived.let(::Date).toString().let { TitledText(R.string.sent, it) }
                     } else {
                         null // Not sending or sent? Don't display anything for the "Sent" element.
                     },
 
                     // Set the "Received" message info TitledText appropriately
-                    received = if (messageRecord.isIncoming) {
+                    received = if (messageRecord.isIncoming && errorString == null) {
                         dateReceived.let(::Date).toString().let { TitledText(R.string.received, it) }
                     } else {
                         null // Not incoming? Then don't display anything for the "Received" element.
                     },
 
-                    error = lokiMessageDatabase.getErrorMessage(id)?.let { TitledText(R.string.theError, it) },
+                    error = errorString?.let { TitledText(context.getString(R.string.theError) + ":", it) },
                     senderInfo = individualRecipient.run { TitledText(name, address.toString()) },
                     sender = individualRecipient,
                     thread = recipient,

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/DisplayRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/DisplayRecord.java
@@ -78,19 +78,7 @@ public abstract class DisplayRecord {
             deliveryStatus < SmsDatabase.Status.STATUS_PENDING) || deliveryReceiptCount > 0;
   }
 
-  public boolean isSent() { return MmsSmsColumns.Types.isSentType(type); }
 
-  public boolean isSyncing() {
-    return MmsSmsColumns.Types.isSyncingType(type);
-  }
-
-  public boolean isResyncing() {
-    return MmsSmsColumns.Types.isResyncingType(type);
-  }
-
-  public boolean isSyncFailed() {
-    return MmsSmsColumns.Types.isSyncFailedMessageType(type);
-  }
 
   public boolean isFailed() {
     return MmsSmsColumns.Types.isFailedMessageType(type)
@@ -105,45 +93,35 @@ public abstract class DisplayRecord {
     return isPending;
   }
 
-  public boolean isRead() { return readReceiptCount > 0; }
-
-  public boolean isOutgoing() {
-    return MmsSmsColumns.Types.isOutgoingMessageType(type);
-  }
-
-  public boolean isIncoming() {
-    return !MmsSmsColumns.Types.isOutgoingMessageType(type);
-  }
-
-  public boolean isGroupUpdateMessage() {
-    return SmsDatabase.Types.isGroupUpdateMessage(type);
-  }
-  public boolean isExpirationTimerUpdate() { return SmsDatabase.Types.isExpirationTimerUpdate(type); }
-  public boolean isGroupV2ExpirationTimerUpdate() { return false; }
-  public boolean isMediaSavedNotification() { return MmsSmsColumns.Types.isMediaSavedExtraction(type); }
-  public boolean isScreenshotNotification() { return MmsSmsColumns.Types.isScreenshotExtraction(type); }
+  public boolean isCallLog()                    { return SmsDatabase.Types.isCallLog(type);                        }
   public boolean isDataExtractionNotification() { return isMediaSavedNotification() || isScreenshotNotification(); }
-  public boolean isOpenGroupInvitation() { return MmsSmsColumns.Types.isOpenGroupInvitation(type); }
-  public boolean isCallLog() {
-    return SmsDatabase.Types.isCallLog(type);
-  }
-  public boolean isIncomingCall() {
-    return SmsDatabase.Types.isIncomingCall(type);
-  }
-  public boolean isOutgoingCall() {
-    return SmsDatabase.Types.isOutgoingCall(type);
-  }
-  public boolean isMissedCall() {
-    return SmsDatabase.Types.isMissedCall(type);
-  }
-  public boolean isFirstMissedCall() {
-    return SmsDatabase.Types.isFirstMissedCall(type);
-  }
-  public boolean isDeleted() { return  MmsSmsColumns.Types.isDeletedMessage(type); }
-  public boolean isMessageRequestResponse() { return  MmsSmsColumns.Types.isMessageRequestResponse(type); }
+  public boolean isDeleted()                    { return  MmsSmsColumns.Types.isDeletedMessage(type);              }
+  public boolean isExpirationTimerUpdate()      { return SmsDatabase.Types.isExpirationTimerUpdate(type);          }
+  public boolean isFirstMissedCall()            { return SmsDatabase.Types.isFirstMissedCall(type);                }
+  public boolean isGroupUpdateMessage()         { return SmsDatabase.Types.isGroupUpdateMessage(type);             }
+  public boolean isIncoming()                   { return !MmsSmsColumns.Types.isOutgoingMessageType(type);         }
+  public boolean isIncomingCall()               { return SmsDatabase.Types.isIncomingCall(type);                   }
+  public boolean isMediaSavedNotification()     { return MmsSmsColumns.Types.isMediaSavedExtraction(type);         }
+  public boolean isMessageRequestResponse()     { return  MmsSmsColumns.Types.isMessageRequestResponse(type);      }
+  public boolean isMissedCall()                 { return SmsDatabase.Types.isMissedCall(type);                     }
+  public boolean isOpenGroupInvitation()        { return MmsSmsColumns.Types.isOpenGroupInvitation(type);          }
+  public boolean isOutgoing()                   { return MmsSmsColumns.Types.isOutgoingMessageType(type);          }
+  public boolean isOutgoingCall()               { return SmsDatabase.Types.isOutgoingCall(type);                   }
+  public boolean isRead()                       { return readReceiptCount > 0;                                     }
+  public boolean isResyncing()                  { return MmsSmsColumns.Types.isResyncingType(type);                }
+  public boolean isScreenshotNotification()     { return MmsSmsColumns.Types.isScreenshotExtraction(type);         }
+  public boolean isSent()                       { return MmsSmsColumns.Types.isSentType(type);                     }
+  public boolean isSending()                    { return isOutgoing() && !isSent();                                }
+  public boolean isSyncFailed()                 { return MmsSmsColumns.Types.isSyncFailedMessageType(type);        }
+  public boolean isSyncing()                    { return MmsSmsColumns.Types.isSyncingType(type);                  }
 
   public boolean isControlMessage() {
-    return isGroupUpdateMessage() || isExpirationTimerUpdate() || isDataExtractionNotification()
-            || isMessageRequestResponse() || isCallLog();
+    return isGroupUpdateMessage()          ||
+            isExpirationTimerUpdate()      ||
+            isDataExtractionNotification() ||
+            isMessageRequestResponse()     ||
+            isCallLog();
   }
+
+  public boolean isGroupV2ExpirationTimerUpdate() { return false; }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/Strings.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/Strings.kt
@@ -54,7 +54,7 @@ fun GetString(duration: Duration) = GetString.FromMap(duration, ExpirationUtil::
 /**
  * Represents some text with an associated title.
  */
-data class TitledText(val title: GetString, val text: String) {
-    constructor(title: String, text: String): this(GetString(title), text)
-    constructor(@StringRes title: Int, text: String): this(GetString(title), text)
+data class TitledText(val title: GetString, val text: String?) {
+    constructor(title: String, text: String?): this(GetString(title), text)
+    constructor(@StringRes title: Int, text: String?): this(GetString(title), text)
 }


### PR DESCRIPTION
Fix:
- Only show the "Received" field in Message Info for incoming messages,
- Only show the "Sent" field in Message Info for outgoing sent messages (for messages which are _Sending_ we show the TitledText "Sending..." with no second line containing the sent/received Date/Time).
- Do not show any Sending / Sent / Received data for messages which have failed to send. For these messages we show a TitledText of "Error:" with the actual error message as the second line.

Potential test steps:
- Successfully send a message, long-press on the message and view the Message Info, observe that the **Sent:** data exists with the correct timestamp,
- Send a MMS message such as a GIF then quickly long-press on the message to view the Message Info, observe that there is no "Sent:" or "Received:" information shown - only a "Sending..." title,
- Send a MMS message such as a GIF then quickly enable Flight Mode so that the message send fails. After a few attempts (across a minute or two) the message status will change to Failed. Take a look at the Message Info and observe there is no Sent, Sending, or Received info - only the **Error:** title with the error message below it,
- Long-press on a received message and view the Message Info, observe that there is no Sent or Sending TitleText, only the **Received:** TitledText with the timestamp of when we received the message.