### PR TITLE
Move getSwarm into try catch

### DIFF
--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
@@ -107,21 +107,20 @@ class Poller(
             Log.d(TAG, "Polling...")
 
             isPolling = true
-
-            // check if the polling pool is empty
-            if(pollPool.isEmpty()){
-                // if it is empty, fill it with the snodes from our swarm
-                pollPool.addAll(SnodeAPI.getSwarm(userPublicKey).await())
-            }
-
-            // randomly get a snode from the pool
-            val currentNode = pollPool.random()
-
-            // remove that snode from the pool
-            pollPool.remove(currentNode)
-
             var pollDelay = RETRY_INTERVAL_MS
             try {
+                // check if the polling pool is empty
+                if (pollPool.isEmpty()){
+                    // if it is empty, fill it with the snodes from our swarm
+                    pollPool.addAll(SnodeAPI.getSwarm(userPublicKey).await())
+                }
+
+                // randomly get a snode from the pool
+                val currentNode = pollPool.random()
+
+                // remove that snode from the pool
+                pollPool.remove(currentNode)
+
                 poll(currentNode)
                 retryScalingFactor = 1f
             } catch (e: Exception){


### PR DESCRIPTION
This PR fixes a crash where you go into the app while you are offline. The root cause is that when the 1on1 poll starting, it calls `getSwarm`, however it's outside our `try..catch...` block for the polling logic, hence the exception flows to the top and crashes the app.

The fix should be pretty safe itself.
