### PR TITLE
Fix up log exporting

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/ShareLogsDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/ShareLogsDialog.kt
@@ -7,19 +7,17 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.os.Environment
 import android.provider.MediaStore
 import android.widget.Toast
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope
 import com.squareup.phrase.Phrase
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CancellationException
 import java.io.File
 import java.io.IOException
-import java.util.Objects
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -65,43 +63,26 @@ class ShareLogsDialog(private val updateCallback: (Boolean)->Unit): DialogFragme
 
         updateCallback(true)
 
-        shareJob = lifecycleScope.launch(Dispatchers.IO) {
+        shareJob = lifecycleScope.launch {
             try {
                 Log.d(TAG, "Starting share logs job...")
+                val mediaUri = withContext(Dispatchers.IO) {
+                    withExternalFile(persistentLogger::readAllLogsCompressed)
+                } ?: return@launch
 
-                val context = requireContext()
-                val mediaUri = getExternalFile() ?: return@launch
-
-                val updateValues = ContentValues()
-
-                persistentLogger.readAllLogsCompressed(mediaUri)
-
-                if (Build.VERSION.SDK_INT > 28) {
-                    updateValues.put(MediaStore.MediaColumns.IS_PENDING, 0)
-                }
-                if (updateValues.size() > 0) {
-                    requireContext().contentResolver.update(mediaUri, updateValues, null, null)
+                val shareIntent = Intent().apply {
+                    action = Intent.ACTION_SEND
+                    putExtra(Intent.EXTRA_STREAM, mediaUri)
+                    type = "application/zip"
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 }
 
-                val shareUri = if (mediaUri.scheme == ContentResolver.SCHEME_FILE) {
-                    FileProviderUtil.getUriFor(context, File(mediaUri.path!!))
-                } else {
-                    mediaUri
-                }
-
-                withContext(Main) {
-                    val shareIntent = Intent().apply {
-                        action = Intent.ACTION_SEND
-                        putExtra(Intent.EXTRA_STREAM, shareUri)
-                        type = "text/plain"
-                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                    }
-                    startActivity(Intent.createChooser(shareIntent, getString(R.string.share)))
-                }
+                startActivity(Intent.createChooser(shareIntent, getString(R.string.share)))
             } catch (e: Exception) {
-                withContext(Main) {
+                if (e !is CancellationException) {
                     Log.e("Loki", "Error saving logs", e)
-                    Toast.makeText(context,getString(R.string.errorUnknown), Toast.LENGTH_LONG).show()
+                    Toast.makeText(context, getString(R.string.errorUnknown), Toast.LENGTH_LONG)
+                        .show()
                 }
             }
         }.also { shareJob ->
@@ -132,32 +113,13 @@ class ShareLogsDialog(private val updateCallback: (Boolean)->Unit): DialogFragme
         }
     }
 
-    @Throws(IOException::class)
-    private fun pathTaken(outputUri: Uri, dataPath: String): Boolean {
-        requireContext().contentResolver.query(outputUri, arrayOf(MediaStore.MediaColumns.DATA),
-            MediaStore.MediaColumns.DATA + " = ?", arrayOf(dataPath),
-            null).use { cursor ->
-            if (cursor == null) {
-                throw IOException("Something is wrong with the filename to save")
-            }
-            return cursor.moveToFirst()
-        }
-    }
-
-    private fun getExternalFile(): Uri? {
+    private fun withExternalFile(action: (Uri) -> Unit): Uri? {
         val context = requireContext()
         val base = "${Build.MANUFACTURER}-${Build.DEVICE}-API${Build.VERSION.SDK_INT}-v${BuildConfig.VERSION_NAME}-${System.currentTimeMillis()}"
         val extension = "zip"
         val fileName = "$base.$extension"
         val outputUri: Uri = ExternalStorageUtil.getDownloadUri()
-        val contentValues = ContentValues()
-        contentValues.put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
-        contentValues.put(MediaStore.MediaColumns.MIME_TYPE, "application/zip")
-        contentValues.put(MediaStore.MediaColumns.DATE_ADDED, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()))
-        contentValues.put(MediaStore.MediaColumns.DATE_MODIFIED, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()))
-        if (Build.VERSION.SDK_INT > 28) {
-            contentValues.put(MediaStore.MediaColumns.IS_PENDING, 1)
-        } else if (Objects.equals(outputUri.scheme, ContentResolver.SCHEME_FILE)) {
+        if (outputUri.scheme == ContentResolver.SCHEME_FILE) {
             val outputDirectory = File(outputUri.path)
             var outputFile = File(outputDirectory, "$base.$extension")
             var i = 0
@@ -167,19 +129,34 @@ class ShareLogsDialog(private val updateCallback: (Boolean)->Unit): DialogFragme
             if (outputFile.isHidden) {
                 throw IOException("Specified name would not be visible")
             }
-            return Uri.fromFile(outputFile)
-        } else {
-            var outputFileName = fileName
-            val externalPath = context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)!!
-            var dataPath = String.format("%s/%s", externalPath, outputFileName)
-            var i = 0
-            while (pathTaken(outputUri, dataPath)) {
-                outputFileName = base + "-" + ++i + "." + extension
-                dataPath = String.format("%s/%s", externalPath, outputFileName)
+            try {
+                return FileProviderUtil.getUriFor(requireContext(), outputFile).also(action)
+            } catch (e: Exception) {
+                outputFile.delete()
+                throw e
             }
-            contentValues.put(MediaStore.MediaColumns.DATA, dataPath)
+        } else {
+            val contentValues = ContentValues()
+            contentValues.put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)
+            contentValues.put(MediaStore.MediaColumns.MIME_TYPE, "application/zip")
+            contentValues.put(MediaStore.MediaColumns.DATE_ADDED, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()))
+            contentValues.put(MediaStore.MediaColumns.DATE_MODIFIED, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()))
+            contentValues.put(MediaStore.MediaColumns.IS_PENDING, 1)
+            val uri = context.contentResolver.insert(outputUri, contentValues) ?: return null
+            try {
+                action(uri)
+
+                // Remove the pending flag to make the file available
+                contentValues.clear()
+                contentValues.put(MediaStore.MediaColumns.IS_PENDING, 0)
+                context.contentResolver.update(uri, contentValues, null, null)
+            } catch (e: Exception) {
+                context.contentResolver.delete(uri, null, null)
+                throw e
+            }
+
+            return uri
         }
