### PR TITLE
Fix search issues

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/GroupDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/GroupDatabase.java
@@ -154,29 +154,6 @@ public class GroupDatabase extends Database implements LokiOpenGroupDatabaseProt
     return groups;
   }
 
-  public Cursor getGroupsFilteredByMembers(List<String> members) {
-    if (members == null || members.isEmpty()) {
-      return null;
-    }
-
-    String[] queriesValues = new String[members.size()];
-
-    StringBuilder queries = new StringBuilder();
-    for (int i=0; i < members.size(); i++) {
-      boolean isEnd = i == (members.size() - 1);
-      queries.append(MEMBERS + " LIKE ?");
-      queriesValues[i] = "%"+members.get(i)+"%";
-      if (!isEnd) {
-        queries.append(" OR ");
-      }
-    }
-
-    return getReadableDatabase().query(TABLE_NAME, null,
-            queries.toString(),
-            queriesValues,
-            null, null, null);
-  }
-
   public @NonNull List<Recipient> getGroupMembers(String groupId, boolean includeSelf) {
     List<Address>   members     = getCurrentMembers(groupId, false);
     List<Recipient> recipients  = new LinkedList<>();

--- a/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -441,12 +441,10 @@ public class ThreadDatabase extends Database {
       StringBuilder selection = new StringBuilder(TABLE_NAME + "." + ADDRESS + " = ?");
       String[] selectionArgs = new String[addresses.size()];
 
-      for (int i = 0; i < addresses.size() - 1; i++)
-        selection.append("OR ")
-                .append(TABLE_NAME)
-                .append(".")
-                .append(ADDRESS)
-                .append(" = ?");
+      for (int i = 0; i < addresses.size() - 1; i++) {
+        selection.append("OR " + TABLE_NAME + "." + ADDRESS + " = ?");
+      }
+
       int i= 0;
       for (Address address : addresses) {
         selectionArgs[i++] = DelimiterUtil.escape(address.toString(), ' ');

--- a/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -442,7 +442,7 @@ public class ThreadDatabase extends Database {
       String[] selectionArgs = new String[addresses.size()];
 
       for (int i = 0; i < addresses.size() - 1; i++) {
-        selection.append("OR " + TABLE_NAME + "." + ADDRESS + " = ?");
+        selection.append(" OR " + TABLE_NAME + "." + ADDRESS + " = ?");
       }
 
       int i= 0;

--- a/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -407,8 +407,7 @@ public class ThreadDatabase extends Database {
     }
 
     SQLiteDatabase db = getReadableDatabase();
-    StringBuilder selection = new StringBuilder(TABLE_NAME + "." + ADDRESS + " LIKE ? AND " +
-            TABLE_NAME + "." + MESSAGE_COUNT + " != 0");
+    StringBuilder selection = new StringBuilder(TABLE_NAME + "." + ADDRESS + " LIKE ?");
 
     List<String> selectionArgs = new ArrayList<>();
     selectionArgs.add(addressQuery + "%");
@@ -439,22 +438,25 @@ public class ThreadDatabase extends Database {
     List<Cursor>        cursors              = new LinkedList<>();
 
     for (List<Address> addresses : partitionedAddresses) {
-      String   selection      = TABLE_NAME + "." + ADDRESS + " = ?";
-      String[] selectionArgs  = new String[addresses.size()];
+      StringBuilder selection = new StringBuilder(TABLE_NAME + "." + ADDRESS + " = ?");
+      String[] selectionArgs = new String[addresses.size()];
 
-      for (int i=0;i<addresses.size()-1;i++)
-        selection += (" OR " + TABLE_NAME + "." + ADDRESS + " = ?");
-
+      for (int i = 0; i < addresses.size() - 1; i++)
+        selection.append("OR ")
+                .append(TABLE_NAME)
+                .append(".")
+                .append(ADDRESS)
+                .append(" = ?");
       int i= 0;
       for (Address address : addresses) {
         selectionArgs[i++] = DelimiterUtil.escape(address.toString(), ' ');
       }
 
-      String query = createQuery(selection, 0);
+      String query = createQuery(selection.toString(), 0);
       cursors.add(db.rawQuery(query, selectionArgs));
     }
 
-    Cursor cursor = cursors.size() > 1 ? new MergeCursor(cursors.toArray(new Cursor[cursors.size()])) : cursors.get(0);
+    Cursor cursor = cursors.size() > 1 ? new MergeCursor(cursors.toArray(new Cursor[0])) : cursors.get(0);
     setNotifyConversationListListeners(cursor);
     return cursor;
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/home/search/GlobalSearchAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/search/GlobalSearchAdapter.kt
@@ -35,10 +35,18 @@ class GlobalSearchAdapter(
     fun setNewData(data: Pair<String, List<Model>>) = setNewData(data.first, data.second)
 
     fun setNewData(query: String, newData: List<Model>) {
-        val diffResult = DiffUtil.calculateDiff(GlobalSearchDiff(this.query, query, data, newData))
         this.query = query
-        data = newData
-        diffResult.dispatchUpdatesTo(this)
+
+        if (this.data.size > 500 || newData.size > 500) {
+            // For big data sets, we won't use DiffUtil to calculate the difference as it could be slow
+            this.data = newData
+            notifyDataSetChanged()
+        } else {
+            val diffResult =
+                DiffUtil.calculateDiff(GlobalSearchDiff(this.query, query, data, newData), false)
+            data = newData
+            diffResult.dispatchUpdatesTo(this)
+        }
     }
 
     override fun getItemViewType(position: Int): Int =

--- a/app/src/main/java/org/thoughtcrime/securesms/home/search/GlobalSearchViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/search/GlobalSearchViewModel.kt
@@ -6,27 +6,15 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.WhileSubscribed
-import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
 import network.loki.messenger.R
 import org.session.libsignal.utilities.Log
@@ -72,7 +60,7 @@ class GlobalSearchViewModel @Inject constructor(
                         // without a nickname/name who haven't approved us.
                         GlobalSearchResult(
                             query,
-                            searchRepository.queryContacts("05").first.toList()
+                            searchRepository.queryContacts("05").toList()
                         )
                     }
                 } else {


### PR DESCRIPTION
This PR fixes a few search related issues:

1. Removes previous restriction on the search result of a contact: needs to have messages with them to display them on search screen.
2. Removes the ability to search for a legacy group by its member. The code there is broken and we shouldn't invest new effort to fix the deprecated code.
3. Some general performance improvement to varies places where redundant allocations are performed, and optimise the search result diff dispatch logic so that big data set doesn't get stuck on UI.
