### PR TITLE
fix/QA882 voice message duration on android 9 API 28

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1931,12 +1931,18 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
     private fun sendAttachments(
         attachments: List<Attachment>,
         body: String?,
-        quotedMessage: MessageRecord? = binding.inputBar?.quote,
+        quotedMessage: MessageRecord? = binding.inputBar.quote,
         linkPreview: LinkPreview? = null
     ): Pair<Address, Long>? {
-        val recipient = viewModel.recipient ?: return null
+        if (viewModel.recipient == null) {
+            Log.w(TAG, "Cannot send attachments to a null recipient")
+            return null
+        }
+        val recipient = viewModel.recipient!!
         val sentTimestamp = SnodeAPI.nowWithOffset
         viewModel.beforeSendingAttachments()
+
+
 
         // Create the message
         val message = VisibleMessage().applyExpiryMode(viewModel.threadId)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VoiceMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VoiceMessageView.kt
@@ -68,8 +68,7 @@ class VoiceMessageView @JvmOverloads constructor(
             return
         }
 
-        val player = AudioSlidePlayer.createFor(context.applicationContext, audioSlide, this)
-        this.player = player
+        this.player = AudioSlidePlayer.createFor(context.applicationContext, audioSlide, this)
 
         // This sets the final duration of the uploaded voice message
         (audioSlide.asAttachment() as? DatabaseAttachment)?.let { attachment ->

--- a/libsession/src/main/java/org/session/libsession/messaging/jobs/AttachmentDownloadJob.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/jobs/AttachmentDownloadJob.kt
@@ -1,6 +1,5 @@
 package org.session.libsession.messaging.jobs
 
-import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.session.libsession.database.MessageDataProvider
 import org.session.libsession.database.StorageProtocol
@@ -150,7 +149,7 @@ class AttachmentDownloadJob(val attachmentID: Long, val databaseMessageID: Long)
                 // process the duration
                     try {
                         InputStreamMediaDataSource(getInputStream(tempFile, attachment)).use { mediaDataSource ->
-                            val durationMs = (DecodedAudio.create(mediaDataSource).totalDuration / 1000.0).toLong()
+                            val durationMs = (DecodedAudio.create(mediaDataSource).totalDurationMicroseconds / 1000.0).toLong()
                             messageDataProvider.updateAudioAttachmentDuration(
                                 attachment.attachmentId,
                                 durationMs,

--- a/libsession/src/main/java/org/session/libsession/utilities/DecodedAudio.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/DecodedAudio.kt
@@ -5,6 +5,8 @@ import android.media.MediaCodec
 import android.media.MediaDataSource
 import android.media.MediaExtractor
 import android.media.MediaFormat
+import android.os.Build
+import org.session.libsignal.utilities.Log
 import java.io.FileDescriptor
 import java.io.IOException
 import java.io.InputStream
@@ -53,8 +55,8 @@ class DecodedAudio {
 
     val sampleRate: Int
 
-    /** In microseconds. */
-    val totalDuration: Long
+    /** In microseconds. There are 1 million microseconds in a second. */
+    val totalDurationMicroseconds: Long
 
     val channels: Int
 
@@ -96,16 +98,25 @@ class DecodedAudio {
         channels = mediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
         sampleRate = mediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
         // On some old APIs (23) this field might be missing.
-        totalDuration = if (mediaFormat.containsKey(MediaFormat.KEY_DURATION)) {
+        totalDurationMicroseconds = if (mediaFormat.containsKey(MediaFormat.KEY_DURATION)) {
             mediaFormat.getLong(MediaFormat.KEY_DURATION)
         } else {
             -1L
         }
 
         // Expected total number of samples per channel.
-        val expectedNumSamples = if (totalDuration >= 0) {
-            ((totalDuration / 1000000f) * sampleRate + 0.5f).toInt()
+//        val expectedNumSamples = if (totalDurationMicroseconds >= 0) {
+//            ((totalDurationMicroseconds / 1000000f) * sampleRate + 0.5f).toInt()
+//        } else {
+//            Int.MAX_VALUE
+//        }
+
+        // Expected total number of samples per channel.
+        val useDurationMetadata = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q // `Q` is Android API 29
+        val expectedNumSamples = if (useDurationMetadata && mediaFormat.containsKey(MediaFormat.KEY_DURATION)) {
+            ((mediaFormat.getLong(MediaFormat.KEY_DURATION) / 1_000_000f) * sampleRate + 0.5f).toInt()
         } else {
+            // Fallback: don't rely on duration metadata on older devices.
             Int.MAX_VALUE
         }
 
@@ -137,14 +148,20 @@ class DecodedAudio {
         // only once.
         var decodedBytes: ByteBuffer = ByteBuffer.allocate(1 shl 20)
         var firstSampleData = true
+
+        // Flags to allow us to exit if we don't read audio samples for a given number of attempts
+        val MAX_NO_OUTPUT_COUNT = 50
+        var noOutputCount = 0
+
         while (true) {
             // read data from file and feed it to the decoder input buffers.
             val inputBufferIndex: Int = codec.dequeueInputBuffer(100)
             if (!doneReading && inputBufferIndex >= 0) {
                 sampleSize = extractor.readSampleData(codec.getInputBuffer(inputBufferIndex)!!, 0)
-                if (firstSampleData
-                        && mediaFormat.getString(MediaFormat.KEY_MIME)!! == "audio/mp4a-latm"
-                        && sampleSize == 2
+                if (firstSampleData                                                    &&
+                    mediaFormat.getString(MediaFormat.KEY_MIME)!! == "audio/mp4a-latm" &&
+                    sampleSize == 2                                                    &&
+                    Build.VERSION.SDK_INT <= Build.VERSION_CODES.P // Only apply this workaround for legacy devices <= API 28
                 ) {
                     // For some reasons on some devices (e.g. the Samsung S3) you should not
                     // provide the first two bytes of an AAC stream, otherwise the MediaCodec will
@@ -156,11 +173,10 @@ class DecodedAudio {
                     totalSizeRead += sampleSize
                 } else if (sampleSize < 0) {
                     // All samples have been read.
-                    codec.queueInputBuffer(
-                            inputBufferIndex, 0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM
-                    )
+                    codec.queueInputBuffer(inputBufferIndex, 0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
                     doneReading = true
                 } else {
+                    // Normal case - feed the sample data through
                     presentationTime = extractor.sampleTime
                     codec.queueInputBuffer(inputBufferIndex, 0, sampleSize, presentationTime, 0)
                     extractor.advance()
@@ -172,10 +188,15 @@ class DecodedAudio {
             // Get decoded stream from the decoder output buffers.
             val outputBufferIndex: Int = codec.dequeueOutputBuffer(info, 100)
             if (outputBufferIndex >= 0 && info.size > 0) {
+
+                // Reset counter on successful output
+                noOutputCount = 0
+
                 if (decodedSamplesSize < info.size) {
                     decodedSamplesSize = info.size
                     decodedSamples = ByteArray(decodedSamplesSize)
                 }
+
                 val outputBuffer: ByteBuffer = codec.getOutputBuffer(outputBufferIndex)!!
                 outputBuffer.get(decodedSamples!!, 0, info.size)
                 outputBuffer.clear()
@@ -213,20 +234,18 @@ class DecodedAudio {
                 }
                 decodedBytes.put(decodedSamples, 0, info.size)
                 codec.releaseOutputBuffer(outputBufferIndex, false)
+            } else {
+                // Increase counter if no output is available.
+                noOutputCount++
+                Log.w("ACL", "Incrementing noOutputCount - now: " + noOutputCount)
             }
 
-            if ((info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0
-                    || (decodedBytes.position() / (2 * channels)) >= expectedNumSamples
+            // Only use the End-of-Stream (EOS) flag if available, otherwise use our no-output timeout to break
+            if (
+                (info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0 ||
+                (doneReading && noOutputCount >= MAX_NO_OUTPUT_COUNT)
             ) {
-                // We got all the decoded data from the decoder. Stop here.
-                // Theoretically dequeueOutputBuffer(info, ...) should have set info.flags to
-                // MediaCodec.BUFFER_FLAG_END_OF_STREAM. However some phones (e.g. Samsung S3)
-                // won't do that for some files (e.g. with mono AAC files), in which case subsequent
-                // calls to dequeueOutputBuffer may result in the application crashing, without
-                // even an exception being thrown... Hence the second check.
-                // (for mono AAC files, the S3 will actually double each sample, as if the stream
-                // was stereo. The resulting stream is half what it's supposed to be and with a much
-                // lower pitch.)
+                Log.w("ACL", "Bailing!!!!!!!!!")
                 break
             }
         }


### PR DESCRIPTION
On older Android versions such as API 28 on some devices the final duration of a voice message media can be miscalculated due to legacy codec flakiness.

This means that we record a voice message, set the correct interim duration during upload, and then set an **incorrect** duration on successful upload.

The fix? Don't set the final upload duration on outgoing voice messages - the interim duration set during upload is always correct.

![image](https://github.com/user-attachments/assets/a4175c58-3ad9-4099-a4b6-fb9c75886563)