### PR TITLE
Broaden debugging facility to non-debug builds

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/disappearingmessages/DisappearingMessagesActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/disappearingmessages/DisappearingMessagesActivity.kt
@@ -22,7 +22,7 @@ class DisappearingMessagesActivity: FullComposeScreenLockActivity() {
                 factory.create(
                     threadId = threadId,
                     isNewConfigEnabled = ExpirationConfiguration.isNewConfigEnabled,
-                    showDebugOptions = BuildConfig.DEBUG
+                    showDebugOptions = BuildConfig.BUILD_TYPE != "release"
                 )
             }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsNavHost.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsNavHost.kt
@@ -318,7 +318,7 @@ fun ConversationSettingsNavHost(
                         factory.create(
                             threadId = threadId,
                             isNewConfigEnabled = ExpirationConfiguration.isNewConfigEnabled,
-                            showDebugOptions = BuildConfig.DEBUG
+                            showDebugOptions = BuildConfig.BUILD_TYPE != "release"
                         )
                     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/compose/EditGroupScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/compose/EditGroupScreen.kt
@@ -305,7 +305,7 @@ private fun MemberActionSheet(
                 )
             }
 
-            if (BuildConfig.DEBUG && member.canPromote) {
+            if (BuildConfig.BUILD_TYPE != "release" && member.canPromote) {
                 this += ActionSheetItemData(
                     title = context.getString(R.string.adminPromoteToAdmin),
                     iconRes = R.drawable.ic_user_filled_custom,
@@ -322,7 +322,7 @@ private fun MemberActionSheet(
                 )
             }
 
-            if (BuildConfig.DEBUG && member.canResendPromotion) {
+            if (BuildConfig.BUILD_TYPE != "release" && member.canResendPromotion) {
                 this += ActionSheetItemData(
                     title = "Resend promotion",
                     iconRes = R.drawable.ic_mail,

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -355,7 +355,7 @@ class HomeActivity : ScreenLockActionBarActivity(),
 
         // Schedule a notification about the new Token Page for 1 hour after running the updated app for the first time.
         // Note: We do NOT schedule a debug notification on startup - but one may be triggered from the Debug Menu.
-        if (!BuildConfig.DEBUG) {
+        if (BuildConfig.BUILD_TYPE == "release") {
             tokenPageNotificationManager.scheduleTokenPageNotification(constructDebugNotification = false)
         }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
@@ -282,7 +282,7 @@ class SettingsActivity : ScreenLockActionBarActivity() {
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.settings_general, menu)
-        if (BuildConfig.DEBUG) {
+        if (BuildConfig.BUILD_TYPE != "release") {
             menu.findItem(R.id.action_qr_code)?.contentDescription = resources.getString(R.string.AccessibilityId_qrView)
         }
         return true


### PR DESCRIPTION
Now we have builds that are not debug (and not release), namely: qa and aqa builds, we want to expand some of the debug only codes to these variants as well.
