### PR TITLE
Fix audio duration not set if the player doesn't give us duration

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VoiceMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VoiceMessageView.kt
@@ -62,6 +62,7 @@ class VoiceMessageView @JvmOverloads constructor(
             if (attachment.audioDurationMs > 0) {
                 val formattedVoiceMessageDuration = MediaUtil.getFormattedVoiceMessageDuration(attachment.audioDurationMs)
                 binding.voiceMessageViewDurationTextView.text = formattedVoiceMessageDuration
+                durationMS = attachment.audioDurationMs
             } else {
                 Log.w(TAG, "For some reason attachment.audioDurationMs was NOT greater than zero!")
                 binding.voiceMessageViewDurationTextView.text = "--:--"
@@ -79,6 +80,7 @@ class VoiceMessageView @JvmOverloads constructor(
 
     override fun onPlayerStart(player: AudioSlidePlayer) {
         isPlaying = true
+
         if (player.duration != C.TIME_UNSET) {
             durationMS = player.duration
         }


### PR DESCRIPTION
Basically if the player doesn't give us the audio duration for some reason (may be a different audio format, like the one sent from desktop or older Android clients), then
we will get the duration from the attachment info.
