### PR TITLE
Update deprecation starting time for testing

### DIFF
--- a/libsession/src/main/java/org/session/libsession/messaging/groups/LegacyGroupDeprecationManager.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/groups/LegacyGroupDeprecationManager.kt
@@ -33,7 +33,7 @@ class LegacyGroupDeprecationManager(private val prefs: TextSecurePreferences)  {
     val deprecatedTime: StateFlow<ZonedDateTime> get() = mutableDeprecatedTime
 
     // The time a warning will be shown to users that legacy groups are being deprecated.
-    private val defaultDeprecatingStartTime = ZonedDateTime.of(2025, 3, 19, 22, 0, 0, 0, ZoneId.of("UTC"))
+    private val defaultDeprecatingStartTime = ZonedDateTime.of(2025, 3, 13, 22, 0, 0, 0, ZoneId.of("UTC"))
 
     private val mutableDeprecatingStartTime: MutableStateFlow<ZonedDateTime> = MutableStateFlow(
         prefs.deprecatingStartTimeOverride ?: defaultDeprecatingStartTime


### PR DESCRIPTION
Updated the time so that we can have groupv2 on for regression testing.
