### PR TITLE
Retyped the libSession wrapper in preparation of the 1.3.0 changes

### DIFF
--- a/libsession-util/src/main/cpp/CMakeLists.txt
+++ b/libsession-util/src/main/cpp/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.18.1)
 project("session_util")
 
 # Compiles in C++17 mode
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/libsession-util/src/main/cpp/blinded_key.cpp
+++ b/libsession-util/src/main/cpp/blinded_key.cpp
@@ -14,11 +14,11 @@ Java_network_loki_messenger_libsession_1util_util_BlindKeyAPI_blindVersionKeyPai
                                                                                   jobject thiz,
                                                                                   jbyteArray ed25519_secret_key) {
     return jni_utils::run_catching_cxx_exception_or_throws<jobject>(env, [=] {
-        const auto [pk, sk] = session::blind_version_key_pair(util::ustring_from_bytes(env, ed25519_secret_key));
+        const auto [pk, sk] = session::blind_version_key_pair(util::vector_from_bytes(env, ed25519_secret_key));
 
         jclass kp_class = env->FindClass("network/loki/messenger/libsession_util/util/KeyPair");
         jmethodID kp_constructor = env->GetMethodID(kp_class, "<init>", "([B[B)V");
-        return env->NewObject(kp_class, kp_constructor, util::bytes_from_ustring(env, {pk.data(), pk.size()}), util::bytes_from_ustring(env, {sk.data(), sk.size()}));
+        return env->NewObject(kp_class, kp_constructor, util::bytes_from_vector(env, {pk.data(), pk.data() + pk.size()}), util::bytes_from_vector(env, {sk.data(), sk.data() + sk.size()}));
     });
 }
 extern "C"
@@ -28,7 +28,7 @@ Java_network_loki_messenger_libsession_1util_util_BlindKeyAPI_blindVersionSign(J
                                                                                jbyteArray ed25519_secret_key,
                                                                                jlong timestamp) {
     return jni_utils::run_catching_cxx_exception_or_throws<jbyteArray>(env, [=] {
-        auto bytes = session::blind_version_sign(util::ustring_from_bytes(env, ed25519_secret_key), session::Platform::android, timestamp);
-        return util::bytes_from_ustring(env, bytes);
+        auto bytes = session::blind_version_sign(util::vector_from_bytes(env, ed25519_secret_key), session::Platform::android, timestamp);
+        return util::bytes_from_vector(env, bytes);
     });
 }

