### PR TITLE
Make sure to catch the exception in config merging so we don't break the whole thing

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -782,7 +782,8 @@ class GroupManagerV2Impl @Inject constructor(
 
             // Update our promote state
             configFactory.withMutableGroupConfigs(
-                groupId = groupId
+                groupId = groupId,
+                forceChangeNotification = true,
             ) { configs ->
                 configs.groupKeys.loadAdminKey(adminKey)
 

--- a/libsession-util/src/main/java/network/loki/messenger/libsession_util/Config.kt
+++ b/libsession-util/src/main/java/network/loki/messenger/libsession_util/Config.kt
@@ -508,7 +508,7 @@ class GroupKeysConfig private constructor(
     external override fun groupKeys(): Stack<ByteArray>
     external override fun needsDump(): Boolean
     external override fun dump(): ByteArray
-    external fun loadKey(message: ByteArray,
+    private external fun loadKey(message: ByteArray,
                          hash: String,
                          timestampMs: Long,
                          infoPtr: Long,

--- a/libsession/src/main/java/org/session/libsession/utilities/ConfigFactoryProtocol.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/ConfigFactoryProtocol.kt
@@ -52,9 +52,12 @@ interface ConfigFactoryProtocol {
     fun saveGroupConfigs(groupId: AccountId, groupConfigs: MutableGroupConfigs)
 
     /**
-     * @param recreateConfigInstances If true, the group configs will be recreated before calling the callback. This is useful when you have received an admin key or otherwise.
+     * @param forceChangeNotification If true, the group configs will be marked as changed even if no changes were made.
+     * Normally this is not needed, as in most cases the underlying config system will be able to work out
+     * something has changed, but in some very rare cases it might not be able to, and in those cases you
+     * will need to force a change notification so that other parts of the app can react to the change.
      */
-    fun <T> withMutableGroupConfigs(groupId: AccountId, cb: (MutableGroupConfigs) -> T): T
+    fun <T> withMutableGroupConfigs(groupId: AccountId, forceChangeNotification: Boolean = false, cb: (MutableGroupConfigs) -> T): T
 
     fun conversationInConfig(publicKey: String?, groupPublicKey: String?, openGroupId: String?, visibleOnly: Boolean): Boolean
     fun canPerformChange(variant: String, publicKey: String, changeTimestampMs: Long): Boolean


### PR DESCRIPTION
Some improvement to the resliency of group config merging but it's not essential for group's initial release. Putting it here for later merge.
