### PR TITLE
Fix empty state showing incorrectly

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -246,7 +246,7 @@ class HomeActivity : ScreenLockActionBarActivity(),
                         } else 0
                         homeAdapter.data = data
                         if(firstPos >= 0) { manager.scrollToPositionWithOffset(firstPos, offsetTop) }
-                        updateEmptyState()
+                        binding.emptyStateContainer.isVisible = homeAdapter.itemCount == 0
                     }
             }
         }
@@ -481,11 +481,6 @@ class HomeActivity : ScreenLockActionBarActivity(),
     // endregion
 
     // region Updating
-    private fun updateEmptyState() {
-        val threadCount = binding.conversationsRecyclerView.adapter?.itemCount ?: 0
-        binding.emptyStateContainer.isVisible = threadCount == 0
-    }
-
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onUpdateProfileEvent(event: ProfilePictureModifiedEvent) {
         if (event.recipient.isLocalNumber) {

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -483,7 +483,7 @@ class HomeActivity : ScreenLockActionBarActivity(),
     // region Updating
     private fun updateEmptyState() {
         val threadCount = binding.conversationsRecyclerView.adapter?.itemCount ?: 0
-        binding.emptyStateContainer.isVisible = threadCount == 0 && binding.conversationsRecyclerView.isVisible
+        binding.emptyStateContainer.isVisible = threadCount == 0
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -437,7 +437,6 @@ class HomeActivity : ScreenLockActionBarActivity(),
             binding.newConversationButton.animate().cancel()
             binding.newConversationButton.isVisible = false
         } else {
-            updateEmptyState()
             binding.newConversationButton.apply {
                 alpha = 0.0f
                 visibility = View.VISIBLE


### PR DESCRIPTION
We use to call `updateEmptyState` when you close search screen, but we have tidied up the view model, the home screen's state has nothing to do with search anymore, so it's actually harmful to call the `updateEmptyState` from the search's perspective: so in previous refactoring of search screen, the `setSearchShown` is tied to the view model's state so it gets called even when you haven't done anything to the search (it's to make sure we execute the UI states needed for a "hidden" search).

This PR removes the empty state meddling from the search logic and now it shows the right screen.
