### PR TITLE
Fixing gradient issue on older android versions

### DIFF
--- a/app/src/main/res/drawable/fade_gradient.xml
+++ b/app/src/main/res/drawable/fade_gradient.xml
@@ -5,7 +5,7 @@
 
     <gradient
         android:centerY="0.75"
-        android:centerColor="#00000000"
+        android:centerColor="?transparent"
         android:endColor="?colorPrimary"
         android:angle="270" />
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -23,6 +23,7 @@
     <attr name="textColorAlert" format="reference|color"/>
     <attr name="elementBorderColor" format="reference|color"/>
     <attr name="conversation_background" format="reference|color"/>
+    <attr name="transparent" format="reference|color"/>
 
     <attr name="emoji_text_color" format="color" />
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -43,6 +43,7 @@
        <item name="onInvertedBackgroundPrimary">?colorPrimary</item>
        <item name="prominentButtonColor">?colorAccent</item>
        <item name="colorError">?danger</item>
+       <item name="transparent">@color/transparent</item>
 
        <item name="android:actionMenuTextAppearance">@style/MenuTextAppearance</item>
    </style>


### PR DESCRIPTION
Older versions of android can't deal with gradients that use a mix of hex colors and theme attributes.
So I created a theme attribute for transparency...
This it to help with: [SES-3581](https://optf.atlassian.net/browse/SES-3581)