### PR TITLE
[SES-3743] - Fix message request approval message not showing

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1910,7 +1910,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
     private fun sendTextOnlyMessage(hasPermissionToSendSeed: Boolean = false): Pair<Address, Long>? {
         val recipient = viewModel.recipient ?: return null
         val sentTimestamp = SnodeAPI.nowWithOffset
-        viewModel.beforeSendingTextOnlyMessage()
+        val approvalSendJob = viewModel.implicitlyApproveRecipient()
         val text = getMessageBody()
         val userPublicKey = textSecurePreferences.getLocalNumber()
         val isNoteToSelf = (recipient.isContactRecipient && recipient.address.toString() == userPublicKey)
@@ -1949,6 +1949,8 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
                 null,
                 true
             )
+
+            approvalSendJob?.join() // Must wait for approval send job to finish before sending the actual message
             MessageSender.send(message, recipient.address)
         }
         // Send a typing stopped message
@@ -1968,7 +1970,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
         }
         val recipient = viewModel.recipient!!
         val sentTimestamp = SnodeAPI.nowWithOffset
-        viewModel.beforeSendingAttachments()
+        val approvalSendJob = viewModel.implicitlyApproveRecipient()
 
         // Create the message
         val message = VisibleMessage().applyExpiryMode(viewModel.threadId)
@@ -2014,6 +2016,8 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
                 null,
                 runThreadUpdate = true
             )
+
+            approvalSendJob?.join() // Must wait for approval send job to finish before sending the actual message
             MessageSender.send(message, recipient.address, attachments, quote, linkPreview)
         }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1910,7 +1910,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
     private fun sendTextOnlyMessage(hasPermissionToSendSeed: Boolean = false): Pair<Address, Long>? {
         val recipient = viewModel.recipient ?: return null
         val sentTimestamp = SnodeAPI.nowWithOffset
-        val approvalSendJob = viewModel.implicitlyApproveRecipient()
+        viewModel.implicitlyApproveRecipient()
         val text = getMessageBody()
         val userPublicKey = textSecurePreferences.getLocalNumber()
         val isNoteToSelf = (recipient.isContactRecipient && recipient.address.toString() == userPublicKey)
@@ -1950,7 +1950,6 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
                 true
             )
 
-            approvalSendJob?.join() // Must wait for approval send job to finish before sending the actual message
             MessageSender.send(message, recipient.address)
         }
         // Send a typing stopped message
@@ -1970,7 +1969,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
         }
         val recipient = viewModel.recipient!!
         val sentTimestamp = SnodeAPI.nowWithOffset
-        val approvalSendJob = viewModel.implicitlyApproveRecipient()
+        viewModel.implicitlyApproveRecipient()
 
         // Create the message
         val message = VisibleMessage().applyExpiryMode(viewModel.threadId)
@@ -2017,7 +2016,6 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
                 runThreadUpdate = true
             )
 
-            approvalSendJob?.join() // Must wait for approval send job to finish before sending the actual message
             MessageSender.send(message, recipient.address, attachments, quote, linkPreview)
         }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -892,7 +892,7 @@ class ConversationViewModel(
             }
     }
 
-    fun acceptMessageRequest(): Job = viewModelScope.launch {
+    fun acceptMessageRequest() = viewModelScope.launch {
         val recipient = recipient ?: return@launch Log.w("Loki", "Recipient was null for accept message request action")
         val currentState = _uiState.value.messageRequestState as? MessageRequestUiState.Visible
             ?: return@launch Log.w("Loki", "Current state was not visible for accept message request action")
@@ -972,17 +972,15 @@ class ConversationViewModel(
         attachmentDownloadHandler.retryFailedAttachments(attachments)
     }
 
-   fun implicitlyApproveRecipient(): Job? {
+   fun implicitlyApproveRecipient() {
        val recipient = recipient
 
        if (uiState.value.messageRequestState is MessageRequestUiState.Visible) {
-            return acceptMessageRequest()
+            acceptMessageRequest()
         } else if (recipient?.isApproved == false) {
             // edge case for new outgoing thread on new recipient without sending approval messages
             repository.setApproved(recipient, true)
         }
-
-       return null
     }
 
     fun onCommand(command: Commands) {

--- a/app/src/main/java/org/thoughtcrime/securesms/repository/ConversationRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/repository/ConversationRepository.kt
@@ -416,11 +416,8 @@ class DefaultConversationRepository @Inject constructor(
                 )
             } else {
                 val message = MessageRequestResponse(true)
-                MessageSender.sendNonDurably(
-                    message = message,
-                    destination = Destination.from(recipient.address),
-                    isSyncMessage = recipient.isLocalNumber
-                ).await()
+
+                MessageSender.send(message = message, address = recipient.address)
 
                 // add a control message for our user
                 storage.insertMessageRequestResponseFromYou(threadId)


### PR DESCRIPTION
The underlying issue:

> The direct cause is when someone approves you with a message, they send an approve message + reply message. Normally you'll receive them in order. But with push notification enabled, they can be out of order, so you receive the reply message first, then the approve message. If we receive a reply message, we know that person has approved you and we mark it so. Then once we process the approval message, we decide not to show it because that person was "approved" before. It's coming from the delete contact logic.

There are multiple places we can attack this problem, but a simplest one for now is to make sure we send the approval + reply messages in a strong order so they have much less chance to go out of order on the receiving side.

Technically there's nothing we can do if Google's push service decides to send them in a different order as they are very close to each other, but if we send in a strong order then there's less chance for them to send in different order.