-        return context.contentResolver.insert(outputUri, contentValues)
     }
 
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/ClearDataUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/ClearDataUtils.kt
@@ -21,6 +21,7 @@ import org.session.libsignal.utilities.hexEncodedPublicKey
 import org.thoughtcrime.securesms.crypto.IdentityKeyUtil
 import org.thoughtcrime.securesms.crypto.KeyPairUtilities
 import org.thoughtcrime.securesms.database.Storage
+import org.thoughtcrime.securesms.logging.PersistentLogger
 import org.thoughtcrime.securesms.migration.DatabaseMigrationManager
 
 class ClearDataUtils @Inject constructor(
@@ -29,6 +30,7 @@ class ClearDataUtils @Inject constructor(
     private val tokenFetcher: TokenFetcher,
     private val storage: Storage,
     private val prefs: TextSecurePreferences,
+    private val persistentLogger: PersistentLogger,
 ) {
     // Method to clear the local data - returns true on success otherwise false
     @SuppressLint("ApplySharedPref")
@@ -49,6 +51,8 @@ class ClearDataUtils @Inject constructor(
             TextSecurePreferences.clearAll(application)
             application.getSharedPreferences(ApplicationContext.PREFERENCES_NAME, 0).edit(commit = true) { clear() }
             configFactory.clearAll()
+
+            persistentLogger.deleteAllLogs()
 
             // The token deletion is nice but not critical, so don't let it block the rest of the process
             runCatching {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/FileProviderUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/FileProviderUtil.java
@@ -11,6 +11,7 @@ public class FileProviderUtil {
 
   public static final String AUTHORITY = "network.loki.securesms.fileprovider";
 
+  @NonNull
   public static Uri getUriFor(@NonNull Context context, @NonNull File file) {
     return FileProvider.getUriForFile(context, AUTHORITY, file);
   }


### PR DESCRIPTION
This PR fixes the issue where if you logout and login, the previous log file will come into play (they have different encryption keys), screwing up the current log file. So we end up with a log file that is part old key, part new key. Because the first part of the file is encrypted using old key, if you export the log it will fail at beginning as it couldn't read the encryption key.
The change make sure all log files are deleted upon clearing data, and also when the logger starts and see this file exist, it checks if current key can decrypt it, if it can't, the logger will simply override it.

Another part of this PR fixes the general dirtiness around the exporting.
