### PR TITLE
[SES-3731] - Fix multi part config not showing up 

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.kt
@@ -443,9 +443,9 @@ class ApplicationContext : Application(), DefaultLifecycleObserver,
     private class ProviderInitializationException : RuntimeException()
 
     private fun setUpPollingIfNeeded() {
-        val userPublicKey = textSecurePreferences!!.getLocalNumber() ?: return
+        val userPublicKey = textSecurePreferences.getLocalNumber() ?: return
         if (poller == null) {
-            poller = Poller(configFactory!!, storage!!, lokiAPIDatabase!!)
+            poller = Poller(configFactory, storage, lokiAPIDatabase, prefs)
         }
     }
 
@@ -454,7 +454,7 @@ class ApplicationContext : Application(), DefaultLifecycleObserver,
         if (poller != null) {
             poller!!.startIfNeeded()
         }
-        legacyClosedGroupPollerV2!!.start()
+        legacyClosedGroupPollerV2.start()
     }
 
     fun retrieveUserProfile() {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/LokiAPIDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/LokiAPIDatabase.kt
@@ -299,6 +299,12 @@ class LokiAPIDatabase(context: Context, helper: Provider<SQLCipherOpenHelper>) :
             .delete(lastMessageHashValueTable2, "${Companion.publicKey} = ?", arrayOf(publicKey))
     }
 
+    override fun clearLastMessageHashesByNamespaces(vararg namespaces: Int) {
+        // Note that we don't use SQL parameter as the given namespaces are integer anyway so there's little chance of SQL injection
+        writableDatabase
+            .delete(lastMessageHashValueTable2, "$lastMessageHashNamespace IN (${namespaces.joinToString(",")})", null)
+    }
+
     override fun clearAllLastMessageHashes() {
         val database = writableDatabase
         database.delete(lastMessageHashValueTable2, null, null)
@@ -333,6 +339,12 @@ class LokiAPIDatabase(context: Context, helper: Provider<SQLCipherOpenHelper>) :
     override fun clearReceivedMessageHashValues() {
         val database = writableDatabase
         database.delete(receivedMessageHashValuesTable, null, null)
+    }
+
+    override fun clearReceivedMessageHashValuesByNamespaces(vararg namespaces: Int) {
+        // Note that we don't use SQL parameter as the given namespaces are integer anyway so there's little chance of SQL injection
+        writableDatabase
+            .delete(receivedMessageHashValuesTable, "$receivedMessageHashNamespace IN (${namespaces.joinToString(",")})", null)
     }
 
     override fun getAuthToken(server: String): String? {

--- a/libsession/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
@@ -204,6 +204,7 @@ interface TextSecurePreferences {
 
     var migratedToGroupV2Config: Boolean
     var migratedToDisablingKDF: Boolean
+    var migratedToMultiPartConfig: Boolean
 
     companion object {
         val TAG = TextSecurePreferences::class.simpleName
@@ -295,6 +296,7 @@ interface TextSecurePreferences {
         const val ENVIRONMENT = "debug_environment"
         const val MIGRATED_TO_GROUP_V2_CONFIG = "migrated_to_group_v2_config"
         const val MIGRATED_TO_DISABLING_KDF = "migrated_to_disabling_kdf"
+        const val MIGRATED_TO_MULTIPART_CONFIG = "migrated_to_multi_part_config"
 
         const val HAS_RECEIVED_LEGACY_CONFIG = "has_received_legacy_config"
         const val HAS_FORCED_NEW_CONFIG = "has_forced_new_config"
@@ -1003,6 +1005,10 @@ class AppTextSecurePreferences @Inject constructor(
         set(value) = getDefaultSharedPreferences(context).edit(commit = true) {
             putBoolean(TextSecurePreferences.MIGRATED_TO_DISABLING_KDF, value)
         }
+
+    override var migratedToMultiPartConfig: Boolean
+        get() = getBooleanPreference(TextSecurePreferences.MIGRATED_TO_MULTIPART_CONFIG, false)
+        set(value) = setBooleanPreference(TextSecurePreferences.MIGRATED_TO_MULTIPART_CONFIG, value)
 
     override fun getConfigurationMessageSynced(): Boolean {
         return getBooleanPreference(TextSecurePreferences.CONFIGURATION_SYNCED, false)

--- a/libsignal/src/main/java/org/session/libsignal/database/LokiAPIDatabaseProtocol.kt
+++ b/libsignal/src/main/java/org/session/libsignal/database/LokiAPIDatabaseProtocol.kt
@@ -18,11 +18,13 @@ interface LokiAPIDatabaseProtocol {
     fun getLastMessageHashValue(snode: Snode, publicKey: String, namespace: Int): String?
     fun setLastMessageHashValue(snode: Snode, publicKey: String, newValue: String, namespace: Int)
     fun clearLastMessageHashes(publicKey: String)
+    fun clearLastMessageHashesByNamespaces(vararg namespaces: Int)
     fun clearAllLastMessageHashes()
     fun getReceivedMessageHashValues(publicKey: String, namespace: Int): Set<String>?
     fun setReceivedMessageHashValues(publicKey: String, newValue: Set<String>, namespace: Int)
     fun clearReceivedMessageHashValues(publicKey: String)
     fun clearReceivedMessageHashValues()
+    fun clearReceivedMessageHashValuesByNamespaces(vararg namespaces: Int)
     fun getAuthToken(server: String): String?
     fun setAuthToken(server: String, newValue: String?)
     fun setUserCount(room: String, server: String, newValue: Int)


### PR DESCRIPTION
Previously, if the Android app sees multi part/invalid config, it will ignore it. With the new multipart config, we'll have to refetch all config messages so we get the chance to process them. This only needs to be done once after updating to the latest app version
