### PR TITLE
[SES-3434] - Fix receiving left groups' notification

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -40,6 +40,7 @@ import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.ProcessLifecycleOwner;
 import androidx.work.Configuration;
 
+import com.google.firebase.messaging.FirebaseMessaging;
 import com.squareup.phrase.Phrase;
 
 import org.conscrypt.Conscrypt;
@@ -499,37 +500,6 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
             }
         });
     }
-
-    // Method to clear the local data - returns true on success otherwise false
-    @SuppressLint("ApplySharedPref")
-    public boolean clearAllData() {
-        TextSecurePreferences.clearAll(this);
-        getSharedPreferences(PREFERENCES_NAME, 0).edit().clear().commit();
-        if (!deleteDatabase(SQLCipherOpenHelper.DATABASE_NAME)) {
-            Log.d("Loki", "Failed to delete database.");
-            return false;
-        }
-        configFactory.clearAll();
-        return true;
-    }
-
-    /**
-     * Clear all local profile data and message history then restart the app after a brief delay.
-     * @return true on success, false otherwise.
-     */
-    @SuppressLint("ApplySharedPref")
-    public boolean clearAllDataAndRestart() {
-        clearAllData();
-        Util.runOnMain(() -> new Handler().postDelayed(ApplicationContext.this::restartApplication, 200));
-        return true;
-    }
-
-    public void restartApplication() {
-        Intent intent = new Intent(this, HomeActivity.class);
-        startActivity(Intent.makeRestartActivityTask(intent.getComponent()));
-        Runtime.getRuntime().exit(0);
-    }
-
     // endregion
 
     // Method to wake up the screen and dismiss the keyguard

--- a/app/src/main/java/org/thoughtcrime/securesms/onboarding/messagenotifications/MessageNotificationsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/onboarding/messagenotifications/MessageNotificationsViewModel.kt
@@ -16,14 +16,15 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import network.loki.messenger.R
 import org.session.libsession.utilities.TextSecurePreferences
-import org.thoughtcrime.securesms.ApplicationContext
 import org.thoughtcrime.securesms.onboarding.manager.CreateAccountManager
