### PR TITLE
[SES-3740] - Fix "message requests" not showing

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -481,7 +481,7 @@ public class ThreadDatabase extends Database {
   }
 
   public Cursor getUnapprovedConversationList() {
-    String where  = "("+ThreadDatabase.TABLE_NAME+"."+ThreadDatabase.ADDRESS+" LIKE '"+IdPrefix.GROUP.getValue()+"%')" +
+    String where  = "("+MESSAGE_COUNT + " != 0 OR "+ThreadDatabase.TABLE_NAME+"."+ThreadDatabase.ADDRESS+" LIKE '"+IdPrefix.GROUP.getValue()+"%')" +
             " AND " + ARCHIVED + " = 0 AND " + HAS_SENT + " = 0 AND " +
             RecipientDatabase.TABLE_NAME + "." + RecipientDatabase.APPROVED + " = 0 AND " +
             RecipientDatabase.TABLE_NAME + "." + RecipientDatabase.BLOCK + " = 0 AND " +


### PR DESCRIPTION
This was due to previous decision to remove the "message count != 0" condition on getting message request list.

It seems like in this scenario "message count != 0" is actually a valid condition as you would have to have something sent to you to show up as a message request.
