### PR TITLE
Improve community loading performance

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ configurations.configureEach {
     exclude(module = "commons-logging")
 }
 
-val canonicalVersionCode = 409
+val canonicalVersionCode = 410
 val canonicalVersionName = "1.24.0"
 
 val postFixSize = 10

--- a/app/src/main/java/org/session/libsession/database/StorageProtocol.kt
+++ b/app/src/main/java/org/session/libsession/database/StorageProtocol.kt
@@ -37,6 +37,7 @@ import org.session.libsignal.messages.SignalServiceGroup
 import org.session.libsignal.utilities.AccountId
 import org.thoughtcrime.securesms.database.model.MessageId
 import org.thoughtcrime.securesms.database.model.MessageRecord
+import org.thoughtcrime.securesms.database.model.ReactionRecord
 import network.loki.messenger.libsession_util.util.Contact as LibSessionContact
 import network.loki.messenger.libsession_util.util.GroupMember as LibSessionGroupMember
 
@@ -259,6 +260,12 @@ interface StorageProtocol {
      * Add reaction to a specific message. This is preferable to the timestamp lookup.
      */
     fun addReaction(messageId: MessageId, reaction: Reaction, messageSender: String, notifyUnread: Boolean)
+
+    /**
+     * Add reactions into the database. If [replaceAll] is true,
+     * it will remove all existing reactions that belongs to the same message(s).
+     */
+    fun addReactions(reactions: Map<MessageId, List<ReactionRecord>>, replaceAll: Boolean, notifyUnread: Boolean)
     fun removeReaction(emoji: String, messageTimestamp: Long, threadId: Long, author: String, notifyUnread: Boolean)
     fun updateReactionIfNeeded(message: Message, sender: String, openGroupSentTimestamp: Long)
     fun deleteReactions(messageId: MessageId)

--- a/app/src/main/java/org/session/libsession/messaging/jobs/BatchMessageReceiveJob.kt
+++ b/app/src/main/java/org/session/libsession/messaging/jobs/BatchMessageReceiveJob.kt
@@ -185,7 +185,7 @@ class BatchMessageReceiveJob(
                 openGroupID = openGroupID,
             )
 
-            val allReactions = mutableMapOf<MessageId, MutableList<ReactionRecord>>()
+            val communityReactions = mutableMapOf<MessageId, MutableList<ReactionRecord>>()
 
             messages.forEach { (parameters, message, proto) ->
                 try {
@@ -218,7 +218,7 @@ class BatchMessageReceiveJob(
                                     openGroupMessageServerID = it,
                                     context = handlerContext,
                                     reactions = parameters.reactions,
-                                    out = allReactions
+                                    out = communityReactions
                                 )
                             }
                         }
@@ -261,8 +261,8 @@ class BatchMessageReceiveJob(
             storage.updateThread(threadId, true)
             SSKEnvironment.shared.notificationManager.updateNotification(context, threadId)
 
-            if (allReactions.isNotEmpty()) {
-                storage.addReactions(allReactions, replaceAll = true, notifyUnread = false)
+            if (communityReactions.isNotEmpty()) {
+                storage.addReactions(communityReactions, replaceAll = true, notifyUnread = false)
             }
         }
 

--- a/app/src/main/java/org/session/libsession/messaging/jobs/BatchMessageReceiveJob.kt
+++ b/app/src/main/java/org/session/libsession/messaging/jobs/BatchMessageReceiveJob.kt
@@ -1,6 +1,5 @@
 package org.session.libsession.messaging.jobs
 
-import android.os.Debug
 import com.google.protobuf.ByteString
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -12,10 +11,10 @@ import org.session.libsession.messaging.messages.Destination
 import org.session.libsession.messaging.messages.Message
 import org.session.libsession.messaging.messages.Message.Companion.senderOrSync
 import org.session.libsession.messaging.messages.control.CallMessage
-import org.session.libsession.messaging.messages.control.LegacyGroupControlMessage
 import org.session.libsession.messaging.messages.control.ConfigurationMessage
 import org.session.libsession.messaging.messages.control.DataExtractionNotification
 import org.session.libsession.messaging.messages.control.ExpirationTimerUpdate
+import org.session.libsession.messaging.messages.control.LegacyGroupControlMessage
 import org.session.libsession.messaging.messages.control.MessageRequestResponse
 import org.session.libsession.messaging.messages.control.ReadReceipt
 import org.session.libsession.messaging.messages.control.SharedConfigurationMessage
@@ -99,9 +98,6 @@ class BatchMessageReceiveJob(
     }
 
     override suspend fun execute(dispatcherName: String) {
-        Log.i(TAG, "Started processing of ${messages.size} messages (id: $id)")
-//        Debug.startMethodTracingSampling(File.createTempFile("method-tracing", ".trace").absolutePath, 100 * 1024 * 1024, 10)
-
         executeAsync(dispatcherName)
     }
 
@@ -295,7 +291,6 @@ class BatchMessageReceiveJob(
 
     private fun handleSuccess(dispatcherName: String) {
         Log.i(TAG, "Completed processing of ${messages.size} messages (id: $id)")
-        Debug.stopMethodTracing()
         delegate?.handleJobSucceeded(this, dispatcherName)
     }
 

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
@@ -206,14 +206,12 @@ class OpenGroupPoller @AssistedInject constructor(
             .toList()
 
         try {
-            Log.d(TAG, "Start polling $server")
             OpenGroupApi
                 .poll(rooms, server)
                 .await()
                 .asSequence()
                 .filterNot { it.body == null }
                 .forEach { response ->
-                    Log.d(TAG, "Start handling ${response.endpoint}")
                     when (response.endpoint) {
                         is Endpoint.Capabilities -> {
                             handleCapabilities(server, response.body as OpenGroupApi.Capabilities)
@@ -235,7 +233,6 @@ class OpenGroupPoller @AssistedInject constructor(
                         }
                         else -> { /* We don't care about the result of any other calls (won't be polled for) */}
                     }
-                    Log.d(TAG, "Stopped handling ${response.endpoint}")
                 }
         } catch (e: Exception) {
             if (e !is CancellationException) {

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPollerManager.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPollerManager.kt
@@ -98,7 +98,7 @@ class OpenGroupPollerManager @Inject constructor(
             pollers.value.map { (server, handle) ->
                 handle.pollerScope.launch {
                     runCatching {
-                        handle.poller.manualPollOnce()
+                        handle.poller.requestPollOnceAndWait()
                     }.onFailure {
                         Log.e(TAG, "Error polling open group ${server}", it)
                     }

--- a/app/src/main/java/org/session/libsession/utilities/Util.kt
+++ b/app/src/main/java/org/session/libsession/utilities/Util.kt
@@ -234,12 +234,6 @@ object Util {
     }
 
     @JvmStatic
-    @SuppressLint("NewApi")
-    fun isDefaultSmsProvider(context: Context): Boolean {
-        return context.packageName == Telephony.Sms.getDefaultSmsPackage(context)
-    }
-
-    @JvmStatic
     @Throws(IOException::class)
     fun readFully(`in`: InputStream?, buffer: ByteArray) {
         if (`in` == null) return

--- a/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -453,8 +453,7 @@ public class SmsDatabase extends MessagingDatabase {
       groupRecipient = Recipient.from(context, message.getGroupId(), true);
     }
 
-    boolean    unread     = (Util.isDefaultSmsProvider(context) ||
-            message.isSecureMessage() || message.isGroup() || message.isUnreadCallMessage());
+    boolean    unread     = (message.isSecureMessage() || message.isGroup() || message.isUnreadCallMessage());
 
     long       threadId;
 

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -1808,6 +1808,18 @@ open class Storage @Inject constructor(
         )
     }
 
+    override fun addReactions(
+        reactions: Map<MessageId, List<ReactionRecord>>,
+        replaceAll: Boolean,
+        notifyUnread: Boolean
+    ) {
+        reactionDatabase.addReactions(
+            reactionsByMessageId = reactions,
+            replaceAll = replaceAll,
+            notifyUnread = notifyUnread
+        )
+    }
+
     override fun removeReaction(
         emoji: String,
         messageTimestamp: Long,

--- a/app/src/main/java/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
@@ -100,9 +100,10 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper {
   private static final int lokiV47                          = 68;
   private static final int lokiV48                          = 69;
   private static final int lokiV49                          = 70;
+  private static final int lokiV50                          = 71;
 
   // Loki - onUpgrade(...) must be updated to use Loki version numbers if Signal makes any database changes
-  private static final int    DATABASE_VERSION         = lokiV49;
+  private static final int    DATABASE_VERSION         = lokiV50;
   private static final int    MIN_DATABASE_VERSION     = lokiV7;
   public static final String  DATABASE_NAME            = "session.db";
 
@@ -229,6 +230,7 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper {
     executeStatements(db, ReactionDatabase.CREATE_INDEXS);
 
     executeStatements(db, ReactionDatabase.CREATE_REACTION_TRIGGERS);
+    executeStatements(db, ReactionDatabase.CREATE_MESSAGE_ID_MMS_INDEX);
     db.execSQL(RecipientDatabase.getAddWrapperHash());
     db.execSQL(RecipientDatabase.getAddBlocksCommunityMessageRequests());
     db.execSQL(LokiAPIDatabase.CREATE_LAST_LEGACY_MESSAGE_TABLE);
@@ -531,6 +533,10 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper {
 
       if (oldVersion < lokiV49) {
         db.execSQL(LokiMessageDatabase.getUpdateErrorMessageTableCommand());
+      }
+
+      if (oldVersion < lokiV50) {
+        executeStatements(db, ReactionDatabase.CREATE_MESSAGE_ID_MMS_INDEX);
       }
 
       db.setTransactionSuccessful();

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/OpenGroupManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/OpenGroupManager.kt
@@ -72,9 +72,9 @@ class OpenGroupManager @Inject constructor(
             createGroupIfMissingWithPublicKey = publicKey
         )
 
-        // If existing poller for the same server exist, we'll ask it to manual poll once now so we can get the
-        // latest messages for the newly added community
-        pollerManager.pollers.value[server]?.poller?.manualPollOnce()
+        // If existing poller for the same server exist, we'll request a poll once now so new room
+        // can be polled immediately.
+        pollerManager.pollers.value[server]?.poller?.requestPollOnce()
     }
 
     fun delete(server: String, room: String, context: Context) {

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/OpenGroupManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/OpenGroupManager.kt
@@ -11,6 +11,7 @@ import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.open_groups.OpenGroup
 import org.session.libsession.messaging.open_groups.OpenGroupApi
 import org.session.libsession.messaging.sending_receiving.pollers.OpenGroupPoller
+import org.session.libsession.messaging.sending_receiving.pollers.OpenGroupPollerManager
 import org.session.libsession.snode.utilities.await
 import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsession.utilities.StringSubstitutionConstants.COMMUNITY_NAME_KEY
@@ -31,6 +32,7 @@ class OpenGroupManager @Inject constructor(
     private val threadDb: ThreadDatabase,
     private val configFactory: ConfigFactoryProtocol,
     private val groupMemberDatabase: GroupMemberDatabase,
+    private val pollerManager: OpenGroupPollerManager,
 ) {
 
     // flow holding information on write access for our current communities
@@ -69,6 +71,10 @@ class OpenGroupManager @Inject constructor(
             pollInfo = info.toPollInfo(),
             createGroupIfMissingWithPublicKey = publicKey
         )
+
+        // If existing poller for the same server exist, we'll ask it to manual poll once now so we can get the
+        // latest messages for the newly added community
+        pollerManager.pollers.value[server]?.poller?.manualPollOnce()
     }
 
     fun delete(server: String, room: String, context: Context) {


### PR DESCRIPTION
This PR improves the following areas:

1. Reuse some expensive data (like blinded id, user key, etc)
2. Reactions are now updated in one db transaction

