### PR TITLE
SES-3437 : Community Mentions Inconsistent

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/mention/MentionViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/mention/MentionViewModel.kt
@@ -188,6 +188,8 @@ class MentionViewModel(
                     // For communities and one-on-one conversations
                     val contacts = contactDatabase.getContacts(memberIDs) // Get members from contacts based on memberIDs
                     val contactMap = contacts.associateBy { it.accountID }
+
+                    // Map using memberIDs to preserve the order of members
                     memberIDs.asSequence()
                         .filter { it != myId }
                         .mapNotNull { contactMap[it] }
@@ -230,7 +232,6 @@ class MentionViewModel(
                         }
                     }
 
-                    filtered.sortWith(Candidate.MENTION_LIST_COMPARATOR)
                     AutoCompleteState.Result(filtered, query.query)
                 }
             }
@@ -346,12 +347,7 @@ class MentionViewModel(
         val nameHighlighted: CharSequence,
         // The score of matching the query keyword. Lower is better.
         val matchScore: Int,
-    ) {
-        companion object {
-            val MENTION_LIST_COMPARATOR = compareBy<Candidate> { !it.member.isMe }
-                .thenBy { it.matchScore }
-        }
-    }
+    )
 
     sealed interface AutoCompleteState {
         object Idle : AutoCompleteState

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/mention/MentionViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/mention/MentionViewModel.kt
@@ -183,12 +183,14 @@ class MentionViewModel(
                                 )  // returns contact name or blank
                                 .takeIf { it.isNotBlank() } ?: id // fallback to id
                             buildMember(id, name, id in moderatorIDs, false)
-                        }
+                        }.sortedBy { it.name }
                 } else {
                     // Fallback to only local contacts
-                    contactDatabase.getContacts(memberIDs)
-                        .asSequence()
-                        .filter { it.accountID != myId }
+                    val contacts = contactDatabase.getContacts(memberIDs)
+                    val contactMap = contacts.associateBy { it.accountID }
+                    memberIDs.asSequence()
+                        .filter { it != myId }
+                        .mapNotNull { contactMap[it] }
                         .map { contact ->
                             val id = contact.accountID
                             val name = contact.displayName(contactContext)
@@ -348,7 +350,6 @@ class MentionViewModel(
         companion object {
             val MENTION_LIST_COMPARATOR = compareBy<Candidate> { !it.member.isMe }
                 .thenBy { it.matchScore }
-                .then(compareBy { it.member.name })
         }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/mention/MentionViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/mention/MentionViewModel.kt
@@ -163,11 +163,11 @@ class MentionViewModel(
                     true
                 )
 
-                // Other members from this groupv2
+                // Get other members
                 val otherMembers = if (recipient.isGroupV2Recipient) {
                     val groupId = AccountId(recipient.address.toString())
 
-                    // Get members of the group
+                    // Get members of the group from the config
                     val rawMembers = configFactory.withGroupConfigs(groupId) {
                         it.groupMembers.allWithStatus()
                     }
@@ -185,8 +185,8 @@ class MentionViewModel(
                             buildMember(id, name, id in moderatorIDs, false)
                         }.sortedBy { it.name }
                 } else {
-                    // Fallback to only local contacts
-                    val contacts = contactDatabase.getContacts(memberIDs)
+                    // For communities and one-on-one conversations
+                    val contacts = contactDatabase.getContacts(memberIDs) // Get members from contacts based on memberIDs
                     val contactMap = contacts.associateBy { it.accountID }
                     memberIDs.asSequence()
                         .filter { it != myId }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/mention/MentionViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/mention/MentionViewModel.kt
@@ -232,6 +232,7 @@ class MentionViewModel(
                         }
                     }
 
+                    filtered.sortWith(Candidate.MENTION_LIST_COMPARATOR)
                     AutoCompleteState.Result(filtered, query.query)
                 }
             }
@@ -347,7 +348,12 @@ class MentionViewModel(
         val nameHighlighted: CharSequence,
         // The score of matching the query keyword. Lower is better.
         val matchScore: Int,
-    )
+    ) {
+        companion object {
+            val MENTION_LIST_COMPARATOR = compareBy<Candidate> { !it.member.isMe }
+                .thenBy { it.matchScore }
+        }
+    }
 
     sealed interface AutoCompleteState {
         object Idle : AutoCompleteState


### PR DESCRIPTION
Fixes based on [QA feedback](https://optf.atlassian.net/browse/QA-2179?focusedCommentId=18668).

Community mentions should be ordered by most recent message sent instead of by name. By-name ordering is retained for groups.

Contacts database somehow messes up the list so to maintain the order by which members are retrieved, it was mapped from memberIDs.