### PR TITLE
[SES-3395] - Fix group notification issue

### DIFF
--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/notifications/Models.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/notifications/Models.kt
@@ -94,7 +94,7 @@ data class PushNotificationMetadata(
 
         /** The swarm namespace in which this message arrived. */
         @SerialName("n")
-        val namespace: Int,
+        val namespace: Int?,
 
         @SerialName("t")
         val timestampSeconds: Long,


### PR DESCRIPTION
There is this group notification issue where you stay in the background, while the group admin invites someone. The invitation control message and any message afterwards is missing notification.

There are two causes for this issue:
1. The `GroupKeyConfig` message isn't arriving through notification. This has been fixed by the libquic branch merge.
2. On the side of invitiation, the invite control message should be sent after the config is pushed to make sure the order of message arrival is correct.
