### PR TITLE
SES-4229 : Notifications for disappearing message changes are cut off mid-sentence

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
@@ -84,7 +84,7 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
     text = text == null ? "" : text;
 
     return text.length() <= MAX_DISPLAY_LENGTH ? text
-                                               : text.subSequence(0, MAX_DISPLAY_LENGTH - 1) +"\u2026";
+                                               : text.subSequence(0, MAX_DISPLAY_LENGTH - 3) +"\u2026";
   }
 
   @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
@@ -5,7 +5,9 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.SpannableStringBuilder;
+import android.text.TextPaint;
 import android.text.TextUtils;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -24,7 +26,7 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
   @SuppressWarnings("unused")
   private static final String TAG = AbstractNotificationBuilder.class.getSimpleName();
 
-  private static final int MAX_DISPLAY_LENGTH = 50;
+  private static final int MAX_DISPLAY_LENGTH = 80;
 
   protected Context                       context;
   protected NotificationPrivacyPreference privacy;
@@ -82,7 +84,7 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
     text = text == null ? "" : text;
 
     return text.length() <= MAX_DISPLAY_LENGTH ? text
-                                               : text.subSequence(0, MAX_DISPLAY_LENGTH);
+                                               : text.subSequence(0, MAX_DISPLAY_LENGTH - 1) +"\u2026";
   }
 
   @Override


### PR DESCRIPTION
[SES-4229](https://optf.atlassian.net/browse/SES-4229)

Updated max character length for notifications and added ellipsis at the end.

<img width="405" height="254" alt="image" src="https://github.com/user-attachments/assets/89db57aa-a2c8-480e-be3a-02ceb4df19b1" />
