### PR TITLE
QA Fix ups

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
@@ -1,6 +1,9 @@
 package org.thoughtcrime.securesms.conversation.v2
 
 import android.net.Uri
+import androidx.annotation.DrawableRes
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -87,6 +90,16 @@ class MessageDetailsViewModel @Inject constructor(
 
                 val errorString = lokiMessageDatabase.getErrorMessage(id)
 
+                var status: MessageStatus? = null
+                // create a 'failed to send' status if appropriate
+                if(messageRecord.isFailed){
+                    status = MessageStatus(
+                        title = context.getString(R.string.messageStatusFailedToSend),
+                        icon = R.drawable.ic_triangle_alert,
+                        errorStatus = true
+                    )
+                }
+
                 MessageDetailsState(
                     attachments = slides.map(::Attachment),
                     record = messageRecord,
@@ -109,6 +122,7 @@ class MessageDetailsViewModel @Inject constructor(
                     },
 
                     error = errorString?.let { TitledText(context.getString(R.string.theError) + ":", it) },
+                    status = status,
                     senderInfo = individualRecipient.run { TitledText(name, address.toString()) },
                     sender = individualRecipient,
                     thread = recipient,
@@ -181,6 +195,7 @@ data class MessageDetailsState(
     val sent: TitledText? = null,
     val received: TitledText? = null,
     val error: TitledText? = null,
+    val status: MessageStatus? = null,
     val senderInfo: TitledText? = null,
     val sender: Recipient? = null,
     val thread: Recipient? = null,
@@ -196,6 +211,12 @@ data class Attachment(
     val fileName: String?,
     val uri: Uri?,
     val hasImage: Boolean
+)
+
+data class MessageStatus(
+    val title: String,
+    @DrawableRes val icon: Int,
+    val errorStatus: Boolean
 )
 
 sealed class Event {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -193,14 +193,14 @@ class VisibleMessageContentView : ConstraintLayout {
                     message.slideDeck.documentSlide?.let { slide ->
                         onContentClick.add {
                             // open the document when tapping it
-                            val intent = Intent(Intent.ACTION_VIEW)
-                            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                            intent.setDataAndType(
-                                PartAuthority.getAttachmentPublicUri(slide.uri),
-                                slide.contentType
-                            )
-
                             try {
+                                val intent = Intent(Intent.ACTION_VIEW)
+                                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                intent.setDataAndType(
+                                    PartAuthority.getAttachmentPublicUri(slide.uri),
+                                    slide.contentType
+                                )
+
                                 context.startActivity(intent)
                             } catch (e: ActivityNotFoundException) {
                                 Log.e("VisibleMessageContentView", "Error opening document", e)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -191,24 +191,26 @@ class VisibleMessageContentView : ConstraintLayout {
                 if (mediaDownloaded || mediaInProgress || message.isOutgoing) {
                     binding.documentView.root.bind(message, getTextColor(context, message))
                     message.slideDeck.documentSlide?.let { slide ->
-                        onContentClick.add {
-                            // open the document when tapping it
-                            try {
-                                val intent = Intent(Intent.ACTION_VIEW)
-                                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                intent.setDataAndType(
-                                    PartAuthority.getAttachmentPublicUri(slide.uri),
-                                    slide.contentType
-                                )
+                        if(!mediaInProgress) { // do not attempt to open a doc in progress of downloading
+                            onContentClick.add {
+                                // open the document when tapping it
+                                try {
+                                    val intent = Intent(Intent.ACTION_VIEW)
+                                    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                    intent.setDataAndType(
+                                        PartAuthority.getAttachmentPublicUri(slide.uri),
+                                        slide.contentType
+                                    )
 
-                                context.startActivity(intent)
-                            } catch (e: ActivityNotFoundException) {
-                                Log.e("VisibleMessageContentView", "Error opening document", e)
-                                Toast.makeText(
-                                    context,
-                                    R.string.attachmentsErrorOpen,
-                                    Toast.LENGTH_LONG
-                                ).show()
+                                    context.startActivity(intent)
+                                } catch (e: ActivityNotFoundException) {
+                                    Log.e("VisibleMessageContentView", "Error opening document", e)
+                                    Toast.makeText(
+                                        context,
+                                        R.string.attachmentsErrorOpen,
+                                        Toast.LENGTH_LONG
+                                    ).show()
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/theme/Dimensions.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/theme/Dimensions.kt
@@ -24,6 +24,7 @@ data class Dimensions(
     val borderStroke: Dp = 1.dp,
 
     val badgeSize: Dp = 20.dp,
+    val iconXSmall: Dp = 14.dp,
     val iconMedium: Dp = 24.dp,
     val iconLarge: Dp = 46.dp,
     val iconXLarge: Dp = 60.dp,

--- a/app/src/main/java/org/thoughtcrime/securesms/webrtc/WebRtcCallBridge.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/webrtc/WebRtcCallBridge.kt
@@ -190,7 +190,7 @@ class WebRtcCallBridge @Inject constructor(
             val recipient = getRecipientFromAddress(address)
             
             if (isIncomingMessageExpired(callTime)) {
-                debugToast("Pre offer expired - message timestamp was deemed expired: ${System.currentTimeMillis() - callTime}s")
+                Log.d(TAG, "Pre offer expired - message timestamp was deemed expired: ${System.currentTimeMillis() - callTime}s")
                 insertMissedCall(recipient, true)
                 terminate()
                 return@execute
@@ -207,14 +207,6 @@ class WebRtcCallBridge @Inject constructor(
                     context,
                     listOf(BackgroundPollWorker.Target.ONE_TO_ONE)
                 )
-            }
-        }
-    }
-
-    fun debugToast(message: String) {
-        if (BuildConfig.BUILD_TYPE != "release") {
-            ContextCompat.getMainExecutor(context).execute {
-                Toast.makeText(context, message, Toast.LENGTH_LONG).show()
             }
         }
     }
@@ -327,7 +319,7 @@ class WebRtcCallBridge @Inject constructor(
 
             if (isIncomingMessageExpired(timestamp)) {
                 val didHangup = callManager.postConnectionEvent(Event.TimeOut) {
-                    debugToast("Answer expired - message timestamp was deemed expired: ${System.currentTimeMillis() - timestamp}s")
+                    Log.d(TAG, "Answer expired - message timestamp was deemed expired: ${System.currentTimeMillis() - timestamp}s")
                     insertMissedCall(
                         recipient,
                         true


### PR DESCRIPTION
[SES-3506](https://optf.atlassian.net/browse/SES-3506) - Do not attempt to open documents while they are in progress of being downloaded

[SES-3510](https://optf.atlassian.net/browse/SES-3510) - Removed debugToast and logging results instead

[SES-3516](https://optf.atlassian.net/browse/SES-3516) - Display 'Failed to send' status in Message Details

[SES-3515](https://optf.atlassian.net/browse/SES-3515) - Ensuring we get the current user for outgoing messages in Message Details.
I placed the code in a coroutine and added:
```
val sender = if(messageRecord.isOutgoing){
                        Recipient.from(context, Address.fromSerialized(prefs.getLocalNumber() ?: ""), false)
                    } else individualRecipient
                    