### PR TITLE
[ses-3567] - fix error sending group invite

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManagerV2Impl.kt
@@ -299,6 +299,8 @@ class GroupManagerV2Impl @Inject constructor(
                 configs.groupInfo.getName().orEmpty()
             }
 
+            Log.w(TAG, "Failed to invite members to group $group", e)
+
             throw GroupInviteException(
                 isPromotion = false,
                 inviteeAccountIds = newMembers.map { it.hexString },

--- a/libsession/src/main/java/org/session/libsession/messaging/jobs/InviteContactsJob.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/jobs/InviteContactsJob.kt
@@ -115,6 +115,11 @@ class InviteContactsJob(val groupSessionId: String, val memberSessionIds: Array<
 
                 val (_, firstError) = failures.first()
 
+                // Add the rest of the exceptions as suppressed
+                for ((_, suppressed) in failures.asSequence().drop(1)) {
+                    firstError.addSuppressed(suppressed)
+                }
+
                 Log.w("InviteContactsJob", "Failed to invite contacts", firstError)
 
                 GroupInviteException(

--- a/libsession/src/main/java/org/session/libsession/messaging/jobs/InviteContactsJob.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/jobs/InviteContactsJob.kt
@@ -101,7 +101,11 @@ class InviteContactsJob(val groupSessionId: String, val memberSessionIds: Array<
             val groupName = configs.withGroupConfigs(sessionId) { it.groupInfo.getName() }
                 ?: configs.getGroup(sessionId)?.name
 
-            val failures = results.filter { it.second.isFailure }
+            // Gather all the exceptions, while keeping track of the invitee account IDs
+            val failures = results.mapNotNull { (id, result) ->
+                result.exceptionOrNull()?.let { err -> id to err }
+            }
+
             // if there are failed invites, display a message
             // assume job "success" even if we fail, the state of invites is tracked outside of this job
             if (failures.isNotEmpty()) {
@@ -109,14 +113,15 @@ class InviteContactsJob(val groupSessionId: String, val memberSessionIds: Array<
                 val storage = MessagingModuleConfiguration.shared.storage
                 val toaster = MessagingModuleConfiguration.shared.toaster
 
-                val underlying = failures.first().second.exceptionOrNull()!!
+                val (_, firstError) = failures.first()
 
-                Log.w("InviteContactsJob", "Failed to invite contacts", underlying)
+                Log.w("InviteContactsJob", "Failed to invite contacts", firstError)
+
                 GroupInviteException(
                     isPromotion = false,
                     inviteeAccountIds = failures.map { it.first },
                     groupName = groupName.orEmpty(),
-                    underlying = underlying,
+                    underlying = firstError,
                 ).format(MessagingModuleConfiguration.shared.context, storage).let {
                     withContext(Dispatchers.Main) {
                         toaster.toast(it, Toast.LENGTH_LONG)

--- a/libsession/src/main/java/org/session/libsession/messaging/jobs/InviteContactsJob.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/jobs/InviteContactsJob.kt
@@ -21,6 +21,7 @@ import org.session.libsession.utilities.getGroup
 import org.session.libsignal.protos.SignalServiceProtos.DataMessage.GroupUpdateInviteMessage
 import org.session.libsignal.protos.SignalServiceProtos.DataMessage.GroupUpdateMessage
 import org.session.libsignal.utilities.AccountId
+import org.session.libsignal.utilities.Log
 
 class InviteContactsJob(val groupSessionId: String, val memberSessionIds: Array<String>) : Job {
 
@@ -108,11 +109,14 @@ class InviteContactsJob(val groupSessionId: String, val memberSessionIds: Array<
                 val storage = MessagingModuleConfiguration.shared.storage
                 val toaster = MessagingModuleConfiguration.shared.toaster
 
+                val underlying = failures.first().second.exceptionOrNull()!!
+
+                Log.w("InviteContactsJob", "Failed to invite contacts", underlying)
                 GroupInviteException(
                     isPromotion = false,
                     inviteeAccountIds = failures.map { it.first },
                     groupName = groupName.orEmpty(),
-                    underlying = failures.first().second.exceptionOrNull()!!,
+                    underlying = underlying,
                 ).format(MessagingModuleConfiguration.shared.context, storage).let {
                     withContext(Dispatchers.Main) {
                         toaster.toast(it, Toast.LENGTH_LONG)

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
@@ -430,7 +430,7 @@ object MessageSender {
 
     // Result Handling
     fun handleSuccessfulMessageSend(message: Message, destination: Destination, isSyncMessage: Boolean = false, openGroupSentTimestamp: Long = -1) {
-        val threadId = message.threadID!!
+        val threadId by lazy { requireNotNull(message.threadID) { "threadID for the message is null" } }
         if (message is VisibleMessage) MessagingModuleConfiguration.shared.lastSentTimestampCache.submitTimestamp(threadId, openGroupSentTimestamp)
         val storage = MessagingModuleConfiguration.shared.storage
         val userPublicKey = storage.getUserPublicKey()!!
@@ -473,9 +473,9 @@ object MessageSender {
                     }
                 }
                 val encoded = GroupUtil.getEncodedOpenGroupID("$server.$room".toByteArray())
-                val threadID = storage.getThreadId(Address.fromSerialized(encoded))
-                if (threadID != null && threadID >= 0) {
-                    storage.setOpenGroupServerMessageID(messageID, message.openGroupServerMessageID!!, threadID, !(message as VisibleMessage).isMediaMessage())
+                val communityThreadID = storage.getThreadId(Address.fromSerialized(encoded))
+                if (communityThreadID != null && communityThreadID >= 0) {
+                    storage.setOpenGroupServerMessageID(messageID, message.openGroupServerMessageID!!, communityThreadID, !(message as VisibleMessage).isMediaMessage())
                 }
             }
 


### PR DESCRIPTION
Basically you can't assume we always have `threadId` for a message.
