### PR TITLE
SES-1112 : Message request push notifications suppressed 

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -25,6 +25,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.database.Cursor
+import android.graphics.Bitmap
 import android.os.AsyncTask
 import android.text.TextUtils
 import androidx.core.app.ActivityCompat
@@ -313,6 +314,13 @@ class DefaultMessageNotifier(
 
         builder.setThread(notifications[0].recipient)
         builder.setMessageCount(notificationState.notificationCount)
+
+        val isRequestNote = notificationId == REQUEST_NOTIFICATION_ID
+        if(isRequestNote){
+            // Set the notification title to App Name
+            builder.setContentTitle(context.getString(R.string.app_name))
+            builder.setLargeIcon(null as Bitmap?)
+        }
 
         val builderCS = notificationText ?: ""
         val ss = highlightMentions(

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.kt
@@ -555,7 +555,7 @@ class DefaultMessageNotifier(
                 val hasHiddenRequests = hasHiddenMessageRequests(context)
 
                // Only send if you either have no existing message requests or have hidden the section
-                if (!hasPostedRequestOnce && (!hasExistingMessages || hasHiddenRequests)) {
+                if (!hasPostedRequestOnce && (!hasExistingMessages || !hasHiddenRequests)) {
                     val item =
                         // Use a constant ID here so Android treats all request notifications as the same
                         NotificationItem(


### PR DESCRIPTION
[SES-1112](https://optf.atlassian.net/browse/SES-1112)

- Users can now receive a notification from Message requests.
- Only one generic notification will appear for message requests.

Sample notification:
<img width="381" height="167" alt="image" src="https://github.com/user-attachments/assets/b3f1af5f-2e8b-4895-9e98-a0679a2be3ed" />

