### PR TITLE
[SES-3538] - Clean up community related classes

### DIFF
--- a/app/src/main/java/org/session/libsession/database/StorageProtocol.kt
+++ b/app/src/main/java/org/session/libsession/database/StorageProtocol.kt
@@ -20,7 +20,6 @@ import org.session.libsession.messaging.messages.visible.Reaction
 import org.session.libsession.messaging.messages.visible.VisibleMessage
 import org.session.libsession.messaging.open_groups.GroupMember
 import org.session.libsession.messaging.open_groups.OpenGroup
-import org.session.libsession.messaging.open_groups.OpenGroupApi
 import org.session.libsession.messaging.sending_receiving.attachments.AttachmentId
 import org.session.libsession.messaging.sending_receiving.attachments.DatabaseAttachment
 import org.session.libsession.messaging.sending_receiving.data_extraction.DataExtractionNotificationInfoMessage
@@ -82,7 +81,7 @@ interface StorageProtocol {
     fun getAllOpenGroups(): Map<Long, OpenGroup>
     fun updateOpenGroup(openGroup: OpenGroup)
     fun getOpenGroup(threadId: Long): OpenGroup?
-    suspend fun addOpenGroup(urlAsString: String): OpenGroupApi.RoomInfo?
+    suspend fun addOpenGroup(urlAsString: String)
     fun onOpenGroupAdded(server: String, room: String)
     fun hasBackgroundGroupAddJob(groupJoinUrl: String): Boolean
     fun setOpenGroupServerMessageID(messageID: MessageId, serverID: Long, threadID: Long)

--- a/app/src/main/java/org/session/libsession/messaging/jobs/BackgroundGroupAddJob.kt
+++ b/app/src/main/java/org/session/libsession/messaging/jobs/BackgroundGroupAddJob.kt
@@ -1,6 +1,5 @@
 package org.session.libsession.messaging.jobs
 
-import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.open_groups.OpenGroup

--- a/app/src/main/java/org/session/libsession/messaging/open_groups/OpenGroupApi.kt
+++ b/app/src/main/java/org/session/libsession/messaging/open_groups/OpenGroupApi.kt
@@ -18,7 +18,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody
 import org.session.libsession.messaging.MessagingModuleConfiguration
-import org.session.libsession.messaging.sending_receiving.pollers.OpenGroupPoller.Companion.maxInactivityPeriod
+import org.session.libsession.messaging.sending_receiving.pollers.OpenGroupPoller.Companion.MAX_INACTIVITIY_PERIOD_MILLS
 import org.session.libsession.snode.OnionRequestAPI
 import org.session.libsession.snode.OnionResponse
 import org.session.libsession.snode.SnodeAPI
@@ -623,7 +623,7 @@ object OpenGroupApi {
         val context = MessagingModuleConfiguration.shared.context
         val timeSinceLastOpen = this.timeSinceLastOpen
         val shouldRetrieveRecentMessages = (hasPerformedInitialPoll[server] != true
-                && timeSinceLastOpen > maxInactivityPeriod)
+                && timeSinceLastOpen > MAX_INACTIVITIY_PERIOD_MILLS)
         hasPerformedInitialPoll[server] = true
         if (!hasUpdatedLastOpenDate) {
             hasUpdatedLastOpenDate = true

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
@@ -1,14 +1,27 @@
 package org.session.libsession.messaging.sending_receiving.pollers
 
 import com.google.protobuf.ByteString
-import nl.komponents.kovenant.Promise
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
 import nl.komponents.kovenant.functional.map
+import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.BlindedIdMapping
-import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.jobs.BatchMessageReceiveJob
 import org.session.libsession.messaging.jobs.GroupAvatarDownloadJob
 import org.session.libsession.messaging.jobs.JobQueue
-import org.session.libsession.messaging.jobs.MessageReceiveJob
 import org.session.libsession.messaging.jobs.MessageReceiveParameters
 import org.session.libsession.messaging.jobs.OpenGroupDeleteJob
 import org.session.libsession.messaging.jobs.TrimThreadJob
@@ -25,35 +38,42 @@ import org.session.libsession.messaging.sending_receiving.MessageReceiver
 import org.session.libsession.messaging.sending_receiving.handle
 import org.session.libsession.messaging.sending_receiving.handleOpenGroupReactions
 import org.session.libsession.snode.OnionRequestAPI
-import org.session.libsession.snode.utilities.successBackground
+import org.session.libsession.snode.utilities.await
 import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.GroupUtil
 import org.session.libsignal.protos.SignalServiceProtos
 import org.session.libsignal.utilities.Base64
 import org.session.libsignal.utilities.Log
-import java.util.UUID
+import org.thoughtcrime.securesms.util.AppVisibilityManager
 import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
-class OpenGroupPoller(private val server: String, private val executorService: ScheduledExecutorService?) {
-    var hasStarted = false
-    var isCaughtUp = false
-    var secondToLastJob: MessageReceiveJob? = null
-    private var future: ScheduledFuture<*>? = null
-    @Volatile private var runId: UUID = UUID.randomUUID()
+private typealias ManualPollRequestToken = Channel<Result<Unit>>
+
+class OpenGroupPoller @AssistedInject constructor(
+    private val storage: StorageProtocol,
+    private val appVisibilityManager: AppVisibilityManager,
+    @Assisted private val server: String,
+    @Assisted private val scope: CoroutineScope,
+) {
+    private val mutableIsCaughtUp = MutableStateFlow(false)
+    val isCaughtUp: StateFlow<Boolean> get() = mutableIsCaughtUp
+
+    private val manualPollRequest = Channel<ManualPollRequestToken>()
 
     companion object {
-        private const val pollInterval: Long = 4000L
-        const val maxInactivityPeriod = 14 * 24 * 60 * 60 * 1000
+        private const val POLL_INTERVAL_MILLS: Long = 4000L
+        const val MAX_INACTIVITIY_PERIOD_MILLS = 14 * 24 * 60 * 60 * 1000L // 14 days
 
-        public fun handleRoomPollInfo(
+        private const val TAG = "OpenGroupPoller"
+
+        fun handleRoomPollInfo(
+            storage: StorageProtocol,
             server: String,
             roomToken: String,
             pollInfo: OpenGroupApi.RoomPollInfo,
             createGroupIfMissingWithPublicKey: String? = null
         ) {
-            val storage = MessagingModuleConfiguration.shared.storage
             val groupId = "$server.$roomToken"
             val dbGroupId = GroupUtil.getEncodedOpenGroupID(groupId.toByteArray())
             val existingOpenGroup = storage.getOpenGroup(roomToken, server)
@@ -133,79 +153,94 @@ class OpenGroupPoller(private val server: String, private val executorService: S
         }
     }
 
-    fun startIfNeeded() {
-        if (hasStarted) { return }
-        hasStarted = true
-        runId = UUID.randomUUID()
-        future = executorService?.schedule(::poll, 0, TimeUnit.MILLISECONDS)
-    }
+    init {
+        scope.launch {
+            while (true) {
+                // Wait until the app is visible before starting the polling,
+                // or when we receive a manual poll request
+                val token = merge(
+                    appVisibilityManager.isAppVisible.filter { it }.map { null },
+                    manualPollRequest.receiveAsFlow()
+                ).first()
 
-    fun stop() {
-        future?.cancel(false)
-        hasStarted = false
-    }
-
-    fun poll(isPostCapabilitiesRetry: Boolean = false): Promise<Unit, Exception> {
-        val currentRunId = runId
-        val storage = MessagingModuleConfiguration.shared.storage
-        val rooms = storage.getAllOpenGroups().values.filter { it.server == server }.map { it.room }
-
-        return OpenGroupApi.poll(rooms, server).successBackground { responses ->
-            responses.filterNot { it.body == null }.forEach { response ->
-                when (response.endpoint) {
-                    is Endpoint.Capabilities -> {
-                        handleCapabilities(server, response.body as OpenGroupApi.Capabilities)
-                    }
-                    is Endpoint.RoomPollInfo -> {
-                        handleRoomPollInfo(server, response.endpoint.roomToken, response.body as OpenGroupApi.RoomPollInfo)
-                    }
-                    is Endpoint.RoomMessagesRecent -> {
-                        handleMessages(server, response.endpoint.roomToken, response.body as List<OpenGroupApi.Message>)
-                    }
-                    is Endpoint.RoomMessagesSince  -> {
-                        handleMessages(server, response.endpoint.roomToken, response.body as List<OpenGroupApi.Message>)
-                    }
-                    is Endpoint.Inbox, is Endpoint.InboxSince -> {
-                        handleDirectMessages(server, false, response.body as List<OpenGroupApi.DirectMessage>)
-                    }
-                    is Endpoint.Outbox, is Endpoint.OutboxSince -> {
-                        handleDirectMessages(server, true, response.body as List<OpenGroupApi.DirectMessage>)
-                    }
-                    else -> { /* We don't care about the result of any other calls (won't be polled for) */}
+                mutableIsCaughtUp.value = false
+                var delayDuration = POLL_INTERVAL_MILLS
+                try {
+                    Log.d(TAG, "Polling open group messages for server: $server")
+                    pollOnce()
+                    mutableIsCaughtUp.value = true
+                    token?.trySend(Result.success(Unit))
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error while polling open group messages", e)
+                    delayDuration = 2000L
+                    token?.trySend(Result.failure(e))
                 }
-                if (secondToLastJob == null && !isCaughtUp) {
-                    isCaughtUp = true
-                }
-            }
 
-            // Only poll again if it's the same poller run
-            if (currentRunId == runId) {
-                future = executorService?.schedule(this@OpenGroupPoller::poll, pollInterval, TimeUnit.MILLISECONDS)
+                delay(delayDuration)
             }
-        }.fail {
-            updateCapabilitiesIfNeeded(isPostCapabilitiesRetry, currentRunId, it)
-        }.map { }
+        }
     }
 
-    private fun updateCapabilitiesIfNeeded(isPostCapabilitiesRetry: Boolean, currentRunId: UUID, exception: Exception) {
+    private suspend fun pollOnce(isPostCapabilitiesRetry: Boolean = false) {
+        val rooms = storage.getAllOpenGroups()
+            .values
+            .asSequence()
+            .filter { it.server == server }
+            .map { it.room }
+            .toList()
+
+        try {
+            OpenGroupApi
+                .poll(rooms, server)
+                .await()
+                .asSequence()
+                .filterNot { it.body == null }
+                .forEach { response ->
+                    when (response.endpoint) {
+                        is Endpoint.Capabilities -> {
+                            handleCapabilities(server, response.body as OpenGroupApi.Capabilities)
+                        }
+                        is Endpoint.RoomPollInfo -> {
+                            handleRoomPollInfo(storage, server, response.endpoint.roomToken, response.body as OpenGroupApi.RoomPollInfo)
+                        }
+                        is Endpoint.RoomMessagesRecent -> {
+                            handleMessages(server, response.endpoint.roomToken, response.body as List<OpenGroupApi.Message>)
+                        }
+                        is Endpoint.RoomMessagesSince  -> {
+                            handleMessages(server, response.endpoint.roomToken, response.body as List<OpenGroupApi.Message>)
+                        }
+                        is Endpoint.Inbox, is Endpoint.InboxSince -> {
+                            handleDirectMessages(server, false, response.body as List<OpenGroupApi.DirectMessage>)
+                        }
+                        is Endpoint.Outbox, is Endpoint.OutboxSince -> {
+                            handleDirectMessages(server, true, response.body as List<OpenGroupApi.DirectMessage>)
+                        }
+                        else -> { /* We don't care about the result of any other calls (won't be polled for) */}
+                    }
+                }
+        } catch (e: Exception) {
+            updateCapabilitiesIfNeeded(isPostCapabilitiesRetry, e)
+            throw e
+        }
+    }
+
+    suspend fun manualPollOnce() {
+        val token = Channel<Result<Unit>>()
+        manualPollRequest.send(token)
+        token.receive().getOrThrow()
+    }
+
+    private fun updateCapabilitiesIfNeeded(isPostCapabilitiesRetry: Boolean, exception: Exception) {
         if (exception is OnionRequestAPI.HTTPRequestFailedBlindingRequiredException) {
             if (!isPostCapabilitiesRetry) {
                 OpenGroupApi.getCapabilities(server).map {
                     handleCapabilities(server, it)
                 }
-
-                // Only poll again if it's the same poller run
-                if (currentRunId == runId) {
-                    future = executorService?.schedule({ poll(isPostCapabilitiesRetry = true) }, pollInterval, TimeUnit.MILLISECONDS)
-                }
             }
-        } else if (currentRunId == runId) {
-            future = executorService?.schedule(this@OpenGroupPoller::poll, pollInterval, TimeUnit.MILLISECONDS)
         }
     }
 
     private fun handleCapabilities(server: String, capabilities: OpenGroupApi.Capabilities) {
-        val storage = MessagingModuleConfiguration.shared.storage
         storage.setServerCapabilities(server, capabilities.capabilities)
     }
     
@@ -216,7 +251,7 @@ class OpenGroupPoller(private val server: String, private val executorService: S
     ) {
         val sortedMessages = messages.sortedBy { it.seqno }
         sortedMessages.maxOfOrNull { it.seqno }?.let { seqNo ->
-            MessagingModuleConfiguration.shared.storage.setLastMessageServerID(roomToken, server, seqNo)
+            storage.setLastMessageServerID(roomToken, server, seqNo)
             OpenGroupApi.pendingReactions.removeAll { !(it.seqNo == null || it.seqNo!! > seqNo) }
         }
         val (deletions, additions) = sortedMessages.partition { it.deleted }
@@ -239,7 +274,6 @@ class OpenGroupPoller(private val server: String, private val executorService: S
         messages: List<OpenGroupApi.DirectMessage>
     ) {
         if (messages.isEmpty()) return
-        val storage = MessagingModuleConfiguration.shared.storage
         val serverPublicKey = storage.getOpenGroupPublicKey(server)!!
         val sortedMessages = messages.sortedBy { it.id }
         val lastMessageId = sortedMessages.last().id
@@ -281,22 +315,21 @@ class OpenGroupPoller(private val server: String, private val executorService: S
                     }
                     mappingCache[it.recipient] = mapping
                 }
-                val threadId = Message.getThreadId(message, null, MessagingModuleConfiguration.shared.storage, false)
+                val threadId = Message.getThreadId(message, null, storage, false)
                 MessageReceiver.handle(message, proto, threadId ?: -1, null, null)
             } catch (e: Exception) {
-                Log.e("Loki", "Couldn't handle direct message", e)
+                Log.e(TAG, "Couldn't handle direct message", e)
             }
         }
     }
 
     private fun handleNewMessages(server: String, roomToken: String, messages: List<OpenGroupMessage>) {
-        val storage = MessagingModuleConfiguration.shared.storage
         val openGroupID = "$server.$roomToken"
         val groupID = GroupUtil.getEncodedOpenGroupID(openGroupID.toByteArray())
         // check thread still exists
         val threadId = storage.getThreadId(Address.fromSerialized(groupID)) ?: -1
         val threadExists = threadId >= 0
-        if (!hasStarted || !threadExists) { return }
+        if (!threadExists) { return }
         val envelopes =  mutableListOf<Triple<Long?, SignalServiceProtos.Envelope, Map<String, OpenGroupApi.Reaction>?>>()
         messages.sortedBy { it.serverID!! }.forEach { message ->
             if (!message.base64EncodedData.isNullOrEmpty()) {
@@ -329,7 +362,6 @@ class OpenGroupPoller(private val server: String, private val executorService: S
 
     private fun handleDeletedMessages(server: String, roomToken: String, serverIds: List<Long>) {
         val openGroupId = "$server.$roomToken"
-        val storage = MessagingModuleConfiguration.shared.storage
         val groupID = GroupUtil.getEncodedOpenGroupID(openGroupId.toByteArray())
         val threadID = storage.getThreadId(Address.fromSerialized(groupID)) ?: return
 
@@ -337,5 +369,10 @@ class OpenGroupPoller(private val server: String, private val executorService: S
             val deleteJob = OpenGroupDeleteJob(serverIds.toLongArray(), threadID, openGroupId)
             JobQueue.shared.add(deleteJob)
         }
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(server: String, scope: CoroutineScope): OpenGroupPoller
     }
 }

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.selects.select
 import nl.komponents.kovenant.functional.map
 import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.BlindedIdMapping
@@ -45,11 +44,18 @@ import org.session.libsignal.protos.SignalServiceProtos
 import org.session.libsignal.utilities.Base64
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.util.AppVisibilityManager
-import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
 private typealias ManualPollRequestToken = Channel<Result<Unit>>
 
+/**
+ * A [OpenGroupPoller] is responsible for polling all communities on a particular server.
+ *
+ * Once this class is created, it will start polling when the app becomes visible (and stop whe
+ * the app becomes invisible), it will also respond to manual poll requests regardless of the app visibility.
+ *
+ * To stop polling, you can cancel the [CoroutineScope] that was passed to the constructor.
+ */
 class OpenGroupPoller @AssistedInject constructor(
     private val storage: StorageProtocol,
     private val appVisibilityManager: AppVisibilityManager,

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPollerManager.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPollerManager.kt
@@ -1,0 +1,106 @@
+package org.session.libsession.messaging.sending_receiving.pollers
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.scan
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import org.session.libsession.utilities.ConfigFactoryProtocol
+import org.session.libsession.utilities.ConfigUpdateNotification
+import org.session.libsession.utilities.TextSecurePreferences
+import org.session.libsignal.utilities.Log
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "OpenGroupPollerManager"
+
+@Singleton
+class OpenGroupPollerManager @Inject constructor(
+    pollerFactory: OpenGroupPoller.Factory,
+    configFactory: ConfigFactoryProtocol,
+    preferences: TextSecurePreferences,
+) {
+    val pollers: StateFlow<Map<String, PollerHandle>> =
+        preferences.watchLocalNumber()
+            .map { it != null }
+            .distinctUntilChanged()
+            .flatMapLatest { loggedIn ->
+                if (loggedIn) {
+                    (configFactory
+                        .configUpdateNotifications
+                        .filter { it is ConfigUpdateNotification.UserConfigsMerged || it == ConfigUpdateNotification.UserConfigsModified } as Flow<*>)
+                        .onStart { emit(Unit) }
+                        .map {
+                            configFactory.withUserConfigs { configs ->
+                                configs.userGroups.allCommunityInfo()
+                            }.mapTo(hashSetOf()) { it.community.baseUrl }
+                        }
+                } else {
+                    flowOf(emptySet())
+                }
+            }
+            .scan(emptyMap<String, PollerHandle>()) { acc, value ->
+                if (acc.keys == value) {
+                    acc // No change, return the same map
+                } else {
+                    val newPollerStates = value.associateWith { baseUrl ->
+                        acc[baseUrl] ?: run {
+                            val scope = CoroutineScope(Dispatchers.Default)
+                            Log.d(TAG, "Creating new poller for $baseUrl")
+                            PollerHandle(
+                                poller = pollerFactory.create(baseUrl, scope),
+                                pollerScope = scope
+                            )
+                        }
+                    }
+
+                    for ((baseUrl, handle) in acc) {
+                        if (baseUrl !in value) {
+                            Log.d(TAG, "Stopping poller for $baseUrl")
+                            handle.pollerScope.cancel()
+                        }
+                    }
+
+                    newPollerStates
+                }
+            }
+            .stateIn(GlobalScope, SharingStarted.Eagerly, emptyMap())
+
+    val isAllCaughtUp: Boolean
+        get() = pollers.value.values.all { it.poller.isCaughtUp.value }
+
+
+    suspend fun pollAllOpenGroupsOnce() {
+        Log.d(TAG, "Polling all open groups once")
+        supervisorScope {
+            pollers.value.map { (server, handle) ->
+                handle.pollerScope.launch {
+                    runCatching {
+                        handle.poller.manualPollOnce()
+                    }.onFailure {
+                        Log.e(TAG, "Error polling open group ${server}", it)
+                    }
+                }
+            }.joinAll()
+        }
+    }
+
+    data class PollerHandle(
+        val poller: OpenGroupPoller,
+        val pollerScope: CoroutineScope
+    )
+}

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPollerManager.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPollerManager.kt
@@ -3,7 +3,6 @@ package org.session.libsession.messaging.sending_receiving.pollers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -28,6 +27,15 @@ import javax.inject.Singleton
 
 private const val TAG = "OpenGroupPollerManager"
 
+/**
+ * [OpenGroupPollerManager] manages the lifecycle of [OpenGroupPoller] instances for all
+ * subscribed open groups. It creates a poller for a server (a server can host
+ * multiple open groups), and it stops the poller when the server is no longer subscribed by
+ * any open groups.
+ *
+ * This process is fully responsive to changes in the user's config and as long as the config
+ * is up to date, the pollers will be created and stopped correctly.
+ */
 @Singleton
 class OpenGroupPollerManager @Inject constructor(
     pollerFactory: OpenGroupPoller.Factory,

--- a/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
@@ -64,13 +64,13 @@ class ConfigToDatabaseSync @Inject constructor(
     private val configFactory: ConfigFactoryProtocol,
     private val storage: StorageProtocol,
     private val threadDatabase: ThreadDatabase,
-    private val recipientDatabase: RecipientDatabase,
     private val clock: SnodeClock,
     private val profileManager: ProfileManager,
     private val preferences: TextSecurePreferences,
     private val conversationRepository: ConversationRepository,
     private val mmsSmsDatabase: MmsSmsDatabase,
     private val legacyClosedGroupPollerV2: LegacyClosedGroupPollerV2,
+    private val openGroupManager: OpenGroupManager,
 ) {
     init {
         if (!preferences.migratedToGroupV2Config) {
@@ -285,7 +285,7 @@ class ConfigToDatabaseSync @Inject constructor(
 
         // delete the ones which are not listed in the config
         toDeleteCommunities.values.forEach { openGroup ->
-            OpenGroupManager.delete(openGroup.server, openGroup.room, context)
+            openGroupManager.delete(openGroup.server, openGroup.room, context)
         }
 
         toDeleteLegacyClosedGroups.forEach { deleteGroup ->

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1930,7 +1930,11 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
         if (viewModel.recipient?.isGroupOrCommunityRecipient == true) {
             val isUserModerator = viewModel.openGroup?.let { openGroup ->
                 val userPublicKey = textSecurePreferences.getLocalNumber() ?: return@let false
-                openGroupManager.isUserModerator(this, openGroup.id, userPublicKey, viewModel.blindedPublicKey)
+                openGroupManager.isUserModerator(
+                    openGroup.id,
+                    userPublicKey,
+                    viewModel.blindedPublicKey
+                )
             } ?: false
             val fragment = ReactionsDialogFragment.create(messageId, isUserModerator, emoji, viewModel.canRemoveReaction)
             fragment.show(supportFragmentManager, null)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -257,6 +257,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
     @Inject lateinit var groupManagerV2: GroupManagerV2
     @Inject lateinit var typingStatusRepository: TypingStatusRepository
     @Inject lateinit var typingStatusSender: TypingStatusSender
+    @Inject lateinit var openGroupManager: OpenGroupManager
 
     override val applyDefaultWindowInsets: Boolean
         get() = false
@@ -1547,7 +1548,8 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
             adapter = adapter,
             threadID = viewModel.threadId,
             context = this,
-            deprecationManager = viewModel.legacyGroupDeprecationManager
+            deprecationManager = viewModel.legacyGroupDeprecationManager,
+            openGroupManager = openGroupManager,
         )
         actionModeCallback.delegate = this
         actionModeCallback.updateActionModeMenu(actionMode.menu)
@@ -1571,7 +1573,8 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
             adapter = adapter,
             threadID = viewModel.threadId,
             context = this,
-            deprecationManager = viewModel.legacyGroupDeprecationManager
+            deprecationManager = viewModel.legacyGroupDeprecationManager,
+            openGroupManager = openGroupManager,
         )
         actionModeCallback.delegate = this
         if(binding.searchBottomBar.isVisible) onSearchClosed()
@@ -1927,7 +1930,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
         if (viewModel.recipient?.isGroupOrCommunityRecipient == true) {
             val isUserModerator = viewModel.openGroup?.let { openGroup ->
                 val userPublicKey = textSecurePreferences.getLocalNumber() ?: return@let false
-                OpenGroupManager.isUserModerator(this, openGroup.id, userPublicKey, viewModel.blindedPublicKey)
+                openGroupManager.isUserModerator(this, openGroup.id, userPublicKey, viewModel.blindedPublicKey)
             } ?: false
             val fragment = ReactionsDialogFragment.create(messageId, isUserModerator, emoji, viewModel.canRemoveReaction)
             fragment.show(supportFragmentManager, null)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
@@ -109,6 +109,7 @@ class ConversationReactionOverlay : FrameLayout {
     @Inject lateinit var threadDatabase: ThreadDatabase
     @Inject lateinit var textSecurePreferences: TextSecurePreferences
     @Inject lateinit var deprecationManager: LegacyGroupDeprecationManager
+    @Inject lateinit var openGroupManager: OpenGroupManager
 
     private var job: Job? = null
 
@@ -643,7 +644,7 @@ class ConversationReactionOverlay : FrameLayout {
     private fun userCanBanSelectedUsers(context: Context, message: MessageRecord, openGroup: OpenGroup?, userPublicKey: String, blindedPublicKey: String?): Boolean {
         if (openGroup == null)  return false
         if (message.isOutgoing) return false // Users can't ban themselves
-        return OpenGroupManager.isUserModerator(context, openGroup.groupId, userPublicKey, blindedPublicKey)
+        return openGroupManager.isUserModerator(context, openGroup.groupId, userPublicKey, blindedPublicKey)
     }
 
     private fun handleActionItemClicked(action: Action) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
@@ -3,7 +3,6 @@ package org.thoughtcrime.securesms.conversation.v2
 import android.animation.Animator
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
-import android.animation.ValueAnimator
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
@@ -29,11 +28,9 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -48,7 +45,6 @@ import org.session.libsession.utilities.TextSecurePreferences.Companion.getLocal
 import org.session.libsession.utilities.ThemeUtil
 import org.session.libsession.utilities.getColorFromAttr
 import org.session.libsession.utilities.recipients.Recipient
-import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.components.emoji.EmojiImageView
 import org.thoughtcrime.securesms.components.emoji.RecentEmojiPageModel
 import org.thoughtcrime.securesms.components.menu.ActionItem
@@ -56,7 +52,6 @@ import org.thoughtcrime.securesms.database.LokiThreadDatabase
 import org.thoughtcrime.securesms.database.MmsSmsDatabase
 import org.thoughtcrime.securesms.database.ThreadDatabase
 import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord
-import org.thoughtcrime.securesms.database.model.MessageId
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.database.model.ReactionRecord
 import org.thoughtcrime.securesms.groups.OpenGroupManager
@@ -644,7 +639,7 @@ class ConversationReactionOverlay : FrameLayout {
     private fun userCanBanSelectedUsers(context: Context, message: MessageRecord, openGroup: OpenGroup?, userPublicKey: String, blindedPublicKey: String?): Boolean {
         if (openGroup == null)  return false
         if (message.isOutgoing) return false // Users can't ban themselves
-        return openGroupManager.isUserModerator(context, openGroup.groupId, userPublicKey, blindedPublicKey)
+        return openGroupManager.isUserModerator(openGroup.groupId, userPublicKey, blindedPublicKey)
     }
 
     private fun handleActionItemClicked(action: Action) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -107,8 +107,8 @@ class ConversationViewModel(
     private val expiredGroupManager: ExpiredGroupManager,
     private val usernameUtils: UsernameUtils,
     private val avatarUtils: AvatarUtils,
-    private val recipientChangeSource: RecipientChangeSource
-
+    private val recipientChangeSource: RecipientChangeSource,
+    private val openGroupManager: OpenGroupManager,
 ) : ViewModel() {
 
     val showSendAfterApprovalText: Boolean
@@ -343,7 +343,7 @@ class ConversationViewModel(
 
         // Listen for changes in the open group's write access
         viewModelScope.launch {
-            OpenGroupManager.getCommunitiesWriteAccessFlow()
+            openGroupManager.getCommunitiesWriteAccessFlow()
                 .map {
                     withContext(Dispatchers.Default) {
                         if (openGroup?.groupId != null)
@@ -1015,7 +1015,7 @@ class ConversationViewModel(
 
     private fun isUserCommunityManager() = openGroup?.let { openGroup ->
         val userPublicKey = textSecurePreferences.getLocalNumber() ?: return@let false
-        OpenGroupManager.isUserModerator(application, openGroup.id, userPublicKey, blindedPublicKey)
+        openGroupManager.isUserModerator(application, openGroup.id, userPublicKey, blindedPublicKey)
     } ?: false
 
     /**
@@ -1297,6 +1297,7 @@ class ConversationViewModel(
         private val usernameUtils: UsernameUtils,
         private val avatarUtils: AvatarUtils,
         private val recipientChangeSource: RecipientChangeSource,
+        private val openGroupManager: OpenGroupManager,
     ) : ViewModelProvider.Factory {
 
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -1321,7 +1322,8 @@ class ConversationViewModel(
                 expiredGroupManager = expiredGroupManager,
                 usernameUtils = usernameUtils,
                 avatarUtils = avatarUtils,
-                recipientChangeSource = recipientChangeSource
+                recipientChangeSource = recipientChangeSource,
+                openGroupManager = openGroupManager,
             ) as T
         }
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -1015,7 +1015,7 @@ class ConversationViewModel(
 
     private fun isUserCommunityManager() = openGroup?.let { openGroup ->
         val userPublicKey = textSecurePreferences.getLocalNumber() ?: return@let false
-        openGroupManager.isUserModerator(application, openGroup.id, userPublicKey, blindedPublicKey)
+        openGroupManager.isUserModerator(openGroup.id, userPublicKey, blindedPublicKey)
     } ?: false
 
     /**

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/dialogs/JoinOpenGroupDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/dialogs/JoinOpenGroupDialog.kt
@@ -30,6 +30,9 @@ class JoinOpenGroupDialog(private val name: String, private val url: String) : D
     @Inject
     lateinit var storage: StorageProtocol
 
+    @Inject
+    lateinit var openGroupManager: OpenGroupManager
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog = createSessionDialog {
         title(resources.getString(R.string.communityJoin))
         val explanation = Phrase.from(context, R.string.communityJoinDescription).put(COMMUNITY_NAME_KEY, name).format()
@@ -53,7 +56,7 @@ class JoinOpenGroupDialog(private val name: String, private val url: String) : D
         GlobalScope.launch(Dispatchers.Main) {
             try {
                 withContext(Dispatchers.Default) {
-                    OpenGroupManager.add(
+                    openGroupManager.add(
                         server = openGroup.server,
                         room = openGroup.room,
                         publicKey = openGroup.serverPublicKey,

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationActionModeCallback.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationActionModeCallback.kt
@@ -28,6 +28,7 @@ class ConversationActionModeCallback(
     private val threadID: Long,
     private val context: Context,
     private val deprecationManager: LegacyGroupDeprecationManager,
+    private val openGroupManager: OpenGroupManager,
     ) : ActionMode.Callback {
     var delegate: ConversationActionModeCallbackDelegate? = null
 
@@ -76,7 +77,7 @@ class ConversationActionModeCallback(
             if (anySentByCurrentUser) { return false } // Users can't ban themselves
             val selectedUsers = selectedItems.map { it.recipient.address.toString() }.toSet()
             if (selectedUsers.size > 1) { return false }
-            return OpenGroupManager.isUserModerator(context, openGroup.groupId, userPublicKey, blindedPublicKey)
+            return openGroupManager.isUserModerator(context, openGroup.groupId, userPublicKey, blindedPublicKey)
         }
 
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationActionModeCallback.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationActionModeCallback.kt
@@ -77,7 +77,11 @@ class ConversationActionModeCallback(
             if (anySentByCurrentUser) { return false } // Users can't ban themselves
             val selectedUsers = selectedItems.map { it.recipient.address.toString() }.toSet()
             if (selectedUsers.size > 1) { return false }
-            return openGroupManager.isUserModerator(context, openGroup.groupId, userPublicKey, blindedPublicKey)
+            return openGroupManager.isUserModerator(
+                openGroup.groupId,
+                userPublicKey,
+                blindedPublicKey
+            )
         }
 
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
@@ -230,7 +230,11 @@ class VisibleMessageView : FrameLayout {
                     } else {
                         standardPublicKey = senderAccountID
                     }
-                    val isModerator = openGroupManager.isUserModerator(context, openGroup.groupId, standardPublicKey, blindedPublicKey)
+                    val isModerator = openGroupManager.isUserModerator(
+                        openGroup.groupId,
+                        standardPublicKey,
+                        blindedPublicKey
+                    )
                     binding.moderatorIconImageView.isVisible = isModerator
                 }
                 else if (thread.isLegacyGroupRecipient) { // legacy groups

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
@@ -87,6 +87,7 @@ class VisibleMessageView : FrameLayout {
     @Inject lateinit var dateUtils: DateUtils
     @Inject lateinit var configFactory: ConfigFactoryProtocol
     @Inject lateinit var usernameUtils: UsernameUtils
+    @Inject lateinit var openGroupManager: OpenGroupManager
 
     private val binding = ViewVisibleMessageBinding.inflate(LayoutInflater.from(context), this, true)
 
@@ -229,7 +230,7 @@ class VisibleMessageView : FrameLayout {
                     } else {
                         standardPublicKey = senderAccountID
                     }
-                    val isModerator = OpenGroupManager.isUserModerator(context, openGroup.groupId, standardPublicKey, blindedPublicKey)
+                    val isModerator = openGroupManager.isUserModerator(context, openGroup.groupId, standardPublicKey, blindedPublicKey)
                     binding.moderatorIconImageView.isVisible = isModerator
                 }
                 else if (thread.isLegacyGroupRecipient) { // legacy groups

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsViewModel.kt
@@ -94,6 +94,7 @@ class ConversationSettingsViewModel @AssistedInject constructor(
     private val prefs: TextSecurePreferences,
     private val lokiThreadDatabase: LokiThreadDatabase,
     private val groupManager: GroupManagerV2,
+    private val openGroupManager: OpenGroupManager,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<UIState> = MutableStateFlow(
@@ -497,7 +498,7 @@ class ConversationSettingsViewModel @AssistedInject constructor(
                     serverPubKey = Hex.fromStringCondensed(it),
                 )?.pubKey?.data }
                 ?.let { AccountId(IdPrefix.BLINDED, it) }?.hexString
-            return OpenGroupManager.isUserModerator(context, community!!.id, userPublicKey, blindedPublicKey)
+            return openGroupManager.isUserModerator(context, community!!.id, userPublicKey, blindedPublicKey)
         }
     }
 
@@ -717,7 +718,7 @@ class ConversationSettingsViewModel @AssistedInject constructor(
             withContext(Dispatchers.Default) {
                 val community = lokiThreadDatabase.getOpenGroupChat(threadId)
                 if (community != null) {
-                    OpenGroupManager.delete(community.server, community.room, context)
+                    openGroupManager.delete(community.server, community.room, context)
                 }
             }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsViewModel.kt
@@ -498,7 +498,7 @@ class ConversationSettingsViewModel @AssistedInject constructor(
                     serverPubKey = Hex.fromStringCondensed(it),
                 )?.pubKey?.data }
                 ?.let { AccountId(IdPrefix.BLINDED, it) }?.hexString
-            return openGroupManager.isUserModerator(context, community!!.id, userPublicKey, blindedPublicKey)
+            return openGroupManager.isUserModerator(community!!.id, userPublicKey, blindedPublicKey)
         }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/database/GroupDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/GroupDatabase.java
@@ -36,7 +36,7 @@ import javax.inject.Provider;
 
 /**
  * @deprecated This database table management is only used for
- * legacy group management. It is not used in groupv2. For group v2 data, you generally need
+ * legacy group and community management. It is not used in groupv2. For group v2 data, you generally need
  * to query config system directly. The Storage class may also be more up-to-date.
  *
  */

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -1067,7 +1067,6 @@ open class Storage @Inject constructor(
     }
 
     override fun onOpenGroupAdded(server: String, room: String) {
-        OpenGroupManager.restartPollerForServer(server.removeSuffix("/"))
         configFactory.withMutableUserConfigs { configs ->
             val groups = configs.userGroups
             val volatileConfig = configs.convoInfoVolatile

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -44,7 +44,6 @@ import org.session.libsession.messaging.messages.visible.Reaction
 import org.session.libsession.messaging.messages.visible.VisibleMessage
 import org.session.libsession.messaging.open_groups.GroupMember
 import org.session.libsession.messaging.open_groups.OpenGroup
-import org.session.libsession.messaging.open_groups.OpenGroupApi
 import org.session.libsession.messaging.sending_receiving.attachments.AttachmentId
 import org.session.libsession.messaging.sending_receiving.attachments.DatabaseAttachment
 import org.session.libsession.messaging.sending_receiving.data_extraction.DataExtractionNotificationInfoMessage
@@ -1063,7 +1062,7 @@ open class Storage @Inject constructor(
         return groupDatabase.getAllGroups(includeInactive)
     }
 
-    override suspend fun addOpenGroup(urlAsString: String): OpenGroupApi.RoomInfo? {
+    override suspend fun addOpenGroup(urlAsString: String) {
         return openGroupManager.get().addOpenGroup(urlAsString, context)
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -129,7 +129,8 @@ open class Storage @Inject constructor(
     private val messageExpirationManager: SSKEnvironment.MessageExpirationManagerProtocol,
     private val clock: SnodeClock,
     private val preferences: TextSecurePreferences,
-    private val usernameUtils: UsernameUtils
+    private val usernameUtils: UsernameUtils,
+    private val openGroupManager: Provider<OpenGroupManager>,
 ) : Database(context, helper), StorageProtocol, ThreadDatabase.ConversationThreadUpdateListener {
 
     init {
@@ -1055,7 +1056,7 @@ open class Storage @Inject constructor(
     }
 
     override fun updateOpenGroup(openGroup: OpenGroup) {
-        OpenGroupManager.updateOpenGroup(openGroup, context)
+        openGroupManager.get().updateOpenGroup(openGroup, context)
     }
 
     override fun getAllGroups(includeInactive: Boolean): List<GroupRecord> {
@@ -1063,7 +1064,7 @@ open class Storage @Inject constructor(
     }
 
     override suspend fun addOpenGroup(urlAsString: String): OpenGroupApi.RoomInfo? {
-        return OpenGroupManager.addOpenGroup(urlAsString, context)
+        return openGroupManager.get().addOpenGroup(urlAsString, context)
     }
 
     override fun onOpenGroupAdded(server: String, room: String) {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.database
 
 import android.content.Context
 import android.net.Uri
+import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import network.loki.messenger.libsession_util.ConfigBase.Companion.PRIORITY_HIDDEN
 import network.loki.messenger.libsession_util.ConfigBase.Companion.PRIORITY_PINNED
@@ -129,7 +130,7 @@ open class Storage @Inject constructor(
     private val clock: SnodeClock,
     private val preferences: TextSecurePreferences,
     private val usernameUtils: UsernameUtils,
-    private val openGroupManager: Provider<OpenGroupManager>,
+    private val openGroupManager: Lazy<OpenGroupManager>,
 ) : Database(context, helper), StorageProtocol, ThreadDatabase.ConversationThreadUpdateListener {
 
     init {

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/AppModule.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/AppModule.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import org.session.libsession.messaging.groups.GroupManagerV2
 import org.session.libsession.messaging.sending_receiving.notifications.MessageNotifier
+import org.session.libsession.messaging.sending_receiving.pollers.OpenGroupPollerManager
 import org.session.libsession.utilities.AppTextSecurePreferences
 import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsession.utilities.SSKEnvironment
@@ -32,9 +33,10 @@ class AppModule {
     @Provides
     @Singleton
     fun provideMessageNotifier(
-        avatarUtils: AvatarUtils
+        avatarUtils: AvatarUtils,
+        openGroupPollerManager: OpenGroupPollerManager,
     ): MessageNotifier {
-        return OptimizedMessageNotifier(DefaultMessageNotifier(avatarUtils))
+        return OptimizedMessageNotifier(DefaultMessageNotifier(avatarUtils), openGroupPollerManager)
     }
 }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManager.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupManager.java
@@ -63,7 +63,6 @@ public class GroupManager {
 
     long threadID = DatabaseComponent.get(context).threadDatabase().getOrCreateThreadIdFor(
             groupRecipient, DistributionTypes.CONVERSATION);
-    DatabaseComponent.get(context).threadDatabase().setThreadArchived(threadID);
     return new GroupActionResult(groupRecipient, threadID);
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/JoinCommunityFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/JoinCommunityFragment.kt
@@ -30,6 +30,7 @@ import org.thoughtcrime.securesms.conversation.start.StartConversationDelegate
 import org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2
 import org.thoughtcrime.securesms.ui.getSubbedString
 import org.thoughtcrime.securesms.util.ConfigurationMessageUtilities
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class JoinCommunityFragment : Fragment() {
@@ -39,6 +40,9 @@ class JoinCommunityFragment : Fragment() {
     lateinit var delegate: StartConversationDelegate
 
     var lastUrl: String? = null
+
+    @Inject
+    lateinit var openGroupManager: OpenGroupManager
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -104,7 +108,7 @@ class JoinCommunityFragment : Fragment() {
                     try {
                         val sanitizedServer = openGroup.server.removeSuffix("/")
                         val openGroupID = "$sanitizedServer.${openGroup.room}"
-                        OpenGroupManager.add(
+                        openGroupManager.add(
                             sanitizedServer,
                             openGroup.room,
                             openGroup.serverPublicKey,

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/JoinCommunityFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/JoinCommunityFragment.kt
@@ -12,7 +12,6 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.tabs.TabLayoutMediator
-import com.squareup.phrase.Phrase
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -29,7 +28,6 @@ import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.conversation.start.StartConversationDelegate
 import org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2
 import org.thoughtcrime.securesms.ui.getSubbedString
-import org.thoughtcrime.securesms.util.ConfigurationMessageUtilities
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/OpenGroupManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/OpenGroupManager.kt
@@ -21,6 +21,9 @@ import org.thoughtcrime.securesms.database.ThreadDatabase
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Manage common operations for open groups, such as adding, deleting, and updating them.
+ */
 @Singleton
 class OpenGroupManager @Inject constructor(
     private val storage: StorageProtocol,

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/OpenGroupManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/OpenGroupManager.kt
@@ -1,6 +1,5 @@
 package org.thoughtcrime.securesms.groups
 
-import android.app.Application
 import android.content.Context
 import android.widget.Toast
 import com.squareup.phrase.Phrase
@@ -13,10 +12,8 @@ import org.session.libsession.messaging.open_groups.OpenGroup
 import org.session.libsession.messaging.open_groups.OpenGroupApi
 import org.session.libsession.messaging.sending_receiving.pollers.OpenGroupPoller
 import org.session.libsession.snode.utilities.await
-import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsession.utilities.StringSubstitutionConstants.COMMUNITY_NAME_KEY
-import org.session.libsession.utilities.recipients.Recipient
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.database.GroupMemberDatabase
 import org.thoughtcrime.securesms.database.LokiThreadDatabase
@@ -31,7 +28,6 @@ class OpenGroupManager @Inject constructor(
     private val threadDb: ThreadDatabase,
     private val configFactory: ConfigFactoryProtocol,
     private val groupMemberDatabase: GroupMemberDatabase,
-    private val application: Application,
 ) {
 
     // flow holding information on write access for our current communities
@@ -77,7 +73,6 @@ class OpenGroupManager @Inject constructor(
             val openGroupID = "${server.removeSuffix("/")}.$room"
             val threadID = GroupManager.getOpenGroupThreadID(openGroupID, context)
             val recipient = threadDb.getRecipientForThreadId(threadID) ?: return
-            threadDb.setThreadArchived(threadID)
             val groupID = recipient.address.toString()
             // Stop the poller if needed
             configFactory.withMutableUserConfigs {

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -282,7 +282,6 @@ class HomeActivity : ScreenLockActionBarActivity(),
                 // update things based on TextSecurePrefs (profile info etc)
                 // Set up remaining components if needed
                 if (textSecurePreferences.getLocalNumber() != null) {
-                    OpenGroupManager.startPolling()
                     JobQueue.shared.resumePendingJobs()
                 }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -123,6 +123,7 @@ class HomeActivity : ScreenLockActionBarActivity(),
     @Inject lateinit var clock: SnodeClock
     @Inject lateinit var messageNotifier: MessageNotifier
     @Inject lateinit var dateUtils: DateUtils
+    @Inject lateinit var openGroupManager: OpenGroupManager
 
     private val globalSearchViewModel by viewModels<GlobalSearchViewModel>()
     private val homeViewModel by viewModels<HomeViewModel>()
@@ -717,7 +718,7 @@ class HomeActivity : ScreenLockActionBarActivity(),
                 // Delete the conversation
                 val community = lokiThreadDatabase.getOpenGroupChat(threadID)
                 if (community != null) {
-                    OpenGroupManager.delete(community.server, community.room, context)
+                    openGroupManager.delete(community.server, community.room, context)
                 } else {
                     lifecycleScope.launch(Dispatchers.Default) {
                         storage.deleteConversation(threadID)

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/OptimizedMessageNotifier.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/OptimizedMessageNotifier.java
@@ -3,16 +3,15 @@ package org.thoughtcrime.securesms.notifications;
 import android.content.Context;
 import android.os.Looper;
 
-import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 
 import org.session.libsession.messaging.sending_receiving.notifications.MessageNotifier;
+import org.session.libsession.messaging.sending_receiving.pollers.OpenGroupPollerManager;
 import org.session.libsession.messaging.sending_receiving.pollers.Poller;
-import org.session.libsession.utilities.recipients.Recipient;
 import org.session.libsession.utilities.Debouncer;
+import org.session.libsession.utilities.recipients.Recipient;
 import org.session.libsignal.utilities.ThreadUtils;
 import org.thoughtcrime.securesms.ApplicationContext;
-import org.thoughtcrime.securesms.groups.OpenGroupManager;
 
 import java.util.concurrent.TimeUnit;
 
@@ -22,10 +21,12 @@ public class OptimizedMessageNotifier implements MessageNotifier {
   private final MessageNotifier         wrapped;
   private final Debouncer               debouncer;
 
-  @MainThread
-  public OptimizedMessageNotifier(@NonNull MessageNotifier wrapped) {
+  private final OpenGroupPollerManager  openGroupPollerManager;
+
+  public OptimizedMessageNotifier(@NonNull MessageNotifier wrapped, OpenGroupPollerManager openGroupPollerManager) {
     this.wrapped   = wrapped;
-    this.debouncer = new Debouncer(TimeUnit.SECONDS.toMillis(2));
+      this.openGroupPollerManager = openGroupPollerManager;
+      this.debouncer = new Debouncer(TimeUnit.SECONDS.toMillis(2));
   }
 
   @Override
@@ -55,7 +56,7 @@ public class OptimizedMessageNotifier implements MessageNotifier {
       isCaughtUp = isCaughtUp && !poller.isPolling();
     }
 
-    isCaughtUp = isCaughtUp && OpenGroupManager.INSTANCE.isAllCaughtUp();
+    isCaughtUp = isCaughtUp && openGroupPollerManager.isAllCaughtUp();
 
     if (isCaughtUp) {
       performOnBackgroundThreadIfNeeded(() -> wrapped.updateNotification(context));
@@ -72,7 +73,7 @@ public class OptimizedMessageNotifier implements MessageNotifier {
       isCaughtUp = isCaughtUp && !lokiPoller.isPolling();
     }
 
-    isCaughtUp = isCaughtUp && OpenGroupManager.INSTANCE.isAllCaughtUp();
+    isCaughtUp = isCaughtUp && openGroupPollerManager.isAllCaughtUp();
     
     if (isCaughtUp) {
       performOnBackgroundThreadIfNeeded(() -> wrapped.updateNotification(context, threadId));
@@ -89,7 +90,7 @@ public class OptimizedMessageNotifier implements MessageNotifier {
       isCaughtUp = isCaughtUp && !lokiPoller.isPolling();
     }
 
-    isCaughtUp = isCaughtUp && OpenGroupManager.INSTANCE.isAllCaughtUp();
+    isCaughtUp = isCaughtUp && openGroupPollerManager.isAllCaughtUp();
 
     if (isCaughtUp) {
       performOnBackgroundThreadIfNeeded(() -> wrapped.updateNotification(context, threadId, signal));
@@ -106,7 +107,7 @@ public class OptimizedMessageNotifier implements MessageNotifier {
       isCaughtUp = isCaughtUp && !lokiPoller.isPolling();
     }
 
-    isCaughtUp = isCaughtUp && OpenGroupManager.INSTANCE.isAllCaughtUp();
+    isCaughtUp = isCaughtUp && openGroupPollerManager.isAllCaughtUp();
 
     if (isCaughtUp) {
       performOnBackgroundThreadIfNeeded(() -> wrapped.updateNotification(context, signal, reminderCount));

--- a/app/src/test/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModelTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModelTest.kt
@@ -91,7 +91,9 @@ class ConversationViewModelTest: BaseViewModelTest() {
             lokiAPIDb = mock(),
             recipientChangeSource = NoopRecipientChangeSource,
             dateUtils = mock(),
-            openGroupManager = mock()
+            openGroupManager = mock {
+                on { getCommunitiesWriteAccessFlow() } doReturn MutableStateFlow(emptyMap())
+            }
         )
     }
 

--- a/app/src/test/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModelTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModelTest.kt
@@ -90,7 +90,8 @@ class ConversationViewModelTest: BaseViewModelTest() {
             avatarUtils = avatarUtils,
             lokiAPIDb = mock(),
             recipientChangeSource = NoopRecipientChangeSource,
-            dateUtils = mock()
+            dateUtils = mock(),
+            openGroupManager = mock()
         )
     }
 


### PR DESCRIPTION
This PR:

1. Clean up the logic behind `OpenGroupPoller`: now we are doing automatic state handling based on configs
2. Change a few classes to use dependency injection 
3. Actually fix up the slow community initial  show up
