### PR TITLE
Feature/blocked users options

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -377,10 +377,14 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
                 handleSwipeToReply(message)
             },
             onItemLongPress = { message, position, view ->
-                if (!viewModel.isMessageRequestThread) {
-                    showConversationReaction(message, view)
-                } else {
-                    selectMessage(message, position)
+                // long pressing message for blocked users should show unblock dialog
+                if(viewModel.recipient?.isBlocked == true) unblock()
+                else {
+                    if (!viewModel.isMessageRequestThread) {
+                        showConversationReaction(message, view)
+                    } else {
+                        selectMessage(message, position)
+                    }
                 }
             },
             onDeselect = { message, position ->

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsViewModel.kt
@@ -288,12 +288,20 @@ class ConversationSettingsViewModel @AssistedInject constructor(
 
                 mainOptions.addAll(listOf(
                     optionCopyAccountId,
-                    optionSearch,
-                    optionDisappearingMessage(disappearingSubtitle),
-                    if(pinned) optionUnpin else optionPin,
-                    optionNotifications(notificationIconRes, notificationSubtitle),
-                    optionAttachments,
+                    optionSearch
                 ))
+
+                // these options are only for users who aren't blocked
+                if(!conversation.isBlocked) {
+                    mainOptions.addAll(listOf(
+                        optionDisappearingMessage(disappearingSubtitle),
+                        if(pinned) optionUnpin else optionPin,
+                        optionNotifications(notificationIconRes, notificationSubtitle),
+                    ))
+                }
+
+                // finally add attachments
+                mainOptions.add(optionAttachments)
 
                 dangerOptions.addAll(listOf(
                     if(recipient?.isBlocked == true) optionUnblock else optionBlock,


### PR DESCRIPTION
Making sure blocked users have less options in the new UCS as per [this discussion](https://discord.com/channels/408081923835953153/1352517028451454976/1377856924556591115).
Also making sure that long pressing a message shows the unblock dialog when a user is blocked