### PR TITLE
Fix/attachment controls qa

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/AttachmentDownloadHandler.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/AttachmentDownloadHandler.kt
@@ -115,10 +115,14 @@ class AttachmentDownloadHandler(
 
     fun retryFailedAttachments(attachments: List<DatabaseAttachment>){
         attachments.forEach { attachment ->
-            if (attachment.transferState != AttachmentState.FAILED.value) return Log.d(
-                LOG_TAG,
-                "Attachment ${attachment.attachmentId} is not failed, skipping retry"
-            )
+            if (attachment.transferState != AttachmentState.FAILED.value){
+                Log.d(
+                    LOG_TAG,
+                    "Attachment ${attachment.attachmentId} is not failed, skipping retry"
+                )
+
+                return@forEach
+            }
 
             downloadRequests.trySend(attachment)
         }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/components/AlbumThumbnailView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/components/AlbumThumbnailView.kt
@@ -83,7 +83,7 @@ class AlbumThumbnailView : RelativeLayout {
 
     fun bind(glideRequests: RequestManager, message: MmsMessageRecord,
              isStart: Boolean, isEnd: Boolean) {
-        slides = message.slideDeck.thumbnailSlides
+        slides = message.slideDeck.thumbnailSlides.filter { it.isDone }
         if (slides.isEmpty()) {
             // this should never be encountered because it's checked by parent
             return

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/AttachmentControlView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/AttachmentControlView.kt
@@ -1,10 +1,12 @@
 package org.thoughtcrime.securesms.conversation.v2.messages
 
 import android.content.Context
+import android.graphics.Typeface
 import android.text.format.Formatter
 import android.util.AttributeSet
 import android.widget.LinearLayout
 import androidx.annotation.ColorInt
+import androidx.core.graphics.ColorUtils
 import androidx.core.view.isVisible
 import com.squareup.phrase.Phrase
 import dagger.hilt.android.AndroidEntryPoint
@@ -71,14 +73,14 @@ class AttachmentControlView: LinearLayout {
 
         when(state){
             AttachmentState.EXPIRED -> {
-                val expiredColor = textColor.also { alpha = 0.7f }
+                val expiredColor = ColorUtils.setAlphaComponent(textColor, (0.7f * 255).toInt())
 
                 binding.pendingDownloadIcon.setColorFilter(expiredColor)
 
                 binding.title.apply {
                     text = context.getString(R.string.attachmentsExpired)
                     setTextColor(expiredColor)
-                    setTypeface(typeface, android.graphics.Typeface.ITALIC)
+                    setTypeface(Typeface.defaultFromStyle(Typeface.ITALIC))
                 }
 
                 binding.subtitle.isVisible = false
@@ -94,7 +96,7 @@ class AttachmentControlView: LinearLayout {
                 binding.title.apply{
                     text = title
                     setTextColor(textColor)
-                    setTypeface(typeface, android.graphics.Typeface.NORMAL)
+                    setTypeface(Typeface.defaultFromStyle(Typeface.NORMAL))
                 }
 
                 binding.subtitle.isVisible = false
@@ -108,7 +110,7 @@ class AttachmentControlView: LinearLayout {
                 binding.title.apply{
                     text = title
                     setTextColor(textColor)
-                    setTypeface(typeface, android.graphics.Typeface.NORMAL)
+                    setTypeface(Typeface.defaultFromStyle(Typeface.NORMAL))
                 }
 
                 binding.subtitle.isVisible = true
@@ -127,7 +129,7 @@ class AttachmentControlView: LinearLayout {
                 binding.title.apply{
                     text = title
                     setTextColor(textColor)
-                    setTypeface(typeface, android.graphics.Typeface.NORMAL)
+                    setTypeface(Typeface.defaultFromStyle(Typeface.NORMAL))
                 }
 
                 binding.subtitle.isVisible = false


### PR DESCRIPTION
[SES-3718](https://optf.atlassian.net/browse/SES-3718) - Proper reset of attachment control per style to avoir recyclerview reuse errors
[SES-3719](https://optf.atlassian.net/browse/SES-3719) - There is a special case of error (though nearly impossible to reproduce) where some, but not all, files in an attachment get a 404 response. We now need to handle this properly. Previously the whole attachment was deemed expired as long as one file in the set was 404, but now we should consider the rest of the attachment to be ok and ignore the expired ones within the set. This is different from failed attachments, where the overall attachment is considered failed (which is retryable) until they are all ok.