### PR TITLE
1.27.0  fixes

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -688,6 +688,15 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
                     is ConversationUiEvent.ShowUnblockConfirmation -> {
                         unblock()
                     }
+
+                    is ConversationUiEvent.ShowConversationSettings -> {
+                        val intent = ConversationSettingsActivity.createIntent(
+                            context = this@ConversationActivityV2,
+                            threadId = event.threadId,
+                            threadAddress = event.threadAddress
+                        )
+                        startActivity(intent)
+                    }
                 }
             }
         }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -494,7 +494,8 @@ class ConversationViewModel(
                     pagerData += ConversationAppBarPagerData(
                         title = title,
                         action = {
-                            showGroupMembers()
+                            if(conversation.isCommunityRecipient) showConversationSettings()
+                            else showGroupMembers()
                         },
                     )
                 }
@@ -1319,6 +1320,15 @@ class ConversationViewModel(
         }
     }
 
+    private fun showConversationSettings() {
+        recipient?.let { convo ->
+            _uiEvents.tryEmit(ConversationUiEvent.ShowConversationSettings(
+                threadId = threadId,
+                threadAddress = convo.address
+            ))
+        }
+    }
+
     private fun showNotificationSettings() {
         _uiEvents.tryEmit(ConversationUiEvent.ShowNotificationSettings(threadId))
     }
@@ -1480,6 +1490,7 @@ sealed interface ConversationUiEvent {
     data class ShowDisappearingMessages(val threadId: Long) : ConversationUiEvent
     data class ShowNotificationSettings(val threadId: Long) : ConversationUiEvent
     data class ShowGroupMembers(val groupId: String) : ConversationUiEvent
+    data class ShowConversationSettings(val threadId: Long, val threadAddress: Address) : ConversationUiEvent
     data object ShowUnblockConfirmation : ConversationUiEvent
 }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/util/UserProfileUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/UserProfileUtils.kt
@@ -91,7 +91,7 @@ class UserProfileUtils @AssistedInject constructor(
             isResolvedBlinded -> {
                 "${address.substring(0, 23)}\n${address.substring(23, 46)}\n${address.substring(46)}" to
                         Phrase.from(context, R.string.tooltipAccountIdVisible)
-                            .put(NAME_KEY, recipient.name)
+                            .put(NAME_KEY, truncateName(recipient.name))
                             .format()
             }
 
@@ -117,6 +117,14 @@ class UserProfileUtils @AssistedInject constructor(
             showProCTA = false
         )
 
+    }
+
+    private fun truncateName(name: String): String {
+        return if (name.length > 10) {
+            name.take(10) + "…"
+        } else {
+            name
+        }
     }
 
     fun onCommand(command: UserProfileModalCommands){


### PR DESCRIPTION
[SES-4292](https://optf.atlassian.net/browse/SES-4292) - Fixed a crash in communities where the community members tapp would try to open the closed group members page. It instead goes to the UCS
[SES-4296](https://optf.atlassian.net/browse/SES-4296) - Truncating long names for the UPM tooltip