--- a/libsession-util/src/main/cpp/config_base.cpp
+++ b/libsession-util/src/main/cpp/config_base.cpp
@@ -32,7 +32,7 @@ Java_network_loki_messenger_libsession_1util_ConfigBase_push(JNIEnv *env, jobjec
     auto to_push_str = std::get<1>(push_tuple);
     auto to_delete = std::get<2>(push_tuple);
 
-    jbyteArray returnByteArray = util::bytes_from_ustring(env, to_push_str);
+    jbyteArray returnByteArray = util::bytes_from_vector(env, to_push_str);
     jlong seqNo = std::get<0>(push_tuple);
     jclass returnObjectClass = env->FindClass("network/loki/messenger/libsession_util/util/ConfigPush");
     jclass stackClass = env->FindClass("java/util/Stack");
@@ -59,7 +59,7 @@ Java_network_loki_messenger_libsession_1util_ConfigBase_dump(JNIEnv *env, jobjec
     std::lock_guard lock{util::util_mutex_};
     auto config = ptrToConfigBase(env, thiz);
     auto dumped = config->dump();
-    jbyteArray bytes = util::bytes_from_ustring(env, dumped);
+    jbyteArray bytes = util::bytes_from_vector(env, dumped);
     return bytes;
 }
 
@@ -90,7 +90,7 @@ Java_network_loki_messenger_libsession_1util_ConfigBase_merge___3Lkotlin_Pair_2(
         std::lock_guard lock{util::util_mutex_};
         auto conf = ptrToConfigBase(env, thiz);
         size_t number = env->GetArrayLength(to_merge);
-        std::vector<std::pair<std::string, session::ustring>> configs = {};
+        std::vector<std::pair<std::string, std::vector<unsigned char>>> configs = {};
         for (int i = 0; i < number; i++) {
             auto jElement = (jobject) env->GetObjectArrayElement(to_merge, i);
             auto pair = extractHashAndData(env, jElement);

--- a/libsession-util/src/main/cpp/config_base.h
+++ b/libsession-util/src/main/cpp/config_base.h
@@ -12,15 +12,15 @@ inline session::config::ConfigBase* ptrToConfigBase(JNIEnv *env, jobject obj) {
     return (session::config::ConfigBase*) env->GetLongField(obj, pointerField);
 }
 
-inline std::pair<std::string, session::ustring> extractHashAndData(JNIEnv *env, jobject kotlin_pair) {
+inline std::pair<std::string, std::vector<unsigned char>> extractHashAndData(JNIEnv *env, jobject kotlin_pair) {
     jclass pair = env->FindClass("kotlin/Pair");
     jfieldID first = env->GetFieldID(pair, "first", "Ljava/lang/Object;");
     jfieldID second = env->GetFieldID(pair, "second", "Ljava/lang/Object;");
     jstring hash_as_jstring = static_cast<jstring>(env->GetObjectField(kotlin_pair, first));
     jbyteArray data_as_jbytes = static_cast<jbyteArray>(env->GetObjectField(kotlin_pair, second));
     auto hash_as_string = env->GetStringUTFChars(hash_as_jstring, nullptr);
-    auto data_as_ustring = util::ustring_from_bytes(env, data_as_jbytes);
-    auto ret_pair = std::pair<std::string, session::ustring>{hash_as_string, data_as_ustring};
+    auto data_as_vector = util::vector_from_bytes(env, data_as_jbytes);
+    auto ret_pair = std::pair<std::string, std::vector<unsigned char>>{hash_as_string, data_as_vector};
     env->ReleaseStringUTFChars(hash_as_jstring, hash_as_string);
     return ret_pair;
 }

--- a/libsession-util/src/main/cpp/config_common.cpp
+++ b/libsession-util/src/main/cpp/config_common.cpp
@@ -17,9 +17,9 @@ Java_network_loki_messenger_libsession_1util_ConfigKt_createConfigObject(
         jbyteArray initial_dump) {
     return jni_utils::run_catching_cxx_exception_or_throws<jlong>(env, [=] {
         auto config_name = util::string_from_jstring(env, java_config_name);
-        auto secret_key = util::ustring_from_bytes(env, ed25519_secret_key);
+        auto secret_key = util::vector_from_bytes(env, ed25519_secret_key);
         auto initial = initial_dump
-                       ? std::optional(util::ustring_from_bytes(env, initial_dump))
+                       ? std::optional(util::vector_from_bytes(env, initial_dump))
                        : std::nullopt;
 
 

--- a/libsession-util/src/main/cpp/contacts.h
+++ b/libsession-util/src/main/cpp/contacts.h
@@ -2,6 +2,7 @@
 #define SESSION_ANDROID_CONTACTS_H
 
 #include <jni.h>
+#include <vector>
 #include "session/config/contacts.hpp"
 #include "util.h"
 
@@ -58,7 +59,7 @@ inline session::config::contact_info deserialize_contact(JNIEnv *env, jobject in
     auto expiry_pair = util::deserialize_expiry(env, expiry_mode);
 
     std::string url;
-    session::ustring key;
+    std::vector<unsigned char> key;
 
     if (user_pic != nullptr) {
         auto deserialized_pic = util::deserialize_user_pic(env, user_pic);
@@ -66,7 +67,7 @@ inline session::config::contact_info deserialize_contact(JNIEnv *env, jobject in
         auto url_bytes = env->GetStringUTFChars(url_jstring, nullptr);
         url = std::string(url_bytes);
         env->ReleaseStringUTFChars(url_jstring, url_bytes);
-        key = util::ustring_from_bytes(env, deserialized_pic.second);
+        key = util::vector_from_bytes(env, deserialized_pic.second);
     }
 
     auto account_id_bytes = env->GetStringUTFChars(account_id, nullptr);

--- a/libsession-util/src/main/cpp/conversation.cpp
+++ b/libsession-util/src/main/cpp/conversation.cpp
@@ -152,8 +152,8 @@ Java_network_loki_messenger_libsession_1util_ConversationVolatileConfig_getOrCon
     auto convos = ptrToConvoInfo(env, thiz);
     auto base_url_chars = env->GetStringUTFChars(base_url, nullptr);
     auto room_chars = env->GetStringUTFChars(room, nullptr);
-    auto pub_key_ustring = util::ustring_from_bytes(env, pub_key);
-    auto open = convos->get_or_construct_community(base_url_chars, room_chars, pub_key_ustring);
+    auto pub_key_vector = util::vector_from_bytes(env, pub_key);
+    auto open = convos->get_or_construct_community(base_url_chars, room_chars, pub_key_vector);
     auto serialized = serialize_open_group(env, open);
     return serialized;
 }

--- a/libsession-util/src/main/cpp/group_info.cpp
+++ b/libsession-util/src/main/cpp/group_info.cpp
@@ -10,15 +10,15 @@ Java_network_loki_messenger_libsession_1util_GroupInfoConfig_00024Companion_newI
                                                                                         jbyteArray secret_key,
                                                                                         jbyteArray initial_dump) {
     std::lock_guard guard{util::util_mutex_};
-    std::optional<session::ustring> secret_key_optional{std::nullopt};
-    std::optional<session::ustring> initial_dump_optional{std::nullopt};
-    auto pub_key_bytes = util::ustring_from_bytes(env, pub_key);
+    std::optional<std::vector<unsigned char>> secret_key_optional{std::nullopt};
+    std::optional<std::vector<unsigned char>> initial_dump_optional{std::nullopt};
+    auto pub_key_bytes = util::vector_from_bytes(env, pub_key);
     if (secret_key && env->GetArrayLength(secret_key) > 0) {
-        auto secret_key_bytes = util::ustring_from_bytes(env, secret_key);
+        auto secret_key_bytes = util::vector_from_bytes(env, secret_key);
         secret_key_optional = secret_key_bytes;
     }
     if (initial_dump && env->GetArrayLength(initial_dump) > 0) {
-        auto initial_dump_bytes = util::ustring_from_bytes(env, initial_dump);
+        auto initial_dump_bytes = util::vector_from_bytes(env, initial_dump);
         initial_dump_optional = initial_dump_bytes;
     }
 
@@ -159,7 +159,7 @@ Java_network_loki_messenger_libsession_1util_GroupInfoConfig_setProfilePic(JNIEn
     auto group_info = ptrToInfo(env, thiz);
     auto user_pic = util::deserialize_user_pic(env, new_profile_pic);
     auto url = env->GetStringUTFChars(user_pic.first, nullptr);
-    auto key = util::ustring_from_bytes(env, user_pic.second);
+    auto key = util::vector_from_bytes(env, user_pic.second);
     group_info->set_profile_pic(url, key);
     env->ReleaseStringUTFChars(user_pic.first, url);
 }

--- a/libsession-util/src/main/cpp/group_members.cpp
+++ b/libsession-util/src/main/cpp/group_members.cpp
@@ -8,15 +8,15 @@ Java_network_loki_messenger_libsession_1util_GroupMembersConfig_00024Companion_n
         JNIEnv *env, jobject thiz, jbyteArray pub_key, jbyteArray secret_key,
         jbyteArray initial_dump) {
     std::lock_guard lock{util::util_mutex_};
-    auto pub_key_bytes = util::ustring_from_bytes(env, pub_key);
-    std::optional<session::ustring> secret_key_optional{std::nullopt};
-    std::optional<session::ustring> initial_dump_optional{std::nullopt};
+    auto pub_key_bytes = util::vector_from_bytes(env, pub_key);
+    std::optional<std::vector<unsigned char>> secret_key_optional{std::nullopt};
+    std::optional<std::vector<unsigned char>> initial_dump_optional{std::nullopt};
     if (secret_key && env->GetArrayLength(secret_key) > 0) {
-        auto secret_key_bytes = util::ustring_from_bytes(env, secret_key);
+        auto secret_key_bytes = util::vector_from_bytes(env, secret_key);
         secret_key_optional = secret_key_bytes;
     }
     if (initial_dump && env->GetArrayLength(initial_dump) > 0) {
-        auto initial_dump_bytes = util::ustring_from_bytes(env, initial_dump);
+        auto initial_dump_bytes = util::vector_from_bytes(env, initial_dump);
         initial_dump_optional = initial_dump_bytes;
     }
 
@@ -209,7 +209,7 @@ Java_network_loki_messenger_libsession_1util_util_GroupMember_setProfilePic(JNIE
                                                                             jobject pic) {
     const auto [jurl, jkey] = util::deserialize_user_pic(env, pic);
     auto url = util::string_from_jstring(env, jurl);
-    auto key = util::ustring_from_bytes(env, jkey);
+    auto key = util::vector_from_bytes(env, jkey);
     auto &picture = ptrToMember(env, thiz)->profile_picture;
     picture.url = url;
     picture.key = key;

--- a/libsession-util/src/main/cpp/user_groups.cpp
+++ b/libsession-util/src/main/cpp/user_groups.cpp
@@ -339,8 +339,8 @@ Java_network_loki_messenger_libsession_1util_util_GroupInfo_00024ClosedGroupInfo
 
     auto seed_bytes = env->GetByteArrayElements(seed, nullptr);
     auto admin_key = session::ed25519::ed25519_key_pair(
-            session::ustring_view(reinterpret_cast<unsigned char *>(seed_bytes), 32)).second;
+            std::span<const unsigned char>(reinterpret_cast<const unsigned char *>(seed_bytes), 32)).second;
     env->ReleaseByteArrayElements(seed, seed_bytes, 0);
 
-    return util::bytes_from_ustring(env, session::ustring_view(admin_key.data(), admin_key.size()));
+    return util::bytes_from_span(env, std::span<const unsigned char>(admin_key.data(), admin_key.size()));
 }

--- a/libsession-util/src/main/cpp/user_groups.h
+++ b/libsession-util/src/main/cpp/user_groups.h
@@ -62,8 +62,8 @@ inline session::config::legacy_group_info deserialize_legacy_group_info(JNIEnv *
 
     auto id_bytes = util::string_from_jstring(env, id);
     auto name_bytes = env->GetStringUTFChars(name, nullptr);
-    auto enc_pub_key_bytes = util::ustring_from_bytes(env, enc_pub_key);
-    auto enc_sec_key_bytes = util::ustring_from_bytes(env, enc_sec_key);
+    auto enc_pub_key_bytes = util::vector_from_bytes(env, enc_pub_key);
+    auto enc_sec_key_bytes = util::vector_from_bytes(env, enc_sec_key);
 
     auto info_deserialized = conf->get_or_construct_legacy_group(id_bytes);
 
@@ -115,8 +115,8 @@ inline jobject serialize_legacy_group_info(JNIEnv *env, session::config::legacy_
     jstring account_id = env->NewStringUTF(info.session_id.data());
     jstring name = env->NewStringUTF(info.name.data());
     jobject members = serialize_members(env, info.members());
-    jbyteArray enc_pubkey = util::bytes_from_ustring(env, info.enc_pubkey);
-    jbyteArray enc_seckey = util::bytes_from_ustring(env, info.enc_seckey);
+    jbyteArray enc_pubkey = util::bytes_from_vector(env, info.enc_pubkey);
+    jbyteArray enc_seckey = util::bytes_from_vector(env, info.enc_seckey);
     long long priority = info.priority;
     long long joined_at = info.joined_at;
 
@@ -128,8 +128,8 @@ inline jobject serialize_legacy_group_info(JNIEnv *env, session::config::legacy_
 
 inline jobject serialize_closed_group_info(JNIEnv* env, session::config::group_info info) {
     auto session_id = util::serialize_account_id(env, info.id);
-    jbyteArray admin_bytes = info.secretkey.empty() ? nullptr : util::bytes_from_ustring(env, info.secretkey);
-    jbyteArray auth_bytes = info.auth_data.empty() ? nullptr : util::bytes_from_ustring(env, info.auth_data);
+    jbyteArray admin_bytes = info.secretkey.empty() ? nullptr : util::bytes_from_vector(env, info.secretkey);
+    jbyteArray auth_bytes = info.auth_data.empty() ? nullptr : util::bytes_from_vector(env, info.auth_data);
     jstring name = util::jstringFromOptional(env, info.name);
 
     jclass group_info_class = env->FindClass("network/loki/messenger/libsession_util/util/GroupInfo$ClosedGroupInfo");
@@ -159,8 +159,8 @@ inline session::config::group_info deserialize_closed_group_info(JNIEnv* env, jo
     jstring name_jstring = (jstring)env->GetObjectField(info_serialized, name_field);
 
     auto id_bytes = util::deserialize_account_id(env, id_jobject);
-    auto secret_bytes = util::ustring_from_bytes(env, secret_jBytes);
-    auto auth_bytes = util::ustring_from_bytes(env, auth_jBytes);
+    auto secret_bytes = util::vector_from_bytes(env, secret_jBytes);
+    auto auth_bytes = util::vector_from_bytes(env, auth_jBytes);
     auto name = util::string_from_jstring(env, name_jstring);
 
     session::config::group_info group_info(id_bytes);

--- a/libsession-util/src/main/cpp/user_profile.cpp
+++ b/libsession-util/src/main/cpp/user_profile.cpp
@@ -42,7 +42,7 @@ Java_network_loki_messenger_libsession_1util_UserProfile_setPic(JNIEnv *env, job
     auto profile = ptrToProfile(env, thiz);
     auto pic = util::deserialize_user_pic(env, user_pic);
     auto url = env->GetStringUTFChars(pic.first, nullptr);
-    auto key = util::ustring_from_bytes(env, pic.second);
+    auto key = util::vector_from_bytes(env, pic.second);
     profile->set_profile_pic(url, key);
     env->ReleaseStringUTFChars(pic.first, url);
 }

--- a/libsession-util/src/main/cpp/util.h
+++ b/libsession-util/src/main/cpp/util.h
@@ -4,6 +4,8 @@
 #include <jni.h>
 #include <array>
 #include <optional>
+#include <span>
+#include <vector>
 #include "session/types.hpp"
 #include "session/config/groups/info.hpp"
 #include "session/config/groups/keys.hpp"
@@ -14,8 +16,9 @@
 
 namespace util {
     extern std::mutex util_mutex_;
-    jbyteArray bytes_from_ustring(JNIEnv* env, session::ustring_view from_str);
-    session::ustring ustring_from_bytes(JNIEnv* env, jbyteArray byteArray);
+    jbyteArray bytes_from_vector(JNIEnv* env, std::vector<unsigned char> from_str);
+    std::vector<unsigned char> vector_from_bytes(JNIEnv* env, jbyteArray byteArray);
+    jbyteArray bytes_from_span(JNIEnv* env, std::span<const unsigned char> from_str);
     std::string string_from_jstring(JNIEnv* env, jstring string);
     jobject serialize_user_pic(JNIEnv *env, session::config::profile_pic pic);
     std::pair<jstring, jbyteArray> deserialize_user_pic(JNIEnv *env, jobject user_pic);


### PR DESCRIPTION
In order to properly support libc++18 (and clang-19) no longer support the `ustring`/`ustring_view` convention we were using and as such we were forced to update a number of our libraries to replace this convention with a more standard approach (we settled on `std::vector<unsigned char>` and `std::span<const unsigned char>`)

This "retyping" also affected `libSession` which means there are a number of breaking changes in the next version made as part of https://github.com/session-foundation/libsession-util/pull/26

This PR updates the libSession wrapper code to support these changes

**Note:** This shouldn't be merged until after https://github.com/session-foundation/libsession-util/pull/26 has been merged