### PR TITLE
Fix CI build

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -38,8 +38,6 @@ local ci_dep_mirror(want_mirror) = (if want_mirror then ' -DLOCAL_MIRROR=https:/
         pull: 'always',
         environment: { ANDROID_HOME: '/usr/lib/android-sdk' },
         commands: [
-          'apt-get update --allow-releaseinfo-change',
-          'apt-get install -y ninja-build',
           './gradlew testPlayDebugUnitTestCoverageReport'
         ],
       }
@@ -82,11 +80,8 @@ local ci_dep_mirror(want_mirror) = (if want_mirror then ' -DLOCAL_MIRROR=https:/
         pull: 'always',
         environment: { SSH_KEY: { from_secret: 'SSH_KEY' }, ANDROID_HOME: '/usr/lib/android-sdk' },
         commands: [
-          'apt-get update --allow-releaseinfo-change',
-          'apt-get install -y ninja-build',
           './gradlew assemblePlayQa',
           './gradlew assemblePlayAutomaticQa',
-          './gradlew -Phuawei=1 assembleHuaweiQa',
           './scripts/drone-static-upload.sh'
         ],
       }

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -37,11 +37,9 @@ local ci_dep_mirror(want_mirror) = (if want_mirror then ' -DLOCAL_MIRROR=https:/
         image: docker_base + 'android',
         pull: 'always',
         environment: { ANDROID_HOME: '/usr/lib/android-sdk' },
-        mem_limit: "8g",
         commands: [
           'apt-get update --allow-releaseinfo-change',
-          'apt-get install -y ninja-build openjdk-21-jdk',
-          'update-java-alternatives -s java-1.21.0-openjdk-amd64',
+          'apt-get install -y ninja-build',
           './gradlew testPlayDebugUnitTestCoverageReport'
         ],
       }
@@ -73,7 +71,7 @@ local ci_dep_mirror(want_mirror) = (if want_mirror then ' -DLOCAL_MIRROR=https:/
     platform: { arch: 'amd64' },
     trigger: {
         event: ['push'],
-        branch: ['master', 'dev', 'release/*']
+        branch: ['master', 'dev', 'release/*', 'fix-ci-*']
     },
     steps: [
       version_info,
@@ -82,14 +80,13 @@ local ci_dep_mirror(want_mirror) = (if want_mirror then ' -DLOCAL_MIRROR=https:/
         name: 'Build and upload',
         image: docker_base + 'android',
         pull: 'always',
-        mem_limit: "8g",
         environment: { SSH_KEY: { from_secret: 'SSH_KEY' }, ANDROID_HOME: '/usr/lib/android-sdk' },
         commands: [
           'apt-get update --allow-releaseinfo-change',
-          'apt-get install -y ninja-build openjdk-21-jdk',
-          'update-java-alternatives -s java-1.21.0-openjdk-amd64',
-          './gradlew --no-daemon assemblePlayQa assemblePlayAutomaticQa',
-          './gradlew --no-daemon -Phuawei=1 assembleHuaweiQa',
+          'apt-get install -y ninja-build',
+          './gradlew assemblePlayQa',
+          './gradlew assemblePlayAutomaticQa',
+          './gradlew -Phuawei=1 assembleHuaweiQa',
           './scripts/drone-static-upload.sh'
         ],
       }

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,7 +44,8 @@ jobs:
 
       - name: Build and test with Gradle
         id: build
-        run: ./gradlew assemble${{ matrix.variant }}${{ matrix.build_type }} test${{ matrix.variant }}${{ matrix.build_type }}UnitTest  ${{ matrix.extra_build_command_options }}
+        run: ./gradlew assemble${{ matrix.variant }}${{ matrix.build_type }} ${{ matrix.extra_build_command_options }} && \
+                ./gradlew test${{ matrix.variant }}${{ matrix.build_type }}UnitTest ${{ matrix.extra_build_command_options }}
 
       - name: Upload build reports regardless
         if: always()

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build with gradle
         id: build
-        run: ./gradlew assemble${{ matrix.variant }}${{ matrix.build_type }} ${{ matrix.extra_build_command_options }} &&
+        run: ./gradlew assemble${{ matrix.variant }}${{ matrix.build_type }} ${{ matrix.extra_build_command_options }}
 
       - name: Run unit tests
         if: ${{ matrix.run_test == true }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,6 +22,8 @@ jobs:
         include:
           - variant: 'huawei'
             extra_build_command_options: '-Phuawei=1'
+          - variant: 'play'
+            run_test: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,10 +43,14 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - name: Build and test with Gradle
+      - name: Build with gradle
         id: build
-        run: ./gradlew assemble${{ matrix.variant }}${{ matrix.build_type }} ${{ matrix.extra_build_command_options }} && \
-                ./gradlew test${{ matrix.variant }}${{ matrix.build_type }}UnitTest ${{ matrix.extra_build_command_options }}
+        run: ./gradlew assemble${{ matrix.variant }}${{ matrix.build_type }} ${{ matrix.extra_build_command_options }} &&
+
+      - name: Run unit tests
+        if: ${{ matrix.run_test == true }}
+        id: test
+        run: ./gradlew test${{ matrix.variant }}${{ matrix.build_type }}UnitTest ${{ matrix.extra_build_command_options }}
 
       - name: Upload build reports regardless
         if: always()

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,9 +29,7 @@ jobs:
           path: |
             ~/.gradle/caches
             .gradle
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle.properties') }}-${{ matrix.variant }}
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,6 +23,10 @@ jobs:
           - variant: 'huawei'
             extra_build_command_options: '-Phuawei=1'
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -31,9 +35,6 @@ jobs:
             .gradle
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle.properties') }}-${{ matrix.variant }}
 
-      - uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:

--- a/scripts/drone-static-upload.sh
+++ b/scripts/drone-static-upload.sh
@@ -19,7 +19,7 @@ chmod 600 ssh_key
 
 # Define the output paths
 build_dir="app/build/outputs/apk"
-target_path=$(find "$build_dir" -type f -name "*universal*.apk" -print -quit)
+target_path=$(find "$build_dir" -type f -name "*universal*.apk" )
 
 # Validate the paths exist
 if [ ! -d $build_path ]; then


### PR DESCRIPTION
The two variants `automaticQa` and `qa` can't be built together at the same time as they share same package id.

Also:
- Fixes caching issue (incorrect cache key) on Github Action builds
- Tidy up drone CI build script
