### PR TITLE
Fix/contact delete qa

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -1639,7 +1639,7 @@ open class Storage @Inject constructor(
                     profileManager.setUnidentifiedAccessMode(context, sender, Recipient.UnidentifiedAccessMode.UNKNOWN)
                 }
             }
-            threadDatabase.setHasSent(threadId, true)
+            
             val mappingDb = blindedIdMappingDatabase
             val mappings = mutableMapOf<String, BlindedIdMapping>()
             threadDatabase.readerFor(threadDatabase.conversationList).use { reader ->
@@ -1674,7 +1674,6 @@ open class Storage @Inject constructor(
                 alreadyApprovedMe = it.contacts.get(sender.address.toString())?.approvedMe ?: false
             }
 
-            setRecipientApproved(sender, true)
             setRecipientApprovedMe(sender, true)
 
             // only show the message if wasn't already approvedMe before

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -200,7 +200,7 @@ class HomeActivity : ScreenLockActionBarActivity(),
         binding.globalSearchInputLayout.listener = this
         homeAdapter.setHasStableIds(true)
         homeAdapter.glide = glide
-        binding.searchContactsRecyclerView.adapter = homeAdapter
+        binding.conversationsRecyclerView.adapter = homeAdapter
         binding.globalSearchRecycler.adapter = globalSearchAdapter
 
         binding.configOutdatedView.setOnClickListener {
@@ -237,7 +237,7 @@ class HomeActivity : ScreenLockActionBarActivity(),
                 homeViewModel.data
                     .filterNotNull() // We don't actually want the null value here as it indicates a loading state (maybe we need a loading state?)
                     .collectLatest { data ->
-                        val manager = binding.searchContactsRecyclerView.layoutManager as LinearLayoutManager
+                        val manager = binding.conversationsRecyclerView.layoutManager as LinearLayoutManager
                         val firstPos = manager.findFirstCompletelyVisibleItemPosition()
                         val offsetTop = if(firstPos >= 0) {
                             manager.findViewByPosition(firstPos)?.let { view ->
@@ -429,7 +429,7 @@ class HomeActivity : ScreenLockActionBarActivity(),
 
         binding.searchToolbar.isVisible = isShown
         binding.sessionToolbar.isVisible = !isShown
-        binding.searchContactsRecyclerView.isVisible = !isShown
+        binding.conversationsRecyclerView.isVisible = !isShown
         binding.seedReminderView.isVisible = !TextSecurePreferences.getHasViewedSeed(this) && !isShown
         binding.globalSearchRecycler.isVisible = isShown
         binding.conversationListContainer.isVisible = !isShown
@@ -437,6 +437,7 @@ class HomeActivity : ScreenLockActionBarActivity(),
             binding.newConversationButton.animate().cancel()
             binding.newConversationButton.isVisible = false
         } else {
+            updateEmptyState()
             binding.newConversationButton.apply {
                 alpha = 0.0f
                 visibility = View.VISIBLE
@@ -482,8 +483,8 @@ class HomeActivity : ScreenLockActionBarActivity(),
 
     // region Updating
     private fun updateEmptyState() {
-        val threadCount = (binding.searchContactsRecyclerView.adapter)!!.itemCount
-        binding.emptyStateContainer.isVisible = threadCount == 0 && binding.searchContactsRecyclerView.isVisible
+        val threadCount = binding.conversationsRecyclerView.adapter?.itemCount ?: 0
+        binding.emptyStateContainer.isVisible = threadCount == 0 && binding.conversationsRecyclerView.isVisible
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -606,7 +607,7 @@ class HomeActivity : ScreenLockActionBarActivity(),
                     storage.setBlocked(listOf(thread.recipient), true)
 
                     withContext(Dispatchers.Main) {
-                        binding.searchContactsRecyclerView.adapter!!.notifyDataSetChanged()
+                        binding.conversationsRecyclerView.adapter!!.notifyDataSetChanged()
                     }
                 }
                 // Block confirmation toast added as per SS-64
@@ -625,7 +626,7 @@ class HomeActivity : ScreenLockActionBarActivity(),
                 lifecycleScope.launch(Dispatchers.Default) {
                     storage.setBlocked(listOf(thread.recipient), false)
                     withContext(Dispatchers.Main) {
-                        binding.searchContactsRecyclerView.adapter!!.notifyDataSetChanged()
+                        binding.conversationsRecyclerView.adapter!!.notifyDataSetChanged()
                     }
                 }
             }

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -158,7 +158,7 @@
             android:id="@+id/conversationListContainer">
 
             <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/searchContactsRecyclerView"
+                android:id="@+id/conversationsRecyclerView"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:clipToPadding="false"


### PR DESCRIPTION
[SES-3716](https://optf.atlassian.net/browse/SES-3716) - Checking for empty state when returning from search in case we deleted all contacts
[SES-](https://optf.atlassian.net/browse/SES-3674) - [We should not assumed we have approved or "Sent in a thread" when we get a request response
This fixes an issue where person A sends a message request to person B
Then person  A deletes person B
Then person B accepts the request from person A.
This should create a message request for person A, not a regular conersation.