### PR TITLE
[SES-3834] - Leaving group tidy up

### DIFF
--- a/app/src/main/java/org/session/libsession/database/StorageProtocol.kt
+++ b/app/src/main/java/org/session/libsession/database/StorageProtocol.kt
@@ -160,16 +160,17 @@ interface StorageProtocol {
     // Closed Groups
     fun getMembers(groupPublicKey: String): List<LibSessionGroupMember>
     fun getClosedGroupDisplayInfo(groupAccountId: String): GroupDisplayInfo?
-    fun insertGroupInfoChange(message: GroupUpdated, closedGroup: AccountId): Long?
-    fun insertGroupInfoLeaving(closedGroup: AccountId): Long?
-    fun insertGroupInfoErrorQuit(closedGroup: AccountId): Long?
+    fun insertGroupInfoChange(message: GroupUpdated, closedGroup: AccountId)
+    fun insertGroupInfoLeaving(closedGroup: AccountId)
+    fun insertGroupInfoErrorQuit(closedGroup: AccountId)
     fun insertGroupInviteControlMessage(
         sentTimestamp: Long,
         senderPublicKey: String,
         senderName: String?,
         closedGroup: AccountId,
         groupName: String
-    ): Long?
+    )
+
     fun updateGroupInfoChange(messageId: Long, newType: UpdateMessageData.Kind)
     fun deleteGroupInfoMessages(groupId: AccountId, kind: Class<out UpdateMessageData.Kind>)
 

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -950,33 +950,33 @@ open class Storage @Inject constructor(
         }
     }
 
