### PR TITLE
New ui for failed attachment control

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.conversation.v2
 
 import android.net.Uri
+import android.text.format.Formatter
 import androidx.annotation.DrawableRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -180,7 +181,7 @@ class MessageDetailsViewModel @Inject constructor(
         get() = listOfNotNull(
             TitledText(R.string.attachmentsFileId, filename),
             TitledText(R.string.attachmentsFileType, asAttachment().contentType),
-            TitledText(R.string.attachmentsFileSize, Util.getPrettyFileSize(fileSize)),
+            TitledText(R.string.attachmentsFileSize, Formatter.formatFileSize(context, fileSize)),
             takeIf { it is ImageSlide }
                 ?.let(Slide::asAttachment)
                 ?.run { "${width}x$height" }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ViewUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ViewUtil.java
@@ -180,6 +180,14 @@ public final class ViewUtil {
     }
   }
 
+  public static String safeRTLString(@NonNull Context context, @NonNull String text) {
+    return isLtr(context) ?
+            "\u200E" + text + "\u200E" :
+            "\u200F" + text + "\u200F";
+  }
+
+
+
   public static boolean isLtr(@NonNull View view) {
     return isLtr(view.getContext());
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/AttachmentControlView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/AttachmentControlView.kt
@@ -88,6 +88,7 @@ class AttachmentControlView: LinearLayout {
 
                 binding.separator.isVisible = false
                 binding.pendingDownloadSubtitle.isVisible = false
+                binding.errorIcon.isVisible = false
             }
 
             AttachmentState.DOWNLOADING -> {
@@ -112,6 +113,7 @@ class AttachmentControlView: LinearLayout {
                 }
 
                 binding.pendingDownloadSubtitle.isVisible = false
+                binding.errorIcon.isVisible = false
             }
 
             AttachmentState.FAILED -> {
@@ -119,22 +121,23 @@ class AttachmentControlView: LinearLayout {
 
                 binding.pendingDownloadSize.apply {
                     text = totalSize
-                    setTextColor(errorColor)
+                    setTextColor(textColor)
                     isVisible = true
                 }
 
                 binding.pendingDownloadTitle.apply{
                     text = context.getString(R.string.failedToDownload)
-                    setTextColor(errorColor)
+                    setTextColor(textColor)
                     setTypeface(typeface, android.graphics.Typeface.NORMAL)
                 }
 
                 binding.separator.apply {
-                    imageTintList = ColorStateList.valueOf(errorColor)
+                    imageTintList = ColorStateList.valueOf(textColor)
                     isVisible = true
                 }
 
                 binding.pendingDownloadSubtitle.isVisible = true
+                binding.errorIcon.isVisible = true
             }
 
             else -> {
@@ -160,6 +163,7 @@ class AttachmentControlView: LinearLayout {
                 }
 
                 binding.pendingDownloadSubtitle.isVisible = false
+                binding.errorIcon.isVisible = false
             }
         }
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/AttachmentControlView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/AttachmentControlView.kt
@@ -1,7 +1,7 @@
 package org.thoughtcrime.securesms.conversation.v2.messages
 
 import android.content.Context
-import android.content.res.ColorStateList
+import android.text.format.Formatter
 import android.util.AttributeSet
 import android.widget.LinearLayout
 import androidx.annotation.ColorInt
@@ -14,9 +14,8 @@ import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.sending_receiving.attachments.AttachmentState
 import org.session.libsession.messaging.sending_receiving.attachments.DatabaseAttachment
 import org.session.libsession.utilities.StringSubstitutionConstants.FILE_TYPE_KEY
-import org.session.libsession.utilities.Util
-import org.session.libsession.utilities.getColorFromAttr
 import org.session.libsession.utilities.recipients.Recipient
+import org.thoughtcrime.securesms.conversation.v2.ViewUtil
 import org.thoughtcrime.securesms.conversation.v2.dialogs.AutoDownloadDialog
 import org.thoughtcrime.securesms.mms.Slide
 import org.thoughtcrime.securesms.ui.findActivity
@@ -67,8 +66,7 @@ class AttachmentControlView: LinearLayout {
     ) {
         val (stringRes, iconRes) = getAttachmentData(attachmentType, allMessageAttachments.size)
 
-        val totalSize = Util.getPrettyFileSize(allMessageAttachments.sumOf { it.fileSize })
-
+        val totalSize = Formatter.formatFileSize(context, allMessageAttachments.sumOf { it.fileSize })
         binding.pendingDownloadIcon.setImageResource(iconRes)
 
         when(state){
@@ -91,7 +89,8 @@ class AttachmentControlView: LinearLayout {
                 binding.pendingDownloadIcon.setColorFilter(textColor)
 
                 //todo: ATTACHMENT This will need to be tweaked to dynamically show the the downloaded amount
-                val title = "$totalSize$separator${context.getString(R.string.downloading)}"
+                val title = getFormattedTitle(totalSize, context.getString(R.string.downloading))
+
                 binding.title.apply{
                     text = title
                     setTextColor(textColor)
@@ -105,7 +104,7 @@ class AttachmentControlView: LinearLayout {
             AttachmentState.FAILED -> {
                 binding.pendingDownloadIcon.setColorFilter(textColor)
 
-                val title = "$totalSize$separator${context.getString(R.string.failedToDownload)}"
+                val title = getFormattedTitle(totalSize, context.getString(R.string.failedToDownload))
                 binding.title.apply{
                     text = title
                     setTextColor(textColor)
@@ -119,11 +118,12 @@ class AttachmentControlView: LinearLayout {
             else -> {
                 binding.pendingDownloadIcon.setColorFilter(textColor)
 
-                val title = "$totalSize$separator${
+                val title = getFormattedTitle(totalSize,
                     Phrase.from(context, R.string.attachmentsTapToDownload)
                         .put(FILE_TYPE_KEY, context.getString(stringRes).lowercase(Locale.ROOT))
                         .format()
-                }"
+                )
+
                 binding.title.apply{
                     text = title
                     setTextColor(textColor)
@@ -134,6 +134,10 @@ class AttachmentControlView: LinearLayout {
                 binding.errorIcon.isVisible = false
             }
         }
+    }
+
+    private fun getFormattedTitle(size: String, title: CharSequence): CharSequence {
+        return ViewUtil.safeRTLString(context, "$size$separator$title")
     }
     // endregion
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/AttachmentControlView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/AttachmentControlView.kt
@@ -43,9 +43,7 @@ class AttachmentControlView: LinearLayout {
     // endregion
     @Inject lateinit var storage: StorageProtocol
 
-    val errorColor by lazy {
-        context.getColorFromAttr(R.attr.danger)
-    }
+    val separator = " • "
 
     // region Updating
     private fun getAttachmentData(attachmentType: AttachmentType, messageTotalAttachment: Int): Pair<Int, Int> {
@@ -78,16 +76,14 @@ class AttachmentControlView: LinearLayout {
                 val expiredColor = textColor.also { alpha = 0.7f }
 
                 binding.pendingDownloadIcon.setColorFilter(expiredColor)
-                binding.pendingDownloadSize.isVisible = false
 
-                binding.pendingDownloadTitle.apply {
+                binding.title.apply {
                     text = context.getString(R.string.attachmentsExpired)
                     setTextColor(expiredColor)
                     setTypeface(typeface, android.graphics.Typeface.ITALIC)
                 }
 
-                binding.separator.isVisible = false
-                binding.pendingDownloadSubtitle.isVisible = false
+                binding.subtitle.isVisible = false
                 binding.errorIcon.isVisible = false
             }
 
@@ -95,74 +91,46 @@ class AttachmentControlView: LinearLayout {
                 binding.pendingDownloadIcon.setColorFilter(textColor)
 
                 //todo: ATTACHMENT This will need to be tweaked to dynamically show the the downloaded amount
-                binding.pendingDownloadSize.apply {
-                    text = totalSize
-                    setTextColor(textColor)
-                    isVisible = true
-                }
-
-                binding.pendingDownloadTitle.apply{
-                    text = context.getString(R.string.downloading)
+                val title = "$totalSize$separator${context.getString(R.string.downloading)}"
+                binding.title.apply{
+                    text = title
                     setTextColor(textColor)
                     setTypeface(typeface, android.graphics.Typeface.NORMAL)
                 }
 
-                binding.separator.apply {
-                    imageTintList = ColorStateList.valueOf(textColor)
-                    isVisible = true
-                }
-
-                binding.pendingDownloadSubtitle.isVisible = false
+                binding.subtitle.isVisible = false
                 binding.errorIcon.isVisible = false
             }
 
             AttachmentState.FAILED -> {
                 binding.pendingDownloadIcon.setColorFilter(textColor)
 
-                binding.pendingDownloadSize.apply {
-                    text = totalSize
-                    setTextColor(textColor)
-                    isVisible = true
-                }
-
-                binding.pendingDownloadTitle.apply{
-                    text = context.getString(R.string.failedToDownload)
+                val title = "$totalSize$separator${context.getString(R.string.failedToDownload)}"
+                binding.title.apply{
+                    text = title
                     setTextColor(textColor)
                     setTypeface(typeface, android.graphics.Typeface.NORMAL)
                 }
 
-                binding.separator.apply {
-                    imageTintList = ColorStateList.valueOf(textColor)
-                    isVisible = true
-                }
-
-                binding.pendingDownloadSubtitle.isVisible = true
+                binding.subtitle.isVisible = true
                 binding.errorIcon.isVisible = true
             }
 
             else -> {
                 binding.pendingDownloadIcon.setColorFilter(textColor)
 
-                binding.pendingDownloadSize.apply {
-                    text = totalSize
-                    setTextColor(textColor)
-                    isVisible = true
-                }
-
-                binding.pendingDownloadTitle.apply{
-                    text = Phrase.from(context, R.string.attachmentsTapToDownload)
+                val title = "$totalSize$separator${
+                    Phrase.from(context, R.string.attachmentsTapToDownload)
                         .put(FILE_TYPE_KEY, context.getString(stringRes).lowercase(Locale.ROOT))
                         .format()
+                }"
+                binding.title.apply{
+                    text = title
                     setTextColor(textColor)
                     setTypeface(typeface, android.graphics.Typeface.NORMAL)
                 }
 
-                binding.separator.apply {
-                    imageTintList = ColorStateList.valueOf(textColor)
-                    isVisible = true
-                }
-
-                binding.pendingDownloadSubtitle.isVisible = false
+                binding.subtitle.isVisible = false
                 binding.errorIcon.isVisible = false
             }
         }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/DocumentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/DocumentView.kt
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.conversation.v2.messages
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.text.format.Formatter
 import android.util.AttributeSet
 import android.widget.LinearLayout
 import androidx.annotation.ColorInt
@@ -24,7 +25,7 @@ class DocumentView : LinearLayout {
         val document = message.slideDeck.documentSlide!!
         binding.documentTitleTextView.text = document.filename
         binding.documentTitleTextView.setTextColor(textColor)
-        binding.documentSize.text = Util.getPrettyFileSize(document.fileSize)
+        binding.documentSize.text = Formatter.formatFileSize(context, document.fileSize)
         binding.documentSize.setTextColor(textColor)
         binding.documentViewIconImageView.imageTintList = ColorStateList.valueOf(textColor)
         binding.documentViewProgress.indeterminateTintList = ColorStateList.valueOf(textColor)

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -637,17 +637,11 @@ class HomeActivity : ScreenLockActionBarActivity(),
         if (!isMuted) {
             lifecycleScope.launch(Dispatchers.Default) {
                 recipientDatabase.setMuted(thread.recipient, 0)
-                withContext(Dispatchers.Main) {
-                    binding.searchContactsRecyclerView.adapter!!.notifyDataSetChanged()
-                }
             }
         } else {
             showMuteDialog(this) { until ->
                 lifecycleScope.launch(Dispatchers.Default) {
                     recipientDatabase.setMuted(thread.recipient, until)
-                    withContext(Dispatchers.Main) {
-                        binding.searchContactsRecyclerView.adapter!!.notifyDataSetChanged()
-                    }
                 }
             }
         }
@@ -656,9 +650,6 @@ class HomeActivity : ScreenLockActionBarActivity(),
     private fun setNotifyType(thread: ThreadRecord, newNotifyType: Int) {
         lifecycleScope.launch(Dispatchers.Default) {
             recipientDatabase.setNotifyType(thread.recipient, newNotifyType)
-            withContext(Dispatchers.Main) {
-                binding.searchContactsRecyclerView.adapter!!.notifyDataSetChanged()
-            }
         }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/media/DocumentsPage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/media/DocumentsPage.kt
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms.media
 
+import android.text.format.Formatter
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -24,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -93,7 +95,7 @@ fun DocumentsPage(
                                 Row(modifier = Modifier.fillMaxWidth()) {
                                     Text(
                                         modifier = Modifier.weight(1f),
-                                        text = Util.getPrettyFileSize(file.fileSize),
+                                        text = Formatter.formatFileSize(LocalContext.current, file.fileSize),
                                         style = LocalType.current.small,
                                         color = LocalColors.current.textSecondary,
                                         textAlign = TextAlign.Start,

--- a/app/src/main/java/org/thoughtcrime/securesms/webrtc/CallViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/webrtc/CallViewModel.kt
@@ -177,11 +177,7 @@ class CallViewModel @Inject constructor(
     private val MAX_CALL_STEPS: Int = 5
 
     private fun constructCallLabel(@StringRes label: Int, stepsCount: Int): String {
-        return if(ViewUtil.isLtr(context)) {
-            "${context.getString(label)} $stepsCount/$MAX_CALL_STEPS"
-        } else {
-            "$MAX_CALL_STEPS/$stepsCount ${context.getString(label)}"
-        }
+        return ViewUtil.safeRTLString(context, "${context.getString(label)} $stepsCount/$MAX_CALL_STEPS")
     }
 
 

--- a/app/src/main/res/layout/view_attachment_control.xml
+++ b/app/src/main/res/layout/view_attachment_control.xml
@@ -2,70 +2,89 @@
 <org.thoughtcrime.securesms.conversation.v2.messages.AttachmentControlView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@drawable/message_bubble_background"
+    android:layout_margin="16dp"
     android:contentDescription="@string/AccessibilityId_attachmentsClickToDownload"
-    android:gravity="center"
-    android:orientation="horizontal"
-    android:paddingHorizontal="@dimen/message_spacing"
-    android:paddingVertical="@dimen/small_spacing">
-
-    <ImageView
-        android:id="@+id/pendingDownloadIcon"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layout_marginEnd="8dp"
-        android:src="@drawable/ic_images"
-        app:tint="?android:textColorPrimary" />
+    android:orientation="horizontal">
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:background="@drawable/message_bubble_background"
+        android:gravity="center"
+        android:orientation="horizontal"
+        android:paddingHorizontal="@dimen/message_spacing"
+        android:paddingVertical="@dimen/small_spacing">
+
+        <ImageView
+            android:id="@+id/pendingDownloadIcon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="8dp"
+            android:src="@drawable/ic_images"
+            app:tint="?android:textColorPrimary" />
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:orientation="horizontal">
+            android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/pendingDownloadSize"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:maxLines="1"
-                android:textColor="?android:textColorPrimary"
-                android:textSize="@dimen/medium_font_size"
-                tools:text="1.23MB" />
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
 
-            <ImageView
-                android:id="@+id/separator"
-                android:layout_width="2dp"
-                android:layout_height="2dp"
-                android:layout_marginHorizontal="6dp"
-                android:src="@drawable/circle_tintable"
-                app:tint="?android:textColorPrimary" />
+                <TextView
+                    android:id="@+id/pendingDownloadSize"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:maxLines="1"
+                    android:textColor="?android:textColorPrimary"
+                    android:textSize="@dimen/medium_font_size"
+                    tools:text="1.23MB" />
+
+                <ImageView
+                    android:id="@+id/separator"
+                    android:layout_width="2dp"
+                    android:layout_height="2dp"
+                    android:layout_marginHorizontal="6dp"
+                    android:src="@drawable/circle_tintable"
+                    app:tint="?android:textColorPrimary" />
+
+                <TextView
+                    android:id="@+id/pendingDownloadTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="2"
+                    android:textColor="?android:textColorPrimary"
+                    android:textSize="@dimen/medium_font_size"
+                    tools:text="Failed to download" />
+
+            </LinearLayout>
 
             <TextView
-                android:id="@+id/pendingDownloadTitle"
+                android:id="@+id/pendingDownloadSubtitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:maxLines="2"
-                android:textColor="?android:textColorPrimary"
-                android:textSize="@dimen/medium_font_size"
-                tools:text="I'm a very long document title. Did you know that?" />
-
+                android:text="@string/tapToRetry"
+                android:textColor="?android:textColorTertiary"
+                android:textSize="@dimen/small_font_size" />
         </LinearLayout>
-
-        <TextView
-            android:id="@+id/pendingDownloadSubtitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/tapToRetry"
-            android:textColor="?android:textColorTertiary"
-            android:textSize="@dimen/small_font_size" />
     </LinearLayout>
+
+    <ImageView
+        android:id="@+id/errorIcon"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_gravity="center"
+        android:layout_marginStart="8dp"
+        android:visibility="gone"
+        tools:visibility="visible"
+        app:tint="@color/danger_dark"
+        android:src="@drawable/ic_triangle_alert" />
 
 </org.thoughtcrime.securesms.conversation.v2.messages.AttachmentControlView>

--- a/app/src/main/res/layout/view_attachment_control.xml
+++ b/app/src/main/res/layout/view_attachment_control.xml
@@ -5,7 +5,6 @@
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="16dp"
     android:contentDescription="@string/AccessibilityId_attachmentsClickToDownload"
     android:orientation="horizontal">
 
@@ -31,43 +30,19 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <LinearLayout
+            <TextView
+                android:id="@+id/title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="center_vertical"
-                android:orientation="horizontal">
-
-                <TextView
-                    android:id="@+id/pendingDownloadSize"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:maxLines="1"
-                    android:textColor="?android:textColorPrimary"
-                    android:textSize="@dimen/medium_font_size"
-                    tools:text="1.23MB" />
-
-                <ImageView
-                    android:id="@+id/separator"
-                    android:layout_width="2dp"
-                    android:layout_height="2dp"
-                    android:layout_marginHorizontal="6dp"
-                    android:src="@drawable/circle_tintable"
-                    app:tint="?android:textColorPrimary" />
-
-                <TextView
-                    android:id="@+id/pendingDownloadTitle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:maxLines="2"
-                    android:textColor="?android:textColorPrimary"
-                    android:textSize="@dimen/medium_font_size"
-                    tools:text="Failed to download" />
-
-            </LinearLayout>
+                android:ellipsize="end"
+                android:maxLines="2"
+                android:textColor="?android:textColorPrimary"
+                android:maxWidth="240dp"
+                android:textSize="@dimen/medium_font_size"
+                tools:text="1.23MB • Failed to download" />
 
             <TextView
-                android:id="@+id/pendingDownloadSubtitle"
+                android:id="@+id/subtitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/tapToRetry"

--- a/libsession/src/main/java/org/session/libsession/utilities/Util.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/Util.kt
@@ -9,22 +9,18 @@ import android.os.Looper
 import android.provider.Telephony
 import android.text.Spannable
 import android.text.SpannableString
-import android.text.Spanned
 import android.text.TextUtils
 import android.text.style.StyleSpan
-import org.session.libsignal.utilities.Log
 import org.session.libsignal.utilities.Base64
+import org.session.libsignal.utilities.Log
 import org.session.libsignal.utilities.Util.SECURE_RANDOM
 import java.io.*
 import java.nio.charset.StandardCharsets
-import java.security.SecureRandom
-import java.text.DecimalFormat
 import java.util.*
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import kotlin.collections.LinkedHashMap
 import kotlin.math.min
 
 object Util {
@@ -345,14 +341,6 @@ object Util {
         parts[1] = ByteArray(secondLength)
         System.arraycopy(input, firstLength, parts[1], 0, secondLength)
         return parts
-    }
-
-    @JvmStatic
-    fun getPrettyFileSize(sizeBytes: Long): String {
-        if (sizeBytes <= 0) return "0"
-        val units = arrayOf("B", "kB", "MB", "GB", "TB")
-        val digitGroups = (Math.log10(sizeBytes.toDouble()) / Math.log10(1024.0)).toInt()
-        return DecimalFormat("#,##0.#").format(sizeBytes / Math.pow(1024.0, digitGroups.toDouble())) + " " + units[digitGroups]
     }
 }
 


### PR DESCRIPTION
[SES-3599](https://optf.atlassian.net/browse/SES-3599) - Updated UI for failed download.
Should now match this look:
![Screenshot 2025-04-10 at 11 34 28 AM](https://github.com/user-attachments/assets/848f7e62-e4b0-445b-8480-48dcea87e019)
