### PR TITLE
SES-2434

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/home/ConversationView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/ConversationView.kt
@@ -67,7 +67,7 @@ class ConversationView : LinearLayout {
             binding.accentView.background = UnreadStylingHelper.getAccentBackground(context)
             // Using thread.isRead we can determine if the last message was our own, and display it as 'read' even though previous messages may not be
             // This would also not trigger the disappearing message timer which may or may not be desirable
-            binding.accentView.isVisible = isUnread
+            binding.accentView.visibility = if(isUnread) View.VISIBLE else View.INVISIBLE
         }
 
         binding.unreadCountTextView.text = UnreadStylingHelper.formatUnreadCount(unreadCount)

--- a/app/src/main/java/org/thoughtcrime/securesms/messagerequests/MessageRequestView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/messagerequests/MessageRequestView.kt
@@ -50,7 +50,7 @@ class MessageRequestView : LinearLayout {
 
         binding.accentView.apply {
             this.background = UnreadStylingHelper.getAccentBackground(context)
-            isVisible = isUnread
+            visibility = if(isUnread) View.VISIBLE else View.INVISIBLE
         }
 
         binding.unreadCountTextView.text = UnreadStylingHelper.formatUnreadCount(unreadCount)


### PR DESCRIPTION
[SES-2434](https://optf.atlassian.net/browse/SES-2434)

Fix for this [bug.](https://optf.atlassian.net/browse/SES-2434?focusedCommentId=18390)

This fixed the adjusted margins for the unread messages. The bug was caused by the visibility of the accentView being set to `Gone` instead of `Invisible`.

The fix is also applied to `ConversationView`

<img width="200" height="400" alt="Fix alignment" src="https://github.com/user-attachments/assets/bb20450a-bd9b-41bf-b373-d40c97cfe9cc" />
