### PR TITLE
Feature/hide blocked contacts

### DIFF
--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
@@ -551,7 +551,7 @@ object MessageSender {
         // if we are sending a 'Note to Self' make sure it is not hidden
         if( message is VisibleMessage &&
             address.toString() == MessagingModuleConfiguration.shared.storage.getUserPublicKey() &&
-            // only show the NTW if it is currently marked as hidden
+            // only show the NTS if it is currently marked as hidden
             MessagingModuleConfiguration.shared.configFactory.withUserConfigs { it.userProfile.getNtsPriority() == PRIORITY_HIDDEN }
         ){
             // make sure note to self is not hidden

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -718,8 +718,6 @@ class ConversationViewModel(
     private fun markAsDeletedForEveryone(
         data: DeleteForEveryoneDialogData
     ) = viewModelScope.launch {
-        val recipient = recipient ?: return@launch Log.w("Loki", "Recipient was null for delete for everyone - aborting delete operation.")
-
         // make sure to stop audio messages, if any
         data.messages.filterIsInstance<MmsMessageRecord>()
             .mapNotNull { it.slideDeck.audioSlide }

--- a/app/src/main/java/org/thoughtcrime/securesms/home/ConversationOptionsBottomSheet.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/ConversationOptionsBottomSheet.kt
@@ -131,7 +131,7 @@ class ConversationOptionsBottomSheet(private val parentContext: Context) : Botto
                 recipient.isLocalNumber -> {
                     text = context.getString(R.string.hide)
                     contentDescription = context.getString(R.string.AccessibilityId_clear)
-                    drawableStartRes = R.drawable.ic_trash_2
+                    drawableStartRes = R.drawable.ic_eye_off
                 }
 
                 // 1on1

--- a/app/src/main/java/org/thoughtcrime/securesms/home/ConversationView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/ConversationView.kt
@@ -136,7 +136,7 @@ class ConversationView : LinearLayout {
                 binding.statusIndicatorImageView.imageTintList = ColorStateList.valueOf(ThemeUtil.getThemedColor(context, R.attr.danger))
             }
             thread.isPending -> binding.statusIndicatorImageView.setImageResource(R.drawable.ic_circle_dots_custom)
-            thread.isRead -> binding.statusIndicatorImageView.setImageResource(R.drawable.ic_circle_check)
+            thread.isRead -> binding.statusIndicatorImageView.setImageResource(R.drawable.ic_eye)
             else -> binding.statusIndicatorImageView.setImageResource(R.drawable.ic_circle_check)
         }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeDiffUtil.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeDiffUtil.kt
@@ -55,6 +55,7 @@ class HomeDiffUtil(
         if (isSameItem) { isSameItem = (oldItem.count == newItem.count) }
         if (isSameItem) { isSameItem = (oldItem.unreadCount == newItem.unreadCount) }
         if (isSameItem) { isSameItem = (oldItem.isPinned == newItem.isPinned) }
+        if (isSameItem) { isSameItem = (oldItem.isRead == newItem.isRead) }
 
         // The recipient is passed as a reference and changes to recipients update the reference so we
         // need to cache the hashCode for the recipient and use that for diffing - unfortunately

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeViewModel.kt
@@ -102,8 +102,12 @@ class HomeViewModel @Inject constructor(
                 messageRequests?.let { add(it) }
 
                 threads.mapNotNullTo(this) { thread ->
-                    // if the note to self is marked as hidden, do not add it
-                    if (thread.recipient.isLocalNumber && hideNoteToSelf) {
+                    // if the note to self is marked as hidden,
+                    // or if the contact is blocked, do not add it
+                    if (
+                        thread.recipient.isLocalNumber && hideNoteToSelf ||
+                        thread.recipient.isBlocked
+                    ) {
                         return@mapNotNullTo null
                     }
 

--- a/app/src/main/res/layout/view_input_bar.xml
+++ b/app/src/main/res/layout/view_input_bar.xml
@@ -47,7 +47,7 @@
                 android:contentDescription="@string/AccessibilityId_inputBox"
                 android:gravity="center_vertical"
                 android:hint="@string/message"
-                android:inputType="textCapSentences|textMultiLine|textAutoComplete"
+                android:inputType="text|textCapSentences|textMultiLine|textAutoComplete"
                 android:maxLength="@integer/max_input_chars"
                 android:textColor="?input_bar_text_user"
                 android:textColorHint="?attr/input_bar_text_hint"


### PR DESCRIPTION
[SES-3253](https://optf.atlassian.net/browse/SES-3253) - Blocked contacts should not be shown in conversation list
[SES-3675](https://optf.atlassian.net/browse/SES-3675) - Showing the read indicator when appropriate
[SES-3805](https://optf.atlassian.net/browse/SES-3805) - NTS unpinned for wrong reasons: The logic was broken with making sure NTS were visible when sending a message there. We need to make sure it only happens when sending a Visible Message, but also only when the NTS is configured as hidden.