### PR TITLE
SES-4269 : Inconsistent Separator Length Theming

### DIFF
--- a/app/src/main/res/layout/activity_appearance_settings.xml
+++ b/app/src/main/res/layout/activity_appearance_settings.xml
@@ -67,6 +67,7 @@
 
                 <View
                     android:alpha="0.15"
+                    android:layout_marginHorizontal="@dimen/medium_spacing"
                     android:layout_width="match_parent"
                     android:layout_height="1dp"
                     android:background="?android:textColorPrimary"/>


### PR DESCRIPTION
Added missing horizontal margin for Classic Dark's divider in Appearance screen

<img width="406" height="224" alt="image" src="https://github.com/user-attachments/assets/e60f5b23-19c9-4575-95cb-18db20c49c23" />
