### PR TITLE
Fix deadlock clearing data on migration failure

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/migration/DatabaseMigrationManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/migration/DatabaseMigrationManager.kt
@@ -203,10 +203,10 @@ class DatabaseMigrationManager @Inject constructor(
             db.rawExecSQL("DETACH DATABASE new_db")
 
             // Delay and fail at first
-//            if (BuildConfig.DEBUG && !fromRetry) {
-//                Thread.sleep(2000)
-//                throw RuntimeException("Fail")
-//            }
+            if (BuildConfig.DEBUG && !fromRetry) {
+                Thread.sleep(2000)
+                throw RuntimeException("Fail")
+            }
         }
 
         check(newDb.exists()) { "New database was not created" }

--- a/app/src/main/java/org/thoughtcrime/securesms/migration/DatabaseMigrationManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/migration/DatabaseMigrationManager.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.runBlocking
 import net.zetetic.database.sqlcipher.SQLiteConnection
 import net.zetetic.database.sqlcipher.SQLiteDatabase
 import net.zetetic.database.sqlcipher.SQLiteDatabaseHook
-import network.loki.messenger.BuildConfig
 import network.loki.messenger.R
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.utilities.Log
@@ -202,11 +201,11 @@ class DatabaseMigrationManager @Inject constructor(
             // Detach the new database
             db.rawExecSQL("DETACH DATABASE new_db")
 
-            // Delay and fail at first
-            if (BuildConfig.DEBUG && !fromRetry) {
-                Thread.sleep(2000)
-                throw RuntimeException("Fail")
-            }
+//            // Delay and fail at first
+//            if (BuildConfig.DEBUG && !fromRetry) {
+//                Thread.sleep(2000)
+//                throw RuntimeException("Fail")
+//            }
         }
 
         check(newDb.exists()) { "New database was not created" }

--- a/app/src/main/java/org/thoughtcrime/securesms/migration/DatabaseMigrationScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/migration/DatabaseMigrationScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentManager
 import com.squareup.phrase.Phrase
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import network.loki.messenger.R
 import org.session.libsession.utilities.StringSubstitutionConstants.APP_NAME_KEY
@@ -78,12 +79,12 @@ fun DatabaseMigrationScreen(
         },
         onClearData = {
             scope.launch {
-                clearDataUtils.clearAllDataAndRestart()
+                clearDataUtils.clearAllDataAndRestart(Dispatchers.IO)
             }
         },
         onClearDataWithoutLoggingOut = {
             scope.launch {
-                clearDataUtils.clearAllDataWithoutLoggingOutAndRestart()
+                clearDataUtils.clearAllDataWithoutLoggingOutAndRestart(Dispatchers.IO)
             }
         }
     )


### PR DESCRIPTION
This PR is to fix this issue on migration error screen: tapping on "clear data" does nothing. See QA-1477.

There are two issues here:
1. As all database access is blocked waiting on error screen, and the config system was  holding a lock while accessing the db, the "clear data" unfortunately will also need access to the config system. The lock then become a deadlock. The solution here is to remove the lock while creating the config from db. 
2. The use of Default dispatcher might not be ideal as all default dispatcher threads are blocked waiting on db. Here for clearing the data, we'll need to use the unconstrained IO dispatcher.
