### PR TITLE
Make sure migration is only done outside ThreadDatabase's constructor

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.kt
@@ -72,6 +72,7 @@ import org.thoughtcrime.securesms.configs.ConfigUploader
 import org.thoughtcrime.securesms.database.EmojiSearchDatabase
 import org.thoughtcrime.securesms.database.LokiAPIDatabase
 import org.thoughtcrime.securesms.database.Storage
+import org.thoughtcrime.securesms.database.ThreadDatabase
 import org.thoughtcrime.securesms.database.model.EmojiSearchData
 import org.thoughtcrime.securesms.debugmenu.DebugActivity
 import org.thoughtcrime.securesms.dependencies.AppComponent
@@ -205,6 +206,9 @@ class ApplicationContext : Application(), DefaultLifecycleObserver,
 
     @Inject
     lateinit var openGroupPollerManager: Lazy<OpenGroupPollerManager>
+
+    @Inject
+    lateinit var threadDatabase: Lazy<ThreadDatabase>
 
     @Volatile
     var isAppVisible: Boolean = false
@@ -381,6 +385,8 @@ class ApplicationContext : Application(), DefaultLifecycleObserver,
         groupPollerManager.get()
         expiredGroupManager.get()
         openGroupPollerManager.get()
+
+        threadDatabase.get().onAppCreated()
     }
 
     override fun onStart(owner: LifecycleOwner) {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -168,6 +168,7 @@ public class ThreadDatabase extends Database {
 
   private ConversationThreadUpdateListener updateListener;
   private final Json json;
+  private final TextSecurePreferences prefs;
 
   @Inject
   public ThreadDatabase(
@@ -177,7 +178,12 @@ public class ThreadDatabase extends Database {
           Json json) {
     super(context, databaseHelper);
     this.json = json;
+    this.prefs = prefs;
+  }
 
+  // This method is called when the application is created, providing an opportunity to perform
+  // initialization tasks that need to be done only once.
+  public void onAppCreated() {
     if (!prefs.getMigratedDisappearingMessagesToMessageContent()) {
       migrateDisappearingMessagesToMessageContent();
       prefs.setMigratedDisappearingMessagesToMessageContent(true);


### PR DESCRIPTION
There is tricky dependency that can't be satifisied during construction of `ThreadDatabase` so the migration has to be post-init.