+import org.thoughtcrime.securesms.util.ClearDataUtils
 
 internal class MessageNotificationsViewModel(
     private val state: State,
     private val application: Application,
     private val prefs: TextSecurePreferences,
-    private val createAccountManager: CreateAccountManager
+    private val createAccountManager: CreateAccountManager,
+    private val clearDataUtils: ClearDataUtils,
 ): AndroidViewModel(application) {
     private val _uiStates = MutableStateFlow(UiState())
     val uiStates = _uiStates.asStateFlow()
@@ -71,8 +72,8 @@ internal class MessageNotificationsViewModel(
     fun quit() {
         _uiStates.update { it.copy(clearData = true) }
 
-        viewModelScope.launch(Dispatchers.IO) {
-            ApplicationContext.getInstance(application).clearAllDataAndRestart()
+        viewModelScope.launch {
+            clearDataUtils.clearAllDataAndRestart()
         }
     }
 
@@ -100,6 +101,7 @@ internal class MessageNotificationsViewModel(
         private val application: Application,
         private val prefs: TextSecurePreferences,
         private val createAccountManager: CreateAccountManager,
+        private val clearDataUtils: ClearDataUtils,
     ) : ViewModelProvider.Factory {
 
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -107,7 +109,8 @@ internal class MessageNotificationsViewModel(
                 state = profileName?.let(State::CreateAccount) ?: State.LoadAccount,
                 application = application,
                 prefs = prefs,
-                createAccountManager = createAccountManager
+                createAccountManager = createAccountManager,
+                clearDataUtils = clearDataUtils,
             ) as T
         }
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/ClearDataUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/ClearDataUtils.kt
@@ -1,0 +1,63 @@
+package org.thoughtcrime.securesms.util
+
+import android.annotation.SuppressLint
+import android.app.Application
+import android.content.Intent
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import org.session.libsession.utilities.TextSecurePreferences
+import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.ApplicationContext
+import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper
+import org.thoughtcrime.securesms.dependencies.ConfigFactory
+import org.thoughtcrime.securesms.home.HomeActivity
+import javax.inject.Inject
+import androidx.core.content.edit
+import kotlinx.coroutines.tasks.await
+
+class ClearDataUtils @Inject constructor(
+    private val application: Application,
+    private val configFactory: ConfigFactory,
+) {
+    // Method to clear the local data - returns true on success otherwise false
+    @SuppressLint("ApplySharedPref")
+    suspend fun clearAllData() {
+        return withContext(Dispatchers.Default) {
+            // Should not proceed if we can't delete db
+            check(application.deleteDatabase(SQLCipherOpenHelper.DATABASE_NAME)) {
+                "Failed to delete database"
+            }
+
+            TextSecurePreferences.clearAll(application)
+            application.getSharedPreferences(ApplicationContext.PREFERENCES_NAME, 0).edit(commit = true) { clear() }
+            configFactory.clearAll()
+
+            // The token deletion is nice but not critical, so don't let it block the rest of the process
+            runCatching {
+                FirebaseMessaging.getInstance().deleteToken().await()
+            }.onFailure { e ->
+                Log.w("ClearDataUtils", "Failed to delete Firebase token: ${e.message}", e)
+            }
+        }
+    }
+
+    /**
+     * Clear all local profile data and message history then restart the app after a brief delay.
+     * @return true on success, false otherwise.
+     */
+    @SuppressLint("ApplySharedPref")
+    suspend fun clearAllDataAndRestart() {
+        clearAllData()
+        delay(200)
+        restartApplication()
+    }
+
+    private fun restartApplication() {
+        val intent = Intent(application, HomeActivity::class.java)
+        application.startActivity(Intent.makeRestartActivityTask(intent.component))
+        Runtime.getRuntime().exit(0)
+    }
+
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/util/ClearDataUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/ClearDataUtils.kt
@@ -54,7 +54,7 @@ class ClearDataUtils @Inject constructor(
         restartApplication()
     }
 
-    private fun restartApplication() {
+    fun restartApplication() {
         val intent = Intent(application, HomeActivity::class.java)
         application.startActivity(Intent.makeRestartActivityTask(intent.component))
         Runtime.getRuntime().exit(0)

--- a/app/src/play/kotlin/org/thoughtcrime/securesms/notifications/FirebaseTokenFetcher.kt
+++ b/app/src/play/kotlin/org/thoughtcrime/securesms/notifications/FirebaseTokenFetcher.kt
@@ -2,11 +2,7 @@ package org.thoughtcrime.securesms.notifications
 
 import com.google.firebase.messaging.FirebaseMessaging
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-
-import kotlinx.coroutines.tasks.await
 import org.session.libsession.messaging.notifications.TokenFetcher
-import org.session.libsignal.utilities.Log
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/app/src/play/kotlin/org/thoughtcrime/securesms/notifications/FirebaseTokenFetcher.kt
+++ b/app/src/play/kotlin/org/thoughtcrime/securesms/notifications/FirebaseTokenFetcher.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 import kotlinx.coroutines.tasks.await
 import org.session.libsession.messaging.notifications.TokenFetcher
+import org.session.libsignal.utilities.Log
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/app/src/test/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModelTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModelTest.kt
@@ -49,6 +49,7 @@ class ConversationViewModelTest: BaseViewModelTest() {
             configFactory = mock(),
             groupManagerV2 = mock(),
             legacyGroupDeprecationManager = mock(),
+            expiredGroupManager = mock()
         )
     }
 


### PR DESCRIPTION
This PR contains two fixes:
1. To request a new FCM token on log out so you don't receive anything from previous session
2. To skip handling of all group related notification if the group is not active
