### PR TITLE
Clean up ApplicationContext dependencies

### DIFF
--- a/app/src/firebaseCommon/kotlin/org/thoughtcrime/securesms/notifications/FirebaseTokenFetcher.kt
+++ b/app/src/firebaseCommon/kotlin/org/thoughtcrime/securesms/notifications/FirebaseTokenFetcher.kt
@@ -4,11 +4,12 @@ import com.google.firebase.messaging.FirebaseMessaging
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.tasks.await
 import org.session.libsession.messaging.notifications.TokenFetcher
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class FirebaseTokenFetcher @Inject constructor(): TokenFetcher {
+class FirebaseTokenFetcher @Inject constructor(): TokenFetcher, OnAppStartupComponent {
     override val token = MutableStateFlow<String?>(null)
 
     init {

--- a/app/src/main/java/org/session/libsession/messaging/MessagingModuleConfiguration.kt
+++ b/app/src/main/java/org/session/libsession/messaging/MessagingModuleConfiguration.kt
@@ -1,28 +1,29 @@
 package org.session.libsession.messaging
 
 import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
 import org.session.libsession.database.MessageDataProvider
 import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.groups.GroupManagerV2
 import org.session.libsession.messaging.groups.LegacyGroupDeprecationManager
 import org.session.libsession.messaging.jobs.MessageSendJob
 import org.session.libsession.messaging.notifications.TokenFetcher
-import org.session.libsession.messaging.sending_receiving.ReceivedMessageHandler
 import org.session.libsession.snode.SnodeClock
 import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsession.utilities.Device
 import org.session.libsession.utilities.TextSecurePreferences
-import org.session.libsession.utilities.Toaster
 import org.session.libsession.utilities.UsernameUtils
 import org.thoughtcrime.securesms.pro.ProStatusManager
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class MessagingModuleConfiguration(
-    val context: Context,
+@Singleton
+class MessagingModuleConfiguration @Inject constructor(
+    @param:ApplicationContext val context: Context,
     val storage: StorageProtocol,
     val device: Device,
     val messageDataProvider: MessageDataProvider,
     val configFactory: ConfigFactoryProtocol,
-    val toaster: Toaster,
     val tokenFetcher: TokenFetcher,
     val groupManagerV2: GroupManagerV2,
     val clock: SnodeClock,

--- a/app/src/main/java/org/session/libsession/messaging/groups/LegacyGroupDeprecationManager.kt
+++ b/app/src/main/java/org/session/libsession/messaging/groups/LegacyGroupDeprecationManager.kt
@@ -14,8 +14,13 @@ import org.session.libsession.utilities.TextSecurePreferences
 import java.time.Duration
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class LegacyGroupDeprecationManager(private val prefs: TextSecurePreferences)  {
+@Singleton
+class LegacyGroupDeprecationManager
+    @Inject constructor(private val prefs: TextSecurePreferences
+)  {
     private val mutableDeprecationStateOverride = MutableStateFlow(
         DeprecationState.entries.firstOrNull { it.name == prefs.deprecationStateOverride }
     )

--- a/app/src/main/java/org/session/libsession/messaging/jobs/InviteContactsJob.kt
+++ b/app/src/main/java/org/session/libsession/messaging/jobs/InviteContactsJob.kt
@@ -110,8 +110,6 @@ class InviteContactsJob(val groupSessionId: String, val memberSessionIds: Array<
             // assume job "success" even if we fail, the state of invites is tracked outside of this job
             if (failures.isNotEmpty()) {
                 // show the failure toast
-                val toaster = MessagingModuleConfiguration.shared.toaster
-
                 val (_, firstError) = failures.first()
 
                 // Add the rest of the exceptions as suppressed
@@ -129,7 +127,7 @@ class InviteContactsJob(val groupSessionId: String, val memberSessionIds: Array<
                 ).format(MessagingModuleConfiguration.shared.context,
                     MessagingModuleConfiguration.shared.usernameUtils).let {
                     withContext(Dispatchers.Main) {
-                        toaster.toast(it, Toast.LENGTH_LONG)
+                        Toast.makeText(MessagingModuleConfiguration.shared.context, it, Toast.LENGTH_LONG).show()
                     }
                 }
             }

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPollerManager.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPollerManager.kt
@@ -2,7 +2,6 @@ package org.session.libsession.messaging.sending_receiving.pollers
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -22,6 +21,8 @@ import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsession.utilities.ConfigUpdateNotification
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -41,7 +42,8 @@ class OpenGroupPollerManager @Inject constructor(
     pollerFactory: OpenGroupPoller.Factory,
     configFactory: ConfigFactoryProtocol,
     preferences: TextSecurePreferences,
-) {
+    @ManagerScope scope: CoroutineScope
+) : OnAppStartupComponent {
     val pollers: StateFlow<Map<String, PollerHandle>> =
         preferences.watchLocalNumber()
             .map { it != null }
@@ -86,7 +88,7 @@ class OpenGroupPollerManager @Inject constructor(
                     newPollerStates
                 }
             }
-            .stateIn(GlobalScope, SharingStarted.Eagerly, emptyMap())
+            .stateIn(scope, SharingStarted.Eagerly, emptyMap())
 
     val isAllCaughtUp: Boolean
         get() = pollers.value.values.all { it.poller.isCaughtUp.value }

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/PollerManager.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/PollerManager.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import org.session.libsession.utilities.TextSecurePreferences
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -27,7 +28,7 @@ import javax.inject.Singleton
 class PollerManager @Inject constructor(
     prefers: TextSecurePreferences,
     provider: Poller.Factory,
-) {
+) : OnAppStartupComponent {
     @OptIn(DelicateCoroutinesApi::class)
     private val currentPoller: StateFlow<Poller?> = channelFlow {
         prefers.watchLocalNumber()

--- a/app/src/main/java/org/session/libsession/snode/OnionRequestAPI.kt
+++ b/app/src/main/java/org/session/libsession/snode/OnionRequestAPI.kt
@@ -26,16 +26,15 @@ import org.session.libsignal.crypto.secureRandom
 import org.session.libsignal.crypto.secureRandomOrNull
 import org.session.libsignal.database.LokiAPIDatabaseProtocol
 import org.session.libsignal.utilities.Base64
+import org.session.libsignal.utilities.ByteArraySlice
+import org.session.libsignal.utilities.ByteArraySlice.Companion.view
 import org.session.libsignal.utilities.ForkInfo
 import org.session.libsignal.utilities.HTTP
 import org.session.libsignal.utilities.JsonUtil
 import org.session.libsignal.utilities.Log
-import org.session.libsignal.utilities.ByteArraySlice
-import org.session.libsignal.utilities.ByteArraySlice.Companion.view
 import org.session.libsignal.utilities.Snode
 import org.session.libsignal.utilities.recover
 import org.session.libsignal.utilities.toHexString
-import kotlin.collections.set
 
 private typealias Path = List<Snode>
 
@@ -367,7 +366,7 @@ object OnionRequestAPI {
         }
         val promise = deferred.promise
         promise.fail { exception ->
-            if (exception is HTTP.HTTPRequestFailedException && SnodeModule.isInitialized) {
+            if (exception is HTTP.HTTPRequestFailedException) {
                 val checkedGuardSnode = guardSnode
                 val path =
                     if (checkedGuardSnode == null) null

--- a/app/src/main/java/org/session/libsession/snode/SnodeModule.kt
+++ b/app/src/main/java/org/session/libsession/snode/SnodeModule.kt
@@ -1,22 +1,28 @@
 package org.session.libsession.snode
 
+import android.app.Application
+import dagger.Lazy
 import org.session.libsession.utilities.Environment
+import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.database.LokiAPIDatabaseProtocol
 import org.session.libsignal.utilities.Broadcaster
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class SnodeModule(
-    val storage: LokiAPIDatabaseProtocol, val broadcaster: Broadcaster, val environment: Environment
+@Singleton
+class SnodeModule @Inject constructor(
+    application: Application,
+    val storage: LokiAPIDatabaseProtocol,
+    prefs: TextSecurePreferences,
 ) {
 
+    val broadcaster: Broadcaster = org.thoughtcrime.securesms.util.Broadcaster(application)
+    val environment: Environment = prefs.getEnvironment()
+
     companion object {
+        lateinit var sharedLazy: Lazy<SnodeModule>
+
         @Deprecated("Use properly DI components instead")
-        lateinit var shared: SnodeModule
-
-        val isInitialized: Boolean get() = Companion::shared.isInitialized
-
-        fun configure(storage: LokiAPIDatabaseProtocol, broadcaster: Broadcaster, environment: Environment) {
-            if (isInitialized) { return }
-            shared = SnodeModule(storage, broadcaster, environment)
-        }
+        val shared: SnodeModule get() = sharedLazy.get()
     }
 }

--- a/app/src/main/java/org/session/libsession/utilities/SSKEnvironment.kt
+++ b/app/src/main/java/org/session/libsession/utilities/SSKEnvironment.kt
@@ -1,17 +1,18 @@
 package org.session.libsession.utilities
 
 import android.content.Context
+import dagger.Lazy
 import org.session.libsession.messaging.contacts.Contact
 import org.session.libsession.messaging.messages.Message
 import org.session.libsession.messaging.messages.control.ExpirationTimerUpdate
-import org.session.libsession.messaging.sending_receiving.notifications.MessageNotifier
 import org.session.libsession.utilities.recipients.Recipient
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class SSKEnvironment(
+@Singleton
+class SSKEnvironment @Inject constructor(
     val typingIndicators: TypingIndicatorsProtocol,
-    val readReceiptManager: ReadReceiptManagerProtocol,
     val profileManager: ProfileManagerProtocol,
-    val notificationManager: MessageNotifier,
     val messageExpirationManager: MessageExpirationManagerProtocol
 ) {
 
@@ -53,16 +54,9 @@ class SSKEnvironment(
     }
 
     companion object {
-        @Deprecated("Use Hilt to inject your dependencies instead")
-        lateinit var shared: SSKEnvironment
+        lateinit var sharedLazy: Lazy<SSKEnvironment>
 
-        fun configure(typingIndicators: TypingIndicatorsProtocol,
-                      readReceiptManager: ReadReceiptManagerProtocol,
-                      profileManager: ProfileManagerProtocol,
-                      notificationManager: MessageNotifier,
-                      messageExpirationManager: MessageExpirationManagerProtocol) {
-            if (Companion::shared.isInitialized) { return }
-            shared = SSKEnvironment(typingIndicators, readReceiptManager, profileManager, notificationManager, messageExpirationManager)
-        }
+        @Deprecated("Use Hilt to inject your dependencies instead")
+        val shared: SSKEnvironment get() = sharedLazy.get()
     }
 }

--- a/app/src/main/java/org/session/libsession/utilities/Toaster.kt
+++ b/app/src/main/java/org/session/libsession/utilities/Toaster.kt
@@ -1,8 +1,0 @@
-package org.session.libsession.utilities
-
-import androidx.annotation.StringRes
-
-interface Toaster {
-    fun toast(@StringRes stringRes: Int, toastLength: Int, parameters: Map<String, String>)
-    fun toast(message: CharSequence, toastLength: Int)
-}

--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.kt
@@ -21,8 +21,6 @@ import android.content.Intent
 import android.os.AsyncTask
 import android.os.Handler
 import android.os.HandlerThread
-import android.widget.Toast
-import androidx.annotation.StringRes
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
@@ -31,7 +29,6 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.Configuration
-import com.squareup.phrase.Phrase
 import dagger.Lazy
 import dagger.hilt.EntryPoints
 import dagger.hilt.android.HiltAndroidApp
@@ -42,80 +39,35 @@ import network.loki.messenger.libsession_util.util.Logger
 import nl.komponents.kovenant.android.startKovenant
 import nl.komponents.kovenant.android.stopKovenant
 import org.conscrypt.Conscrypt
-import org.session.libsession.database.MessageDataProvider
 import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.MessagingModuleConfiguration.Companion.configure
-import org.session.libsession.messaging.groups.GroupManagerV2
-import org.session.libsession.messaging.groups.LegacyGroupDeprecationManager
-import org.session.libsession.messaging.jobs.MessageSendJob
-import org.session.libsession.messaging.notifications.TokenFetcher
-import org.session.libsession.messaging.sending_receiving.ReceivedMessageHandler
 import org.session.libsession.messaging.sending_receiving.notifications.MessageNotifier
-import org.session.libsession.messaging.sending_receiving.pollers.OpenGroupPollerManager
-import org.session.libsession.messaging.sending_receiving.pollers.PollerManager
-import org.session.libsession.snode.SnodeClock
 import org.session.libsession.snode.SnodeModule
-import org.session.libsession.utilities.Device
 import org.session.libsession.utilities.ProfilePictureUtilities.resubmitProfilePictureIfNeeded
-import org.session.libsession.utilities.SSKEnvironment.Companion.configure
-import org.session.libsession.utilities.SSKEnvironment.ProfileManagerProtocol
+import org.session.libsession.utilities.SSKEnvironment
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsession.utilities.TextSecurePreferences.Companion.pushSuffix
-import org.session.libsession.utilities.Toaster
-import org.session.libsession.utilities.UsernameUtils
 import org.session.libsession.utilities.WindowDebouncer
 import org.session.libsignal.utilities.HTTP.isConnectedToNetwork
-import org.session.libsignal.utilities.JsonUtil
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.AppContext.configureKovenant
-import org.thoughtcrime.securesms.components.TypingStatusSender
-import org.thoughtcrime.securesms.configs.ConfigUploader
-import org.thoughtcrime.securesms.database.EmojiSearchDatabase
-import org.thoughtcrime.securesms.database.LokiAPIDatabase
-import org.thoughtcrime.securesms.database.Storage
-import org.thoughtcrime.securesms.database.ThreadDatabase
-import org.thoughtcrime.securesms.database.model.EmojiSearchData
 import org.thoughtcrime.securesms.debugmenu.DebugActivity
-import org.thoughtcrime.securesms.dependencies.AppComponent
-import org.thoughtcrime.securesms.dependencies.ConfigFactory
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
 import org.thoughtcrime.securesms.dependencies.DatabaseModule.init
-import org.thoughtcrime.securesms.disguise.AppDisguiseManager
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponents
 import org.thoughtcrime.securesms.emoji.EmojiSource.Companion.refresh
-import org.thoughtcrime.securesms.groups.ExpiredGroupManager
-import org.thoughtcrime.securesms.groups.GroupPollerManager
-import org.thoughtcrime.securesms.groups.handler.AdminStateSync
-import org.thoughtcrime.securesms.groups.handler.CleanupInvitationHandler
-import org.thoughtcrime.securesms.groups.handler.DestroyedGroupSync
-import org.thoughtcrime.securesms.groups.handler.RemoveGroupMemberHandler
 import org.thoughtcrime.securesms.jobmanager.impl.NetworkConstraint
 import org.thoughtcrime.securesms.logging.AndroidLogger
 import org.thoughtcrime.securesms.logging.PersistentLogger
 import org.thoughtcrime.securesms.logging.UncaughtExceptionLogger
 import org.thoughtcrime.securesms.migration.DatabaseMigrationManager
-import org.thoughtcrime.securesms.notifications.BackgroundPollManager
 import org.thoughtcrime.securesms.notifications.NotificationChannels
-import org.thoughtcrime.securesms.notifications.PushRegistrationHandler
-import org.thoughtcrime.securesms.pro.ProStatusManager
 import org.thoughtcrime.securesms.providers.BlobUtils
-import org.thoughtcrime.securesms.service.ExpiringMessageManager
 import org.thoughtcrime.securesms.service.KeyCachingService
-import org.thoughtcrime.securesms.sskenvironment.ReadReceiptManager
-import org.thoughtcrime.securesms.sskenvironment.TypingStatusRepository
-import org.thoughtcrime.securesms.tokenpage.TokenDataManager
-import org.thoughtcrime.securesms.util.AppVisibilityManager
-import org.thoughtcrime.securesms.util.Broadcaster
-import org.thoughtcrime.securesms.util.CurrentActivityObserver
-import org.thoughtcrime.securesms.util.VersionDataFetcher
-import org.thoughtcrime.securesms.webrtc.CallMessageProcessor
-import org.thoughtcrime.securesms.webrtc.WebRtcCallBridge
 import org.webrtc.PeerConnectionFactory
 import org.webrtc.PeerConnectionFactory.InitializationOptions
-import java.io.IOException
 import java.security.Security
-import java.util.Arrays
 import java.util.Timer
-import java.util.concurrent.Executors
 import javax.inject.Inject
 import kotlin.concurrent.Volatile
 
@@ -129,9 +81,7 @@ import kotlin.concurrent.Volatile
  * @author Moxie Marlinspike
  */
 @HiltAndroidApp
-class ApplicationContext : Application(), DefaultLifecycleObserver,
-    Toaster, Configuration.Provider {
-    var broadcaster: Broadcaster? = null
+class ApplicationContext : Application(), DefaultLifecycleObserver, Configuration.Provider {
     var conversationListDebouncer: WindowDebouncer? = null
         get() {
             if (field == null) {
@@ -143,76 +93,15 @@ class ApplicationContext : Application(), DefaultLifecycleObserver,
     private var conversationListHandlerThread: HandlerThread? = null
     private var conversationListHandler: Handler? = null
 
+    @Inject lateinit var messagingModuleConfiguration: Lazy<MessagingModuleConfiguration>
     @Inject lateinit var workerFactory: Lazy<HiltWorkerFactory>
-    @Inject lateinit var lokiAPIDatabase: Lazy<LokiAPIDatabase>
-    @Inject lateinit var storage: Lazy<Storage>
-    @Inject lateinit var device: Lazy<Device>
-    @Inject lateinit var messageDataProvider: Lazy<MessageDataProvider>
-    @Inject lateinit var textSecurePreferences: Lazy<TextSecurePreferences>
-    @Inject lateinit var configFactory: Lazy<ConfigFactory>
-    @Inject lateinit var versionDataFetcher: Lazy<VersionDataFetcher>
-    @Inject lateinit var pushRegistrationHandler: Lazy<PushRegistrationHandler>
-    @Inject lateinit var tokenFetcher: Lazy<TokenFetcher>
-    @Inject lateinit var groupManagerV2: Lazy<GroupManagerV2>
-    @Inject lateinit var profileManager: Lazy<ProfileManagerProtocol>
-    @Inject lateinit var callMessageProcessor: Lazy<CallMessageProcessor>
-    private var messagingModuleConfiguration: MessagingModuleConfiguration? = null
+    @Inject lateinit var snodeModule: Lazy<SnodeModule>
+    @Inject lateinit var sskEnvironment: Lazy<SSKEnvironment>
 
-    @Inject lateinit var configUploader: Lazy<ConfigUploader>
-    @Inject lateinit var adminStateSync: Lazy<AdminStateSync>
-    @Inject lateinit var destroyedGroupSync: Lazy<DestroyedGroupSync>
-    @Inject lateinit var removeGroupMemberHandler: Lazy<RemoveGroupMemberHandler> // Exists here only to start upon app starts
-    @Inject lateinit var tokenDataManager: Lazy<TokenDataManager> // Exists here only to start upon app starts
-    @Inject lateinit var snodeClock: Lazy<SnodeClock>
-    @Inject lateinit var migrationManager: Lazy<DatabaseMigrationManager>
-    @Inject lateinit var appDisguiseManager: Lazy<AppDisguiseManager>
+    @Inject lateinit var startupComponents: Lazy<OnAppStartupComponents>
     @Inject lateinit var persistentLogger: Lazy<PersistentLogger>
-    @Inject lateinit var currentActivityObserver: Lazy<CurrentActivityObserver>
-
-    @get:Deprecated(message = "Use proper DI to inject this component")
-    @Inject
-    lateinit var expiringMessageManager: Lazy<ExpiringMessageManager>
-
-    @get:Deprecated(message = "Use proper DI to inject this component")
-    @Inject
-    lateinit var typingStatusRepository: Lazy<TypingStatusRepository>
-
-    @get:Deprecated(message = "Use proper DI to inject this component")
-    @Inject
-    lateinit var typingStatusSender: Lazy<TypingStatusSender>
-
-    @get:Deprecated(message = "Use proper DI to inject this component")
-    @Inject
-    lateinit var readReceiptManager: Lazy<ReadReceiptManager>
-
-    @Inject lateinit var messageNotifierLazy: Lazy<MessageNotifier>
-    @Inject lateinit var apiDB: Lazy<LokiAPIDatabase>
-    @Inject lateinit var emojiSearchDb: Lazy<EmojiSearchDatabase>
-    @Inject lateinit var webRtcCallBridge: Lazy<WebRtcCallBridge>
-    @Inject lateinit var legacyGroupDeprecationManager: Lazy<LegacyGroupDeprecationManager>
-    @Inject lateinit var cleanupInvitationHandler: Lazy<CleanupInvitationHandler>
-    @Inject lateinit var usernameUtils: Lazy<UsernameUtils>
-    @Inject lateinit var pollerManager: Lazy<PollerManager>
-    @Inject lateinit var proStatusManager: Lazy<ProStatusManager>
-    @Inject lateinit var messageSendJobFactory: MessageSendJob.Factory
-
-    @Inject
-    lateinit var backgroundPollManager: Lazy<BackgroundPollManager> // Exists here only to start upon app starts
-
-    @Inject
-    lateinit var appVisibilityManager: Lazy<AppVisibilityManager> // Exists here only to start upon app starts
-
-    @Inject
-    lateinit var groupPollerManager: Lazy<GroupPollerManager> // Exists here only to start upon app starts
-
-    @Inject
-    lateinit var expiredGroupManager: Lazy<ExpiredGroupManager> // Exists here only to start upon app starts
-
-    @Inject
-    lateinit var openGroupPollerManager: Lazy<OpenGroupPollerManager>
-
-    @Inject
-    lateinit var threadDatabase: Lazy<ThreadDatabase>
+    @Inject lateinit var textSecurePreferences: Lazy<TextSecurePreferences>
+    @Inject lateinit var migrationManager: Lazy<DatabaseMigrationManager>
 
     @Volatile
     var isAppVisible: Boolean = false
@@ -224,17 +113,11 @@ class ApplicationContext : Application(), DefaultLifecycleObserver,
 
     override fun getSystemService(name: String): Any? {
         if (MessagingModuleConfiguration.MESSAGING_MODULE_SERVICE == name) {
-            return messagingModuleConfiguration!!
+            return messagingModuleConfiguration.get()
         }
+
         return super.getSystemService(name)
     }
-
-    @get:Deprecated(message = "Use proper DI to inject this component")
-    val prefs: TextSecurePreferences
-        get() = EntryPoints.get(
-            applicationContext,
-            AppComponent::class.java
-        ).getPrefs()
 
     @get:Deprecated(message = "Use proper DI to inject this component")
     val databaseComponent: DatabaseComponent
@@ -244,8 +127,7 @@ class ApplicationContext : Application(), DefaultLifecycleObserver,
         )
 
     @get:Deprecated(message = "Use proper DI to inject this component")
-    val messageNotifier: MessageNotifier
-        get() = messageNotifierLazy.get()
+    @Inject lateinit var messageNotifier: MessageNotifier
 
     val conversationListNotificationHandler: Handler
         get() {
@@ -260,21 +142,6 @@ class ApplicationContext : Application(), DefaultLifecycleObserver,
             return conversationListHandler!!
         }
 
-    override fun toast(
-        @StringRes stringRes: Int,
-        toastLength: Int,
-        parameters: Map<String, String>
-    ) {
-        val builder = Phrase.from(this, stringRes)
-        for ((key, value) in parameters) {
-            builder.put(key, value)
-        }
-        Toast.makeText(this, builder.format(), toastLength).show()
-    }
-
-    override fun toast(message: CharSequence, toastLength: Int) {
-        Toast.makeText(this, message, toastLength).show()
-    }
 
     override fun onCreate() {
         pushSuffix = BuildConfig.PUSH_KEY_SUFFIX
@@ -283,23 +150,6 @@ class ApplicationContext : Application(), DefaultLifecycleObserver,
         configure(this)
         super<Application>.onCreate()
 
-        messagingModuleConfiguration = MessagingModuleConfiguration(
-            context = this,
-            storage = storage.get(),
-            device = device.get(),
-            messageDataProvider = messageDataProvider.get(),
-            configFactory = configFactory.get(),
-            toaster = this,
-            tokenFetcher = tokenFetcher.get(),
-            groupManagerV2 = groupManagerV2.get(),
-            clock = snodeClock.get(),
-            preferences = textSecurePreferences.get(),
-            deprecationManager = legacyGroupDeprecationManager.get(),
-            usernameUtils = usernameUtils.get(),
-            proStatusManager = proStatusManager.get(),
-            messageSendJobFactory = messageSendJobFactory,
-        )
-
         startKovenant()
         initializeSecurityProvider()
         initializeLogging()
@@ -307,36 +157,16 @@ class ApplicationContext : Application(), DefaultLifecycleObserver,
         NotificationChannels.create(this)
         ProcessLifecycleOwner.get().lifecycle.addObserver(this)
         configureKovenant()
-        broadcaster = Broadcaster(this)
-        SnodeModule.configure(
-            storage = apiDB.get(),
-            broadcaster = broadcaster!!,
-            environment = textSecurePreferences.get().getEnvironment()
-        )
+        SnodeModule.sharedLazy = snodeModule
+        SSKEnvironment.sharedLazy = sskEnvironment
 
-        configure(
-            typingStatusRepository.get(), readReceiptManager.get(), profileManager.get(),
-            messageNotifier, expiringMessageManager.get()
-        )
         initializeWebRtc()
         initializeBlobProvider()
         resubmitProfilePictureIfNeeded()
-        loadEmojiSearchIndexIfNeeded()
         refresh()
 
         val networkConstraint = NetworkConstraint.Factory(this).create()
         isConnectedToNetwork = { networkConstraint.isMet }
-
-        snodeClock.get().start()
-        pushRegistrationHandler.get().run()
-        configUploader.get().start()
-        destroyedGroupSync.get().start()
-        adminStateSync.get().start()
-        cleanupInvitationHandler.get().start()
-        tokenDataManager.get().getTokenDataWhenLoggedIn()
-
-        // Start our migration process as early as possible so we can show the user a progress UI
-        migrationManager.get().requestMigration(fromRetry = false)
 
         // add our shortcut debug menu if we are not in a release build
         if (BuildConfig.BUILD_TYPE != "release") {
@@ -358,60 +188,15 @@ class ApplicationContext : Application(), DefaultLifecycleObserver,
         // Once we have done initialisation, access the lazy dependencies so we make sure
         // they are initialised.
         workerFactory.get()
-        lokiAPIDatabase.get()
-        storage.get()
-        device.get()
-        messageDataProvider.get()
-        textSecurePreferences.get()
-        configFactory.get()
-        versionDataFetcher.get()
-        pushRegistrationHandler.get()
-        tokenFetcher.get()
-        groupManagerV2.get()
-        profileManager.get()
-        callMessageProcessor.get()
-        configUploader.get()
-        adminStateSync.get()
-        destroyedGroupSync.get()
-        removeGroupMemberHandler.get()
-        snodeClock.get()
-        migrationManager.get()
-        appDisguiseManager.get()
-        expiringMessageManager.get()
-        typingStatusRepository.get()
-        typingStatusSender.get()
-        readReceiptManager.get()
-        messageNotifierLazy.get()
-        apiDB.get()
-        emojiSearchDb.get()
-        webRtcCallBridge.get()
-        pollerManager.get()
-        legacyGroupDeprecationManager.get()
-        cleanupInvitationHandler.get()
-        usernameUtils.get()
-        backgroundPollManager.get()
-        appVisibilityManager.get()
-        groupPollerManager.get()
-        expiredGroupManager.get()
-        openGroupPollerManager.get()
-        currentActivityObserver.get()
 
-        threadDatabase.get().onAppCreated()
+        startupComponents.get()
+            .onPostAppStarted()
     }
 
     override fun onStart(owner: LifecycleOwner) {
         isAppVisible = true
         Log.i(TAG, "App is now visible.")
         KeyCachingService.onAppForegrounded(this)
-
-        // If the user account hasn't been created or onboarding wasn't finished then don't start
-        // the pollers
-        if (textSecurePreferences.get().getLocalNumber() == null) {
-            return
-        }
-
-        // fetch last version data
-        versionDataFetcher.get().startTimedVersionCheck()
     }
 
     override fun onStop(owner: LifecycleOwner) {
@@ -419,12 +204,10 @@ class ApplicationContext : Application(), DefaultLifecycleObserver,
         Log.i(TAG, "App is no longer visible.")
         KeyCachingService.onAppBackgrounded(this)
         messageNotifier.setVisibleThread(-1)
-        versionDataFetcher.get().stopTimedVersionCheck()
     }
 
     override fun onTerminate() {
         stopKovenant() // Loki
-        versionDataFetcher.get().stopTimedVersionCheck()
         super.onTerminate()
     }
 
@@ -483,28 +266,7 @@ class ApplicationContext : Application(), DefaultLifecycleObserver,
         resubmitProfilePictureIfNeeded(this)
     }
 
-    private fun loadEmojiSearchIndexIfNeeded() {
-        Executors.newSingleThreadExecutor().execute {
-            if (emojiSearchDb.get().query("face", 1).isEmpty()) {
-                try {
-                    assets.open("emoji/emoji_search_index.json").use { inputStream ->
-                        val searchIndex = Arrays.asList(
-                            *JsonUtil.fromJson(
-                                inputStream,
-                                Array<EmojiSearchData>::class.java
-                            )
-                        )
-                        emojiSearchDb.get().setSearchIndex(searchIndex)
-                    }
-                } catch (e: IOException) {
-                    Log.e(
-                        "Loki",
-                        "Failed to load emoji search index"
-                    )
-                }
-            }
-        }
-    } // endregion
+     // endregion
 
     companion object {
         const val PREFERENCES_NAME: String = "SecureSMS-Preferences"

--- a/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigUploader.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigUploader.kt
@@ -44,6 +44,7 @@ import org.session.libsignal.utilities.Base64
 import org.session.libsignal.utilities.Log
 import org.session.libsignal.utilities.Snode
 import org.session.libsignal.utilities.retryWithUniformInterval
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import org.thoughtcrime.securesms.util.NetworkConnectivity
 import javax.inject.Inject
 
@@ -66,7 +67,7 @@ class ConfigUploader @Inject constructor(
     private val clock: SnodeClock,
     private val networkConnectivity: NetworkConnectivity,
     private val textSecurePreferences: TextSecurePreferences,
-) {
+) : OnAppStartupComponent {
     private var job: Job? = null
 
     /**
@@ -93,7 +94,7 @@ class ConfigUploader @Inject constructor(
 
 
     @OptIn(DelicateCoroutinesApi::class, FlowPreview::class, ExperimentalCoroutinesApi::class)
-    fun start() {
+    override fun onPostAppStarted() {
         require(job == null) { "Already started" }
 
         job = GlobalScope.launch {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -61,6 +61,7 @@ import org.thoughtcrime.securesms.database.model.MmsMessageRecord;
 import org.thoughtcrime.securesms.database.model.ThreadRecord;
 import org.thoughtcrime.securesms.database.model.content.MessageContent;
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent;
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent;
 import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.mms.SlideDeck;
 import org.thoughtcrime.securesms.notifications.MarkReadReceiver;
@@ -82,7 +83,7 @@ import kotlinx.serialization.json.Json;
 import network.loki.messenger.libsession_util.util.GroupInfo;
 
 @Singleton
-public class ThreadDatabase extends Database {
+public class ThreadDatabase extends Database implements OnAppStartupComponent {
 
   public interface ConversationThreadUpdateListener {
     void threadCreated(@NonNull Address address, long threadId);
@@ -182,9 +183,8 @@ public class ThreadDatabase extends Database {
     this.prefs = prefs;
   }
 
-  // This method is called when the application is created, providing an opportunity to perform
-  // initialization tasks that need to be done only once.
-  public void onAppCreated() {
+  @Override
+  public void onPostAppStarted() {
     if (!prefs.getMigratedDisappearingMessagesToMessageContent()) {
       migrateDisappearingMessagesToMessageContent();
       prefs.setMigratedDisappearingMessagesToMessageContent(true);

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/ConfigFactory.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/ConfigFactory.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import network.loki.messenger.libsession_util.ConfigBase
@@ -75,7 +74,8 @@ class ConfigFactory @Inject constructor(
     private val textSecurePreferences: TextSecurePreferences,
     private val clock: SnodeClock,
     private val configToDatabaseSync: Lazy<ConfigToDatabaseSync>,
-    private val usernameUtils: Lazy<UsernameUtils>
+    private val usernameUtils: Lazy<UsernameUtils>,
+    @ManagerScope private val coroutineScope: CoroutineScope
 ) : ConfigFactoryProtocol {
     companion object {
         // This is a buffer period within which we will process messages which would result in a
@@ -94,8 +94,6 @@ class ConfigFactory @Inject constructor(
 
     private val userConfigs = HashMap<AccountId, Pair<ReentrantReadWriteLock, UserConfigsImpl>>()
     private val groupConfigs = HashMap<AccountId, Pair<ReentrantReadWriteLock, GroupConfigsImpl>>()
-
-    private val coroutineScope: CoroutineScope = GlobalScope
 
     private val _configUpdateNotifications = MutableSharedFlow<ConfigUpdateNotification>()
     override val configUpdateNotifications get() = _configUpdateNotifications

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/OnAppStartupComponent.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/OnAppStartupComponent.kt
@@ -1,0 +1,11 @@
+package org.thoughtcrime.securesms.dependencies
+
+/**
+ * An interface for components that need to be initialized, or get notified when the app starts.
+ *
+ * After implementing this interface, you need to add this component into [OnAppStartupComponents]
+ */
+interface OnAppStartupComponent {
+    fun onPostAppStarted() {
+    }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/OnAppStartupComponents.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/OnAppStartupComponents.kt
@@ -1,0 +1,95 @@
+package org.thoughtcrime.securesms.dependencies
+
+import org.session.libsession.messaging.sending_receiving.pollers.OpenGroupPollerManager
+import org.session.libsession.messaging.sending_receiving.pollers.PollerManager
+import org.session.libsession.snode.SnodeClock
+import org.thoughtcrime.securesms.configs.ConfigUploader
+import org.thoughtcrime.securesms.database.ThreadDatabase
+import org.thoughtcrime.securesms.disguise.AppDisguiseManager
+import org.thoughtcrime.securesms.emoji.EmojiIndexLoader
+import org.thoughtcrime.securesms.groups.ExpiredGroupManager
+import org.thoughtcrime.securesms.groups.GroupPollerManager
+import org.thoughtcrime.securesms.groups.handler.AdminStateSync
+import org.thoughtcrime.securesms.groups.handler.CleanupInvitationHandler
+import org.thoughtcrime.securesms.groups.handler.DestroyedGroupSync
+import org.thoughtcrime.securesms.groups.handler.RemoveGroupMemberHandler
+import org.thoughtcrime.securesms.logging.PersistentLogger
+import org.thoughtcrime.securesms.migration.DatabaseMigrationManager
+import org.thoughtcrime.securesms.notifications.BackgroundPollManager
+import org.thoughtcrime.securesms.notifications.FirebaseTokenFetcher
+import org.thoughtcrime.securesms.notifications.PushRegistrationHandler
+import org.thoughtcrime.securesms.pro.ProStatusManager
+import org.thoughtcrime.securesms.service.ExpiringMessageManager
+import org.thoughtcrime.securesms.tokenpage.TokenDataManager
+import org.thoughtcrime.securesms.util.AppVisibilityManager
+import org.thoughtcrime.securesms.util.CurrentActivityObserver
+import org.thoughtcrime.securesms.util.VersionDataFetcher
+import org.thoughtcrime.securesms.webrtc.CallMessageProcessor
+import org.thoughtcrime.securesms.webrtc.WebRtcCallBridge
+import javax.inject.Inject
+
+class OnAppStartupComponents private constructor(
+    private val components: List<OnAppStartupComponent>
+) {
+    fun onPostAppStarted() {
+        components.forEach { it.onPostAppStarted() }
+    }
+
+    @Inject constructor(
+        configUploader: ConfigUploader,
+        snodeClock: SnodeClock,
+        backgroundPollManager: BackgroundPollManager,
+        appVisibilityManager: AppVisibilityManager,
+        groupPollerManager: GroupPollerManager,
+        expiredGroupManager: ExpiredGroupManager,
+        openGroupPollerManager: OpenGroupPollerManager,
+        databaseMigrationManager: DatabaseMigrationManager,
+        tokenManager: TokenDataManager,
+        expiringMessageManager: ExpiringMessageManager,
+        currentActivityObserver: CurrentActivityObserver,
+        webRtcCallBridge: WebRtcCallBridge,
+        cleanupInvitationHandler: CleanupInvitationHandler,
+        pollerManager: PollerManager,
+        proStatusManager: ProStatusManager,
+        persistentLogger: PersistentLogger,
+        appDisguiseManager: AppDisguiseManager,
+        removeGroupMemberHandler: RemoveGroupMemberHandler,
+        destroyedGroupSync: DestroyedGroupSync,
+        adminStateSync: AdminStateSync,
+        callMessageProcessor: CallMessageProcessor,
+        pushRegistrationHandler: PushRegistrationHandler,
+        tokenFetcher: FirebaseTokenFetcher,
+        versionDataFetcher: VersionDataFetcher,
+        threadDatabase: ThreadDatabase,
+        emojiIndexLoader: EmojiIndexLoader,
+    ): this(
+        components = listOf(
+            configUploader,
+            snodeClock,
+            backgroundPollManager,
+            appVisibilityManager,
+            groupPollerManager,
+            expiredGroupManager,
+            openGroupPollerManager,
+            databaseMigrationManager,
+            tokenManager,
+            expiringMessageManager,
+            currentActivityObserver,
+            webRtcCallBridge,
+            cleanupInvitationHandler,
+            pollerManager,
+            proStatusManager,
+            persistentLogger,
+            appDisguiseManager,
+            removeGroupMemberHandler,
+            destroyedGroupSync,
+            adminStateSync,
+            callMessageProcessor,
+            pushRegistrationHandler,
+            tokenFetcher,
+            versionDataFetcher,
+            threadDatabase,
+            emojiIndexLoader,
+        )
+    )
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/SessionUtilModule.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/SessionUtilModule.kt
@@ -11,8 +11,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import org.session.libsession.messaging.groups.GroupScope
-import org.session.libsession.messaging.groups.LegacyGroupDeprecationManager
-import org.session.libsession.snode.SnodeClock
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsession.utilities.UsernameUtils
 import org.thoughtcrime.securesms.database.SessionContactDatabase
@@ -38,18 +36,8 @@ object SessionUtilModule {
 
     @Provides
     @Singleton
-    fun provideSnodeClock() = SnodeClock()
-
-    @Provides
-    @Singleton
     fun provideGroupScope() = GroupScope()
 
-
-    @Provides
-    @Singleton
-    fun provideLegacyGroupDeprecationManager(prefs: TextSecurePreferences): LegacyGroupDeprecationManager {
-        return LegacyGroupDeprecationManager(prefs)
-    }
 
     @Provides
     @Singleton

--- a/app/src/main/java/org/thoughtcrime/securesms/disguise/AppDisguiseManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/disguise/AppDisguiseManager.kt
@@ -1,21 +1,15 @@
 package org.thoughtcrime.securesms.disguise
 
-import android.app.Activity
 import android.app.Application
-import android.app.Application.ActivityLifecycleCallbacks
 import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.os.Bundle
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -32,6 +26,7 @@ import network.loki.messenger.R
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import org.thoughtcrime.securesms.util.CurrentActivityObserver
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -46,7 +41,7 @@ class AppDisguiseManager @Inject constructor(
     private val prefs: TextSecurePreferences,
     private val currentActivityObserver: CurrentActivityObserver,
     @param:ManagerScope private val scope: CoroutineScope,
-) {
+) : OnAppStartupComponent {
     val allAppAliases: Flow<List<AppAlias>> = flow {
         emit(
             application.packageManager

--- a/app/src/main/java/org/thoughtcrime/securesms/emoji/EmojiIndexLoader.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/emoji/EmojiIndexLoader.kt
@@ -1,0 +1,43 @@
+package org.thoughtcrime.securesms.emoji
+
+import android.app.Application
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.session.libsignal.utilities.JsonUtil
+import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.database.EmojiSearchDatabase
+import org.thoughtcrime.securesms.database.model.EmojiSearchData
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
+import java.io.IOException
+import javax.inject.Inject
+
+class EmojiIndexLoader @Inject constructor(
+    private val application: Application,
+    private val emojiSearchDb: EmojiSearchDatabase,
+    @param:ManagerScope private val scope: CoroutineScope,
+) : OnAppStartupComponent {
+    override fun onPostAppStarted() {
+        scope.launch {
+            if (emojiSearchDb.query("face", 1).isEmpty()) {
+                try {
+                    application.assets.open("emoji/emoji_search_index.json").use { inputStream ->
+                        val searchIndex = listOf(
+                            *JsonUtil.fromJson(
+                                inputStream,
+                                Array<EmojiSearchData>::class.java
+                            )
+                        )
+                        emojiSearchDb.setSearchIndex(searchIndex)
+                    }
+                } catch (e: IOException) {
+                    Log.e(
+                        "EmojiIndexLoader",
+                        "Failed to load emoji search index",
+                        e
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/ExpiredGroupManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/ExpiredGroupManager.kt
@@ -1,6 +1,6 @@
 package org.thoughtcrime.securesms.groups
 
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.mapNotNull
@@ -8,6 +8,8 @@ import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
 import org.session.libsignal.utilities.AccountId
 import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,7 +24,8 @@ import javax.inject.Singleton
 @Singleton
 class ExpiredGroupManager @Inject constructor(
     pollerManager: GroupPollerManager,
-) {
+    @ManagerScope scope: CoroutineScope
+) : OnAppStartupComponent {
     @Suppress("OPT_IN_USAGE")
     val expiredGroups: StateFlow<Set<AccountId>> = pollerManager.watchAllGroupPollingState()
         .mapNotNull { (groupId, state) ->
@@ -52,5 +55,5 @@ class ExpiredGroupManager @Inject constructor(
             }
         }
 
-        .stateIn(GlobalScope, SharingStarted.Eagerly, emptySet())
+        .stateIn(scope, SharingStarted.Eagerly, emptySet())
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupPollerManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupPollerManager.kt
@@ -29,6 +29,7 @@ import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.utilities.AccountId
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.dependencies.ConfigFactory
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import org.thoughtcrime.securesms.util.NetworkConnectivity
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -52,7 +53,7 @@ class GroupPollerManager @Inject constructor(
     preferences: TextSecurePreferences,
     connectivity: NetworkConnectivity,
     pollFactory: GroupPoller.Factory,
-) {
+) : OnAppStartupComponent {
     @Suppress("OPT_IN_USAGE")
     private val groupPollers: StateFlow<Map<AccountId, GroupPollerHandle>> =
         combine(

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/handler/AdminStateSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/handler/AdminStateSync.kt
@@ -1,6 +1,6 @@
 package org.thoughtcrime.securesms.groups.handler
 
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
@@ -10,6 +10,8 @@ import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsession.utilities.ConfigUpdateNotification
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.utilities.AccountId
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import java.util.EnumSet
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -25,13 +27,14 @@ import javax.inject.Singleton
 class AdminStateSync @Inject constructor(
     private val configFactory: ConfigFactoryProtocol,
     private val preferences: TextSecurePreferences,
-) {
+    @param:ManagerScope private val scope: CoroutineScope
+) : OnAppStartupComponent {
     private var job: Job? = null
 
-    fun start() {
+    override fun onPostAppStarted() {
         require(job == null) { "Already started" }
 
-        job = GlobalScope.launch {
+        job = scope.launch {
             configFactory.configUpdateNotifications
                 .filter { it is ConfigUpdateNotification.UserConfigsMerged || it == ConfigUpdateNotification.UserConfigsModified }
                 .collect {

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/handler/CleanupInvitationHandler.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/handler/CleanupInvitationHandler.kt
@@ -1,6 +1,6 @@
 package org.thoughtcrime.securesms.groups.handler
 
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import network.loki.messenger.libsession_util.allWithStatus
@@ -9,6 +9,8 @@ import org.session.libsession.messaging.groups.GroupScope
 import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.utilities.AccountId
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
 
 /**
@@ -23,10 +25,11 @@ import javax.inject.Inject
 class CleanupInvitationHandler @Inject constructor(
     private val prefs: TextSecurePreferences,
     private val configFactory: ConfigFactoryProtocol,
-    private val groupScope: GroupScope
-) {
-    fun start() {
-        GlobalScope.launch {
+    private val groupScope: GroupScope,
+    @param:ManagerScope private val scope: CoroutineScope
+) : OnAppStartupComponent {
+    override fun onPostAppStarted() {
+        scope.launch {
             // Wait for the local number to be available
             prefs.watchLocalNumber().first { it != null }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/handler/DestroyedGroupSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/handler/DestroyedGroupSync.kt
@@ -1,17 +1,19 @@
 package org.thoughtcrime.securesms.groups.handler
 
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
 import org.session.libsession.database.StorageProtocol
+import org.session.libsession.messaging.groups.GroupScope
 import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsession.utilities.ConfigUpdateNotification
 import org.session.libsession.utilities.waitUntilGroupConfigsPushed
 import org.session.libsignal.utilities.Log
-import org.session.libsession.messaging.groups.GroupScope
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -24,13 +26,14 @@ class DestroyedGroupSync @Inject constructor(
     private val configFactory: ConfigFactoryProtocol,
     private val groupScope: GroupScope,
     private val storage: StorageProtocol,
-) {
+    @param:ManagerScope private val scope: CoroutineScope
+) : OnAppStartupComponent {
     private var job: Job? = null
 
-    fun start() {
+    override fun onPostAppStarted() {
         require(job == null) { "Already started" }
 
-        job = GlobalScope.launch {
+        job = scope.launch {
             configFactory.configUpdateNotifications
                 .filterIsInstance<ConfigUpdateNotification.GroupConfigsUpdated>()
                 .filter { it.fromMerge }

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/handler/RemoveGroupMemberHandler.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/handler/RemoveGroupMemberHandler.kt
@@ -3,9 +3,9 @@ package org.thoughtcrime.securesms.groups.handler
 import android.content.Context
 import com.google.protobuf.ByteString
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flatMapLatest
@@ -19,6 +19,7 @@ import network.loki.messenger.libsession_util.util.GroupMember
 import network.loki.messenger.libsession_util.util.MultiEncrypt
 import org.session.libsession.database.MessageDataProvider
 import org.session.libsession.database.StorageProtocol
+import org.session.libsession.messaging.groups.GroupScope
 import org.session.libsession.messaging.messages.Destination
 import org.session.libsession.messaging.messages.control.GroupUpdated
 import org.session.libsession.messaging.sending_receiving.MessageSender
@@ -38,7 +39,8 @@ import org.session.libsignal.protos.SignalServiceProtos
 import org.session.libsignal.utilities.AccountId
 import org.session.libsignal.utilities.Base64
 import org.session.libsignal.utilities.Log
-import org.session.libsession.messaging.groups.GroupScope
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -52,16 +54,17 @@ private const val TAG = "RemoveGroupMemberHandler"
 @OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
 @Singleton
 class RemoveGroupMemberHandler @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val configFactory: ConfigFactoryProtocol,
     private val textSecurePreferences: TextSecurePreferences,
     private val clock: SnodeClock,
     private val messageDataProvider: MessageDataProvider,
     private val storage: StorageProtocol,
     private val groupScope: GroupScope,
-) {
+    @ManagerScope scope: CoroutineScope,
+) : OnAppStartupComponent {
     init {
-        GlobalScope.launch {
+        scope.launch {
             textSecurePreferences
                 .watchLocalNumber()
                 .flatMapLatest { localNumber ->

--- a/app/src/main/java/org/thoughtcrime/securesms/logging/PersistentLogger.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/logging/PersistentLogger.kt
@@ -3,7 +3,7 @@ package org.thoughtcrime.securesms.logging
 import android.content.Context
 import android.net.Uri
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.SendChannel
@@ -13,8 +13,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import org.session.libsignal.utilities.Log.Logger
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import java.io.File
-import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.regex.Pattern
@@ -29,8 +30,9 @@ import kotlin.time.Duration.Companion.milliseconds
  */
 @Singleton
 class PersistentLogger @Inject constructor(
-    @param:ApplicationContext private val context: Context
-) : Logger() {
+    @param:ApplicationContext private val context: Context,
+    @ManagerScope scope: CoroutineScope,
+) : Logger(), OnAppStartupComponent {
     private val freeLogEntryPool = LogEntryPool()
     private val logEntryChannel: SendChannel<LogEntry>
     private val logChannelIdleSignal = MutableSharedFlow<Unit>()
@@ -51,7 +53,7 @@ class PersistentLogger @Inject constructor(
         val channel = Channel<LogEntry>(capacity = MAX_PENDING_LOG_ENTRIES)
         logEntryChannel = channel
 
-        GlobalScope.launch {
+        scope.launch {
             val bulk = ArrayList<LogEntry>()
             var logWriter: LogFile.Writer? = null
             val entryBuilder = StringBuilder()

--- a/app/src/main/java/org/thoughtcrime/securesms/migration/DatabaseMigrationManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/migration/DatabaseMigrationManager.kt
@@ -5,7 +5,6 @@ import android.os.SystemClock
 import androidx.annotation.StringRes
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -19,6 +18,8 @@ import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.crypto.DatabaseSecretProvider
 import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -27,9 +28,8 @@ class DatabaseMigrationManager @Inject constructor(
     private val application: Application,
     private val prefs: TextSecurePreferences,
     private val databaseSecretProvider: DatabaseSecretProvider,
-) {
-    private val scope: CoroutineScope = GlobalScope
-
+    @param:ManagerScope private val scope: CoroutineScope,
+) : OnAppStartupComponent {
     private val dbSecret by lazy {
         databaseSecretProvider.getOrCreateDatabaseSecret()
     }
@@ -235,6 +235,10 @@ class DatabaseMigrationManager @Inject constructor(
 
         val action: (fromRetry: Boolean) -> Unit,
     )
+
+    override fun onPostAppStarted() {
+        requestMigration(fromRetry = false)
+    }
 
     data class ProgressStep(
         val title: String,

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/BackgroundPollManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/BackgroundPollManager.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import org.thoughtcrime.securesms.util.AppVisibilityManager
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -28,7 +29,7 @@ class BackgroundPollManager @Inject constructor(
     application: Application,
     appVisibilityManager: AppVisibilityManager,
     textSecurePreferences: TextSecurePreferences,
-) {
+) : OnAppStartupComponent {
     init {
         @Suppress("OPT_IN_USAGE")
         GlobalScope.launch {

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/PushRegistrationHandler.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/PushRegistrationHandler.kt
@@ -4,16 +4,12 @@ import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.launch
@@ -27,7 +23,10 @@ import org.session.libsignal.utilities.IdPrefix
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.database.Storage
 import org.thoughtcrime.securesms.dependencies.ConfigFactory
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
+import javax.inject.Singleton
 
 private const val TAG = "PushRegistrationHandler"
 
@@ -37,23 +36,23 @@ private const val TAG = "PushRegistrationHandler"
  *
  * This class DOES NOT handle the legacy groups push notification.
  */
+@Singleton
 class PushRegistrationHandler
 @Inject
 constructor(
     private val configFactory: ConfigFactory,
     private val preferences: TextSecurePreferences,
     private val tokenFetcher: TokenFetcher,
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val registry: PushRegistryV2,
     private val storage: Storage,
-) {
-    @OptIn(DelicateCoroutinesApi::class)
-    private val scope: CoroutineScope = GlobalScope
+    @param:ManagerScope private val scope: CoroutineScope
+) : OnAppStartupComponent {
 
     private var job: Job? = null
 
     @OptIn(FlowPreview::class)
-    fun run() {
+    override fun onPostAppStarted() {
         require(job == null) { "Job is already running" }
 
         job = scope.launch(Dispatchers.Default) {

--- a/app/src/main/java/org/thoughtcrime/securesms/pro/ProStatusManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/pro/ProStatusManager.kt
@@ -9,14 +9,14 @@ import org.session.libsession.messaging.messages.visible.VisibleMessage
 import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.TextSecurePreferences
 import org.thoughtcrime.securesms.database.model.MessageId
-import org.thoughtcrime.securesms.util.AnimatedImageUtils
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class ProStatusManager @Inject constructor(
     private val prefs: TextSecurePreferences,
-){
+) : OnAppStartupComponent {
     val MAX_CHARACTER_PRO = 10000 // max characters in a message for pro users
     private val MAX_CHARACTER_REGULAR = 2000 // max characters in a message for non pro users
     private val MAX_PIN_REGULAR = 5 // max pinned conversation for non pro users

--- a/app/src/main/java/org/thoughtcrime/securesms/service/ExpiringMessageManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/ExpiringMessageManager.kt
@@ -3,7 +3,7 @@ package org.thoughtcrime.securesms.service
 import android.content.Context
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -35,6 +35,8 @@ import org.thoughtcrime.securesms.database.SmsDatabase
 import org.thoughtcrime.securesms.database.Storage
 import org.thoughtcrime.securesms.database.model.MessageId
 import org.thoughtcrime.securesms.database.model.content.DisappearingMessageUpdate
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import org.thoughtcrime.securesms.mms.MmsException
 import org.thoughtcrime.securesms.util.observeChanges
 import java.io.IOException
@@ -60,10 +62,11 @@ class ExpiringMessageManager @Inject constructor(
     private val clock: SnodeClock,
     private val storage: Lazy<Storage>,
     private val preferences: TextSecurePreferences,
-) : MessageExpirationManagerProtocol {
+    @ManagerScope scope: CoroutineScope,
+) : MessageExpirationManagerProtocol, OnAppStartupComponent {
 
     init {
-        GlobalScope.launch {
+        scope.launch {
             listOf(
                 launch { processDatabase(smsDatabase) },
                 launch { processDatabase(mmsDatabase) }

--- a/app/src/main/java/org/thoughtcrime/securesms/tokenpage/TokenDataManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/tokenpage/TokenDataManager.kt
@@ -1,7 +1,7 @@
 package org.thoughtcrime.securesms.tokenpage
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -11,14 +11,17 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class TokenDataManager @Inject constructor(
     private val textSecurePreferences: TextSecurePreferences,
-    private val tokenRepository: TokenRepository
-) {
+    private val tokenRepository: TokenRepository,
+    @param:ManagerScope private val scope: CoroutineScope
+) : OnAppStartupComponent {
     private val TAG = "TokenDataManager"
 
     // Cached infoResponse in memory
@@ -34,9 +37,9 @@ class TokenDataManager @Inject constructor(
     // jank when the UI switches to "Loading..." and then near-instantly updates to the given values.
     private val MINIMUM_SERVER_RESPONSE_DELAY_MS = 500L
 
-    fun getTokenDataWhenLoggedIn() {
+    override fun onPostAppStarted() {
         // we want to preload the data as soon as the user is logged in
-        GlobalScope.launch {
+        scope.launch {
             textSecurePreferences.watchLocalNumber()
                 .map { it != null }
                 .distinctUntilChanged()

--- a/app/src/main/java/org/thoughtcrime/securesms/util/AppVisibilityManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/AppVisibilityManager.kt
@@ -3,21 +3,25 @@ package org.thoughtcrime.securesms.util
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class AppVisibilityManager @Inject constructor() {
+class AppVisibilityManager @Inject constructor(
+    @ManagerScope scope: CoroutineScope
+) : OnAppStartupComponent {
     private val mutableIsAppVisible = MutableStateFlow(false)
 
     init {
         // `addObserver` must be called on the main thread.
-        GlobalScope.launch(Dispatchers.Main) {
+        scope.launch(Dispatchers.Main) {
             ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
                 override fun onStart(owner: LifecycleOwner) {
                     mutableIsAppVisible.value = true

--- a/app/src/main/java/org/thoughtcrime/securesms/util/CurrentActivityObserver.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/CurrentActivityObserver.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,7 +17,7 @@ import javax.inject.Singleton
 @Singleton
 class CurrentActivityObserver @Inject constructor(
     application: Application
-) {
+) : OnAppStartupComponent {
     private val _currentActivity = MutableStateFlow<Activity?>(null)
 
     val currentActivity: StateFlow<Activity?> get() = _currentActivity

--- a/app/src/main/java/org/thoughtcrime/securesms/util/VersionDataFetcher.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/VersionDataFetcher.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.launch
 import org.session.libsession.messaging.file_server.FileServerApi
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.hours
@@ -18,7 +19,7 @@ private val REFRESH_TIME_MS = 4.hours.inWholeMilliseconds
 @Singleton
 class VersionDataFetcher @Inject constructor(
     private val prefs: TextSecurePreferences
-) {
+) : OnAppStartupComponent {
     private val handler = Handler(Looper.getMainLooper())
     private val fetchVersionData = Runnable {
         scope.launch {
@@ -56,5 +57,9 @@ class VersionDataFetcher @Inject constructor(
 
     fun stopTimedVersionCheck() {
         handler.removeCallbacks(fetchVersionData)
+    }
+
+    override fun onPostAppStarted() {
+        startTimedVersionCheck()
     }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/webrtc/CallMessageProcessor.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/webrtc/CallMessageProcessor.kt
@@ -3,8 +3,8 @@ package org.thoughtcrime.securesms.webrtc
 import android.Manifest
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.session.libsession.database.StorageProtocol
@@ -22,6 +22,8 @@ import org.session.libsignal.protos.SignalServiceProtos.CallMessage.Type.OFFER
 import org.session.libsignal.protos.SignalServiceProtos.CallMessage.Type.PRE_OFFER
 import org.session.libsignal.protos.SignalServiceProtos.CallMessage.Type.PROVISIONAL_ANSWER
 import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import org.thoughtcrime.securesms.permissions.Permissions
 import org.webrtc.IceCandidate
 import javax.inject.Inject
@@ -29,11 +31,12 @@ import javax.inject.Singleton
 
 @Singleton
 class CallMessageProcessor @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val textSecurePreferences: TextSecurePreferences,
     private val storage: StorageProtocol,
-    private val webRtcBridge: WebRtcCallBridge
-) {
+    private val webRtcBridge: WebRtcCallBridge,
+    @ManagerScope scope: CoroutineScope
+) : OnAppStartupComponent {
 
     companion object {
         private const val TAG = "CallMessageProcessor"
@@ -41,7 +44,7 @@ class CallMessageProcessor @Inject constructor(
     }
 
     init {
-        GlobalScope.launch(IO) {
+        scope.launch(IO) {
             while (isActive) {
                 val nextMessage = WebRtcUtils.SIGNAL_QUEUE.receive()
                 Log.d("Loki", nextMessage.type?.name ?: "CALL MESSAGE RECEIVED")

--- a/app/src/main/java/org/thoughtcrime/securesms/webrtc/WebRtcCallBridge.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/webrtc/WebRtcCallBridge.kt
@@ -7,23 +7,23 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.media.AudioManager
-import android.widget.Toast
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import network.loki.messenger.BuildConfig
 import org.session.libsession.messaging.calls.CallMessageType
 import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.FutureTaskListener
 import org.session.libsession.utilities.recipients.Recipient
 import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import org.thoughtcrime.securesms.notifications.BackgroundPollWorker
 import org.thoughtcrime.securesms.service.CallForegroundService
 import org.thoughtcrime.securesms.util.NetworkConnectivity
@@ -61,10 +61,11 @@ import org.thoughtcrime.securesms.webrtc.data.State as CallState
  */
 @Singleton
 class WebRtcCallBridge @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val callManager: CallManager,
-    private val networkConnectivity: NetworkConnectivity
-): CallManager.WebRtcListener  {
+    private val networkConnectivity: NetworkConnectivity,
+    @ManagerScope scope: CoroutineScope,
+): CallManager.WebRtcListener, OnAppStartupComponent  {
 
     companion object {
 
@@ -103,7 +104,7 @@ class WebRtcCallBridge @Inject constructor(
         isNetworkAvailable = true
         registerWiredHeadsetStateReceiver()
 
-        GlobalScope.launch {
+        scope.launch {
             networkConnectivity.networkAvailable.collectLatest(::networkChange)
         }
     }


### PR DESCRIPTION
This PR introduces two new classes: `OnAppStartupComponent`, and `OnAppStartupComponents`, to support an organised way to initialize components on app startup.

This is to clean up the clutters in the `ApplicationContext` class.

Also contains some misc cleanup.