-    override fun insertGroupInfoChange(message: GroupUpdated, closedGroup: AccountId): Long? {
+    override fun insertGroupInfoChange(message: GroupUpdated, closedGroup: AccountId) {
         val sentTimestamp = message.sentTimestamp ?: clock.currentTimeMills()
         val senderPublicKey = message.sender
         val groupName = configFactory.withGroupConfigs(closedGroup) { it.groupInfo.getName() }
             ?: configFactory.getGroup(closedGroup)?.name
 
-        val updateData = UpdateMessageData.buildGroupUpdate(message, groupName.orEmpty()) ?: return null
+        val updateData = UpdateMessageData.buildGroupUpdate(message, groupName.orEmpty()) ?: return
 
-        return insertUpdateControlMessage(updateData, sentTimestamp, senderPublicKey, closedGroup)
+        insertUpdateControlMessage(updateData, sentTimestamp, senderPublicKey, closedGroup)
     }
 
-    override fun insertGroupInfoLeaving(closedGroup: AccountId): Long? {
+    override fun insertGroupInfoLeaving(closedGroup: AccountId) {
         val sentTimestamp = clock.currentTimeMills()
-        val senderPublicKey = getUserPublicKey() ?: return null
+        val senderPublicKey = getUserPublicKey() ?: return
         val updateData = UpdateMessageData.buildGroupLeaveUpdate(UpdateMessageData.Kind.GroupLeaving)
 
-        return insertUpdateControlMessage(updateData, sentTimestamp, senderPublicKey, closedGroup)
+        insertUpdateControlMessage(updateData, sentTimestamp, senderPublicKey, closedGroup)
     }
 
-    override fun insertGroupInfoErrorQuit(closedGroup: AccountId): Long? {
+    override fun insertGroupInfoErrorQuit(closedGroup: AccountId) {
         val sentTimestamp = clock.currentTimeMills()
-        val senderPublicKey = getUserPublicKey() ?: return null
+        val senderPublicKey = getUserPublicKey() ?: return
         val groupName = configFactory.withGroupConfigs(closedGroup) { it.groupInfo.getName() }
             ?: configFactory.getGroup(closedGroup)?.name
         val updateData = UpdateMessageData.buildGroupLeaveUpdate(UpdateMessageData.Kind.GroupErrorQuit(groupName.orEmpty()))
 
-        return insertUpdateControlMessage(updateData, sentTimestamp, senderPublicKey, closedGroup)
+        insertUpdateControlMessage(updateData, sentTimestamp, senderPublicKey, closedGroup)
     }
 
     override fun updateGroupInfoChange(messageId: Long, newType: UpdateMessageData.Kind) {
@@ -989,17 +989,17 @@ open class Storage @Inject constructor(
         mmsSmsDatabase.deleteGroupInfoMessage(groupId, kind)
     }
 
-    override fun insertGroupInviteControlMessage(sentTimestamp: Long, senderPublicKey: String, senderName: String?, closedGroup: AccountId, groupName: String): Long? {
+    override fun insertGroupInviteControlMessage(sentTimestamp: Long, senderPublicKey: String, senderName: String?, closedGroup: AccountId, groupName: String) {
         val updateData = UpdateMessageData(UpdateMessageData.Kind.GroupInvitation(
             groupAccountId = closedGroup.hexString,
             invitingAdminId = senderPublicKey,
             invitingAdminName = senderName,
             groupName = groupName
         ))
-        return insertUpdateControlMessage(updateData, sentTimestamp, senderPublicKey, closedGroup)
+        insertUpdateControlMessage(updateData, sentTimestamp, senderPublicKey, closedGroup)
     }
 
-    private fun insertUpdateControlMessage(updateData: UpdateMessageData, sentTimestamp: Long, senderPublicKey: String?, closedGroup: AccountId): Long? {
+    private fun insertUpdateControlMessage(updateData: UpdateMessageData, sentTimestamp: Long, senderPublicKey: String?, closedGroup: AccountId): MessageId? {
         val userPublicKey = getUserPublicKey()!!
         val recipient = Recipient.from(context, fromSerialized(closedGroup.hexString), false)
         val threadDb = threadDatabase
@@ -1036,14 +1036,14 @@ open class Storage @Inject constructor(
                 runThreadUpdate = true
             )
             mmsDB.markAsSent(infoMessageID, true)
-            return infoMessageID
+            return MessageId(infoMessageID, mms = true)
         } else {
             val group = SignalServiceGroup(Hex.fromStringCondensed(closedGroup.hexString), SignalServiceGroup.GroupType.SIGNAL)
             val m = IncomingTextMessage(fromSerialized(senderPublicKey), 1, sentTimestamp, "", Optional.of(group), expiresInMillis, expireStartedAt, true, false)
             val infoMessage = IncomingGroupMessage(m, inviteJson, true)
             val smsDB = smsDatabase
             val insertResult = smsDB.insertMessageInbox(infoMessage,  true)
-            return insertResult.orNull()?.messageId
+            return insertResult.orNull()?.messageId?.let { MessageId(it, mms = false) }
         }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/ConfigFactory.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/ConfigFactory.kt
@@ -291,6 +291,7 @@ class ConfigFactory @Inject constructor(
 
     private fun <T> doWithMutableGroupConfigs(
         groupId: AccountId,
+        fromMerge: Boolean,
         cb: (GroupConfigsImpl) -> Pair<T, Boolean>): T {
         val (lock, configs) = ensureGroupConfigsInitialized(groupId)
         val (result, changed) = lock.write {
@@ -301,7 +302,7 @@ class ConfigFactory @Inject constructor(
             coroutineScope.launch {
                 // Config change notifications are important so we must use suspend version of
                 // emit (not tryEmit)
-                _configUpdateNotifications.emit(ConfigUpdateNotification.GroupConfigsUpdated(groupId))
+                _configUpdateNotifications.emit(ConfigUpdateNotification.GroupConfigsUpdated(groupId, fromMerge = fromMerge))
             }
         }
 
@@ -312,7 +313,7 @@ class ConfigFactory @Inject constructor(
         groupId: AccountId,
         cb: (MutableGroupConfigs) -> T
     ): T {
-        return doWithMutableGroupConfigs(groupId = groupId) {
+        return doWithMutableGroupConfigs(groupId = groupId, fromMerge = false) {
             cb(it) to it.dumpIfNeeded(clock)
         }
     }
@@ -361,7 +362,7 @@ class ConfigFactory @Inject constructor(
         info: List<ConfigMessage>,
         members: List<ConfigMessage>
     ) {
-        val changed = doWithMutableGroupConfigs(groupId) { configs ->
+        val changed = doWithMutableGroupConfigs(groupId, fromMerge = true) { configs ->
             // Keys must be loaded first as they are used to decrypt the other config messages
             val keysLoaded = keys.fold(false) { acc, msg ->
                 configs.groupKeys.loadKey(msg.data, msg.hash, msg.timestamp, configs.groupInfo.pointer, configs.groupMembers.pointer) || acc
@@ -431,7 +432,7 @@ class ConfigFactory @Inject constructor(
             return
         }
 
-        doWithMutableGroupConfigs(groupId) { configs ->
+        doWithMutableGroupConfigs(groupId, fromMerge = false) { configs ->
             members?.let { (push, result) -> configs.groupMembers.confirmPushed(push.seqNo, result.hashes.toTypedArray()) }
             info?.let { (push, result) -> configs.groupInfo.confirmPushed(push.seqNo, result.hashes.toTypedArray()) }
             keysPush?.let { (hashes, timestamp) ->

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/BaseGroupMembersViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/BaseGroupMembersViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -39,12 +40,12 @@ abstract class BaseGroupMembersViewModel (
 ) : ViewModel() {
     // Output: the source-of-truth group information. Other states are derived from this.
     protected val groupInfo: StateFlow<Pair<GroupDisplayInfo, List<GroupMemberState>>?> =
-        configFactory.configUpdateNotifications
+        (configFactory.configUpdateNotifications
             .filter {
                 it is ConfigUpdateNotification.GroupConfigsUpdated && it.groupId == groupId ||
                         it is ConfigUpdateNotification.UserConfigsMerged
-            }
-            .onStart { emit(ConfigUpdateNotification.GroupConfigsUpdated(groupId)) }
+            } as Flow<*>)
+            .onStart { emit(Unit) }
             .map { _ ->
                 withContext(Dispatchers.Default) {
                     val currentUserId = AccountId(checkNotNull(storage.getUserPublicKey()) {

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupLeavingWorker.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupLeavingWorker.kt
@@ -1,0 +1,143 @@
+package org.thoughtcrime.securesms.groups
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CancellationException
+import org.session.libsession.messaging.groups.GroupScope
+import org.session.libsession.messaging.messages.control.GroupUpdated
+import org.session.libsession.messaging.sending_receiving.MessageSender
+import org.session.libsession.messaging.utilities.UpdateMessageData
+import org.session.libsession.utilities.Address
+import org.session.libsession.utilities.getGroup
+import org.session.libsession.utilities.waitUntilGroupConfigsPushed
+import org.session.libsignal.exceptions.NonRetryableException
+import org.session.libsignal.protos.SignalServiceProtos.DataMessage
+import org.session.libsignal.protos.SignalServiceProtos.DataMessage.GroupUpdateMessage
+import org.session.libsignal.utilities.AccountId
+import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.database.LokiAPIDatabase
+import org.thoughtcrime.securesms.database.Storage
+import org.thoughtcrime.securesms.dependencies.ConfigFactory
+
+@HiltWorker
+class GroupLeavingWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val storage: Storage,
+    private val configFactory: ConfigFactory,
+    private val groupScope: GroupScope,
+    private val lokiAPIDatabase: LokiAPIDatabase,
+) : CoroutineWorker(context, params) {
+    override suspend fun doWork(): Result {
+        val groupId = requireNotNull(inputData.getString(KEY_GROUP_ID)) {
+            "Group ID must be provided"
+        }.let(::AccountId)
+
+        Log.d(TAG, "Group leaving work started for $groupId")
+
+        return groupScope.launchAndWait(groupId, "GroupLeavingWorker") {
+            val group = configFactory.getGroup(groupId)
+
+            // Make sure we only have one group leaving control message
+            storage.deleteGroupInfoMessages(groupId, UpdateMessageData.Kind.GroupLeaving::class.java)
+            storage.insertGroupInfoLeaving(groupId)
+
+            try {
+                if (group?.destroyed != true) {
+                    // Only send the left/left notification group message when we are not kicked and we are not the only admin (only admin has a special treatment)
+                    val weAreTheOnlyAdmin = configFactory.withGroupConfigs(groupId) { config ->
+                        val allMembers = config.groupMembers.all()
+                        allMembers.count { it.admin } == 1 &&
+                                allMembers.first { it.admin }
+                                    .accountId() == storage.getUserPublicKey()
+                    }
+
+                    if (group != null && !group.kicked && !weAreTheOnlyAdmin) {
+                        val address = Address.fromSerialized(groupId.hexString)
+
+                        // Always send a "XXX left" message to the group if we can
+                        MessageSender.send(
+                            GroupUpdated(
+                                GroupUpdateMessage.newBuilder()
+                                    .setMemberLeftNotificationMessage(DataMessage.GroupUpdateMemberLeftNotificationMessage.getDefaultInstance())
+                                    .build()
+                            ),
+                            address
+                        )
+
+                        // If we are not the only admin, send a left message for other admin to handle the member removal
+                        MessageSender.send(
+                            GroupUpdated(
+                                GroupUpdateMessage.newBuilder()
+                                    .setMemberLeftMessage(DataMessage.GroupUpdateMemberLeftMessage.getDefaultInstance())
+                                    .build()
+                            ),
+                            address,
+                        )
+                    }
+
+                    // If we are the only admin, leaving this group will destroy the group
+                    if (weAreTheOnlyAdmin) {
+                        configFactory.withMutableGroupConfigs(groupId) { configs ->
+                            configs.groupInfo.destroyGroup()
+                        }
+
+                        // Must wait until the config is pushed, otherwise if we go through the rest
+                        // of the code it will destroy the conversation, destroying the necessary configs
+                        // along the way, we won't be able to push the "destroyed" state anymore.
+                        configFactory.waitUntilGroupConfigsPushed(groupId, timeoutMills = 0L)
+                    }
+                }
+
+                // Delete conversation and group configs
+                storage.getThreadId(Address.fromSerialized(groupId.hexString))
+                    ?.let(storage::deleteConversation)
+                configFactory.removeGroup(groupId)
+                lokiAPIDatabase.clearLastMessageHashes(groupId.hexString)
+                lokiAPIDatabase.clearReceivedMessageHashValues(groupId.hexString)
+                Log.d(TAG, "Group $groupId left successfully")
+                Result.success()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                storage.insertGroupInfoErrorQuit(groupId)
+                Log.e(TAG, "Failed to leave group $groupId", e)
+                if (e is NonRetryableException) {
+                    Result.failure()
+                } else {
+                    Result.retry()
+                }
+            } finally {
+                storage.deleteGroupInfoMessages(groupId, UpdateMessageData.Kind.GroupLeaving::class.java)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "GroupLeavingWorker"
+
+        private const val KEY_GROUP_ID = "group_id"
+
+        fun schedule(context: Context, groupId: AccountId) {
+            WorkManager.getInstance(context)
+                .enqueue(
+                    OneTimeWorkRequestBuilder<GroupLeavingWorker>()
+                        .addTag(KEY_GROUP_ID)
+                        .setConstraints(Constraints(requiredNetworkType = NetworkType.CONNECTED))
+                        .setInputData(
+                            Data.Builder().putString(KEY_GROUP_ID, groupId.hexString).build()
+                        )
+                        .build()
+                )
+        }
+    }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/handler/DestroyedGroupSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/handler/DestroyedGroupSync.kt
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.groups.handler
 
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
 import org.session.libsession.database.StorageProtocol
@@ -32,6 +33,7 @@ class DestroyedGroupSync @Inject constructor(
         job = GlobalScope.launch {
             configFactory.configUpdateNotifications
                 .filterIsInstance<ConfigUpdateNotification.GroupConfigsUpdated>()
+                .filter { it.fromMerge }
                 .collect { update ->
                     val isDestroyed = configFactory.withGroupConfigs(update.groupId) {
                         it.groupInfo.isDestroyed()


### PR DESCRIPTION
The cause of the issue SES-3834 is: when destroying a group, the handler `DestroyedGroupSync` is listening for that and deleting all local messages immediately, which is technically correct, but in the case where you initiate the destruction, you should wait until the config is pushed until you can do it.

So the main change here is: add a `fromMerge` flag into the group config change notification event, so `DestroyedGroupSync` only clear the message when it's coming from the config merge.

Another change along with this PR is to move all the group leaving logic into a worker so that it can survive app restarts.