### PR TITLE
SES-2113 - Never display a username that matches that user's id. 

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/UsernameUtilsImpl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/UsernameUtilsImpl.kt
@@ -46,6 +46,9 @@ class UsernameUtilsImpl(
                 configFactory.withGroupConfigs(groupId) { it.groupMembers.getOrNull(accountID)?.name }
             } else null
 
-        return userName ?: truncateIdForDisplay(accountID)
+        // if the username is actually set to the user's accountId, truncate it
+        val validatedUsername = if(userName == accountID) truncateIdForDisplay(accountID) else userName
+
+        return validatedUsername ?: truncateIdForDisplay(accountID)
     }
 }

--- a/app/src/main/res/layout/view_conversation_action_bar.xml
+++ b/app/src/main/res/layout/view_conversation_action_bar.xml
@@ -17,8 +17,11 @@
 
     <LinearLayout
         android:id="@+id/conversationTitleContainer"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:layout_marginStart="@dimen/medium_spacing"
+        android:paddingEnd="@dimen/medium_spacing"
         android:gravity="center_horizontal|center_vertical"
         android:orientation="vertical">
 


### PR DESCRIPTION
We should never display a user's name if they are set to their sessionId. We should truncate it instead
https://optf.atlassian.net/browse/QA-1034