### PR TITLE
SES-4180 - Preserve text state in media send

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaSendFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaSendFragment.kt
@@ -247,7 +247,12 @@ class MediaSendFragment : Fragment(), RailItemListener, InputBarDelegate {
 
         viewModel.getBucketId().observe(this) { bucketId: String? ->
             if (bucketId == null) return@observe
-            mediaRailAdapter!!.setAddButtonListener { controller.onAddMediaClicked(bucketId) }
+            mediaRailAdapter!!.setAddButtonListener {
+                // save existing text in VM
+                viewModel.onBodyChanged(mentionViewModel.deconstructMessageMentions())
+
+                controller.onAddMediaClicked(bucketId)
+            }
         }
     }
 


### PR DESCRIPTION
[SES-4180](https://optf.atlassian.net/browse/SES-4180) - Preserve input text before picking new media