### PR TITLE
Disappearing messages fixes

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.kt
@@ -367,6 +367,11 @@ class MmsDatabase
         contentValues.put(READ, 1)
         contentValues.put(BODY, displayedMessage)
         contentValues.put(HAS_MENTION, 0)
+
+        // Clear the expiration fields so that the "message is deleted" is never expired.
+        contentValues.put(EXPIRE_STARTED, 0)
+        contentValues.put(EXPIRES_IN, 0)
+
         database.update(TABLE_NAME, contentValues, ID_WHERE, arrayOf(messageId.toString()))
         val attachmentDatabase = get(context).attachmentDatabase()
         queue { attachmentDatabase.deleteAttachmentsForMessage(messageId) }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -246,6 +246,10 @@ public class SmsDatabase extends MessagingDatabase {
     contentValues.put(BODY, displayedMessage);
     contentValues.put(HAS_MENTION, 0);
     contentValues.put(STATUS, Status.STATUS_NONE);
+    // Clear the expiration fields so that the "message is deleted" is never expired.
+    contentValues.put(EXPIRE_STARTED, 0);
+    contentValues.put(EXPIRES_IN, 0);
+
     database.update(TABLE_NAME, contentValues, ID_WHERE, new String[] {String.valueOf(messageId)});
 
     updateTypeBitmask(messageId, Types.BASE_TYPE_MASK,

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -1694,7 +1694,7 @@ open class Storage @Inject constructor(
         val expirationConfig = getExpirationConfiguration(threadId)
         val expiryMode = expirationConfig?.expiryMode?.coerceSendToRead() ?: ExpiryMode.NONE
         val expiresInMillis = expiryMode.expiryMillis
-        val expireStartedAt = if (expiryMode is ExpiryMode.AfterSend) sentTimestamp else 0
+        val expireStartedAt = if (expiryMode != ExpiryMode.NONE) clock.currentTimeMills() else 0
         val callMessage = IncomingTextMessage.fromCallInfo(callMessageType, address, Optional.absent(), sentTimestamp, expiresInMillis, expireStartedAt)
         smsDatabase.insertCallMessage(callMessage)
     }


### PR DESCRIPTION
Forgot to actually improve the logic after the refactoring task. This PR contains fixes as:
1. If messages are being marked as deleted, clear their `expiryStarted`/`expiresIn` so they won't be gone [SES-4224].
2. Start expiring of call messages as soon as they are created, as they aren't real messages sending through [SES-4227]
3. When a message is received/sent, use current time instead of date sent as the expiry started time [SES-2449]