### PR TITLE
Fix/ucs updates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ configurations.configureEach {
     exclude(module = "commons-logging")
 }
 
-val canonicalVersionCode = 409
-val canonicalVersionName = "1.24.0"
+val canonicalVersionCode = 410
+val canonicalVersionName = "1.25.0"
 
 val postFixSize = 10
 val abiPostFix = mapOf(

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsDialogs.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsDialogs.kt
@@ -101,6 +101,8 @@ fun ConversationSettingsDialogs(
                     onChange = { updatedText ->
                         sendCommand(UpdateNickname(updatedText))
                     },
+                    showClear = true,
+                    singleLine = true,
                     onContinue = { sendCommand(SetNickname) },
                     error = dialogsState.nicknameDialog.error,
                 )
@@ -154,6 +156,8 @@ fun ConversationSettingsDialogs(
                         onChange = { updatedText ->
                              sendCommand(UpdateGroupName(updatedText))
                         },
+                        showClear = true,
+                        singleLine = true,
                         error = dialogsState.groupEditDialog.errorName,
                     )
 
@@ -169,6 +173,7 @@ fun ConversationSettingsDialogs(
                         onChange = { updatedText ->
                              sendCommand(UpdateGroupDescription(updatedText))
                         },
+                        showClear = true,
                         error = dialogsState.groupEditDialog.errorDescription,
                     )
                 }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsScreen.kt
@@ -146,7 +146,17 @@ fun ConversationSettings(
                                 sharedTransitionScope.rememberSharedContentState(key = "avatar"),
                                 animatedVisibilityScope = animatedContentScope
                             )
-                            .clickable { showFullscreenAvatar() },
+                            .then(
+                                if(data.avatarUIData.isSingleCustomAvatar()){
+                                    Modifier.clickable(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication = ripple(bounded = false, radius = LocalDimensions.current.iconXXLarge/2),
+                                        onClick = showFullscreenAvatar
+                                    )
+                                } else {
+                                    Modifier
+                                }
+                            ),
                         size = LocalDimensions.current.iconXXLarge,
                         maxSizeLoad = LocalDimensions.current.iconXXLarge, // make sure we load the right size
                         data = data.avatarUIData,

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/Components.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/Components.kt
@@ -921,9 +921,9 @@ fun ExpandableText(
             val px = textLayoutResult.getLineBottom(lastVisible)          // bottom of that line in px
             maxHeight = with(density) { px.toDp() }
         },
-        onTap = {
-            expanded = !expanded
-        }
+        onTap = if(showButton){ // only expand if there is enough text
+            { expanded = !expanded }
+        } else null
     )
 }
 
@@ -979,7 +979,7 @@ fun BaseExpandableText(
     expanded: Boolean = false,
     showScroll: Boolean = false,
     onTextMeasured: (TextLayoutResult) -> Unit = {},
-    onTap: () -> Unit = {}
+    onTap: (() -> Unit)? = null
 ){
     var textModifier: Modifier = Modifier
     if(qaTag != null) textModifier = textModifier.qaTag(qaTag)
@@ -999,7 +999,9 @@ fun BaseExpandableText(
     }
 
     Column(
-        modifier = modifier.clickable { onTap() },
+        modifier = modifier.then(
+            if(onTap != null) Modifier.clickable { onTap() } else Modifier
+        ),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/components/Text.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/components/Text.kt
@@ -85,6 +85,20 @@ fun PreviewSessionOutlinedTextField() {
             )
 
             SessionOutlinedTextField(
+                text = "text with clear",
+                placeholder = "",
+                showClear = true,
+                innerPadding = PaddingValues(LocalDimensions.current.smallSpacing)
+            )
+            SessionOutlinedTextField(
+                text = "text with clear \ntest\ntest\ntest\ntest",
+                placeholder = "",
+                showClear = true,
+                innerPadding = PaddingValues(LocalDimensions.current.smallSpacing)
+            )
+
+
+            SessionOutlinedTextField(
                 text = "",
                 placeholder = "placeholder"
             )
@@ -160,7 +174,9 @@ fun SessionOutlinedTextField(
             color = if (enabled) LocalColors.current.text(isTextErrorColor) else LocalColors.current.textSecondary),
         cursorBrush = SolidColor(LocalColors.current.text(isTextErrorColor)),
         enabled = enabled,
-        keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+        keyboardOptions = KeyboardOptions.Default.copy(
+            imeAction = if (singleLine) ImeAction.Done else ImeAction.Default
+        ),
 
         keyboardActions = KeyboardActions(
             onDone = { onContinue() },
@@ -185,8 +201,7 @@ fun SessionOutlinedTextField(
                         .padding(innerPadding),
                 ) {
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
                     ) {
                         Box(
                             modifier = Modifier.weight(1f),
@@ -203,7 +218,7 @@ fun SessionOutlinedTextField(
                                 ),
                                 modifier = Modifier.qaTag(R.string.qa_conversation_search_clear)
                                     .padding(start = LocalDimensions.current.smallSpacing)
-                                    .size(LocalDimensions.current.iconSmall)
+                                    .size(textStyle.fontSize.value.dp)
                                     .clickable {
                                         onChange("")
                                     }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/AvatarUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/AvatarUtils.kt
@@ -231,7 +231,14 @@ class AvatarUtils @Inject constructor(
 
 data class AvatarUIData(
     val elements: List<AvatarUIElement>,
-)
+){
+    /**
+     * Helper function to determine if an avatar is composed of a single element, which is
+     * a custom photo.
+     * This is used for example to know when to display a fullscreen avatar on tap
+     */
+    fun isSingleCustomAvatar() = elements.size == 1 && elements[0].contactPhoto != null
+}
 
 data class AvatarUIElement(
     val name: String? = null,


### PR DESCRIPTION
Fixing some preliminary UCS issues:
- ExpandableText's logic has been updated to better handle text that doesn't require expansion
- Limiting the avatar view in fullscreen to only single custom avatars
- Fixing clear icon in textfield and making sure it is shown in the dialogs for UCS