### PR TITLE
SES-4107 : https://optf.atlassian.net/browse/SES-4107

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/MediaDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MediaDatabase.java
@@ -63,8 +63,8 @@ public class MediaDatabase extends Database {
   private static final String GALLERY_MEDIA_QUERY  = String.format(BASE_MEDIA_QUERY, AttachmentDatabase.CONTENT_TYPE + " LIKE 'image/%' OR " + AttachmentDatabase.CONTENT_TYPE + " LIKE 'video/%'");
   private static final String DOCUMENT_MEDIA_QUERY = String.format(BASE_MEDIA_QUERY, AttachmentDatabase.CONTENT_TYPE + " NOT LIKE 'image/%' AND " +
                                                                                      AttachmentDatabase.CONTENT_TYPE + " NOT LIKE 'video/%' AND " +
-                                                                                     AttachmentDatabase.CONTENT_TYPE + " NOT LIKE 'audio/%' AND " +
-                                                                                     AttachmentDatabase.CONTENT_TYPE + " NOT LIKE 'text/x-signal-plain'");
+                                                                                     AttachmentDatabase.CONTENT_TYPE + " NOT LIKE 'text/x-signal-plain' AND " +
+                                                                                     "IFNULL(" + AttachmentDatabase.VOICE_NOTE + ", 0) = 0");
 
   public MediaDatabase(Context context, Provider<SQLCipherOpenHelper> databaseHelper) {
     super(context, databaseHelper);


### PR DESCRIPTION
[SES-4107](https://optf.atlassian.net/browse/SES-4107)

Updated a database query where "audio/%" were not included. This led to audio files sent in the conversation to not appear in the list. I updated the query to include audio files but exclude voice notes.

Android:
<img width="250" height="500" alt="image" src="https://github.com/user-attachments/assets/8f28bb7d-8bac-4488-8e72-3afb3389d3a8" />


iOS: 
<img width="250" height="500" alt="image" src="https://github.com/user-attachments/assets/cd8e631d-84ed-4f82-8726-289c8b989606" />
