### PR TITLE
[SES-3564] - Fix crash replying on push notification

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
@@ -109,7 +109,7 @@ public class RemoteReplyReceiver extends BroadcastReceiver {
             case GroupMessage: {
               OutgoingMediaMessage reply = OutgoingMediaMessage.from(message, recipient, Collections.emptyList(), null, null, expiresInMillis, 0);
               try {
-                mmsDatabase.insertMessageOutbox(reply, threadId, false, null, true);
+                message.setId(mmsDatabase.insertMessageOutbox(reply, threadId, false, null, true));
                 MessageSender.send(message, address);
               } catch (MmsException e) {
                 Log.w(TAG, e);
@@ -118,7 +118,7 @@ public class RemoteReplyReceiver extends BroadcastReceiver {
             }
             case SecureMessage: {
               OutgoingTextMessage reply = OutgoingTextMessage.from(message, recipient, expiresInMillis, expireStartedAt);
-              smsDatabase.insertMessageOutbox(threadId, reply, false, System.currentTimeMillis(), null, true);
+              message.setId(smsDatabase.insertMessageOutbox(threadId, reply, false, System.currentTimeMillis(), null, true));
               MessageSender.send(message, address);
               break;
             }

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
@@ -430,7 +430,8 @@ object MessageSender {
 
     // Result Handling
     fun handleSuccessfulMessageSend(message: Message, destination: Destination, isSyncMessage: Boolean = false, openGroupSentTimestamp: Long = -1) {
-        if (message is VisibleMessage) MessagingModuleConfiguration.shared.lastSentTimestampCache.submitTimestamp(message.threadID!!, openGroupSentTimestamp)
+        val threadId = message.threadID!!
+        if (message is VisibleMessage) MessagingModuleConfiguration.shared.lastSentTimestampCache.submitTimestamp(threadId, openGroupSentTimestamp)
         val storage = MessagingModuleConfiguration.shared.storage
         val userPublicKey = storage.getUserPublicKey()!!
         val timestamp = message.sentTimestamp!!
@@ -439,7 +440,7 @@ object MessageSender {
         storage.getMessageIdInDatabase(timestamp, userPublicKey)?.let { (messageID, mms) ->
             if (openGroupSentTimestamp != -1L && message is VisibleMessage) {
                 storage.addReceivedMessageTimestamp(openGroupSentTimestamp)
-                storage.updateSentTimestamp(messageID, message.isMediaMessage(), openGroupSentTimestamp, message.threadID!!)
+                storage.updateSentTimestamp(messageID, message.isMediaMessage(), openGroupSentTimestamp, threadId)
                 message.sentTimestamp = openGroupSentTimestamp
             }
 
@@ -488,8 +489,11 @@ object MessageSender {
             // Fixed in: https://optf.atlassian.net/browse/SES-1567
             if (messageIsAddressedToCommunity)
             {
-                storage.markAsSentToCommunity(message.threadID!!, message.id!!)
-                storage.markUnidentifiedInCommunity(message.threadID!!, message.id!!)
+                val messageId = message.id
+                if (messageId != null) {
+                    storage.markAsSentToCommunity(threadId, messageId)
+                    storage.markUnidentifiedInCommunity(threadId, messageId)
+                }
             }
             else
             {


### PR DESCRIPTION
Basically the reply code should have the message ID set after inserting into the db.
