### PR TITLE
Fix/store crashes

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -498,7 +498,11 @@ public class MediaPreviewActivity extends ScreenLockActionBarActivity implements
 
   private @Nullable MediaItem getCurrentMediaItem() {
     if (adapter == null) return null;
-    return adapter.getMediaItemFor(binding.mediaPager.getCurrentItem());
+    try {
+      return adapter.getMediaItemFor(binding.mediaPager.getCurrentItem());
+    } catch (Exception e) {
+      return null;
+    }
   }
 
   public static boolean isContentTypeSupported(final String contentType) {
@@ -562,10 +566,14 @@ public class MediaPreviewActivity extends ScreenLockActionBarActivity implements
 
       if (adapter == null) return;
 
-      MediaItem item = adapter.getMediaItemFor(position);
-      if (item.recipient != null) item.recipient.addListener(MediaPreviewActivity.this);
-      viewModel.setActiveAlbumRailItem(MediaPreviewActivity.this, position);
-      updateActionBar();
+      try {
+        MediaItem item = adapter.getMediaItemFor(position);
+        if (item.recipient != null) item.recipient.addListener(MediaPreviewActivity.this);
+        viewModel.setActiveAlbumRailItem(MediaPreviewActivity.this, position);
+        updateActionBar();
+      } catch (Exception e) {
+        finish();
+      }
     }
 
 
@@ -577,6 +585,8 @@ public class MediaPreviewActivity extends ScreenLockActionBarActivity implements
         if (item.recipient != null) item.recipient.removeListener(MediaPreviewActivity.this);
       } catch (CursorIndexOutOfBoundsException e) {
         throw new RuntimeException("position = " + position + " leftIsRecent = " + leftIsRecent, e);
+      } catch (Exception e){
+        finish();
       }
 
       adapter.pause(position);

--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -501,6 +501,7 @@ public class MediaPreviewActivity extends ScreenLockActionBarActivity implements
     try {
       return adapter.getMediaItemFor(binding.mediaPager.getCurrentItem());
     } catch (Exception e) {
+      Log.w(TAG, "Error getting current media item", e);
       return null;
     }
   }


### PR DESCRIPTION
Fixing issues from the store:
1. Adding guards when choosing a destination to save media based on mime type
2. Guarding against rare cursor issues by leaving the activity