### PR TITLE
SES-4379 : A 1-1 with a mention doesn't show the @ icon

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/home/ConversationView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/ConversationView.kt
@@ -79,7 +79,7 @@ class ConversationView : LinearLayout {
         binding.unreadCountTextView.text = UnreadStylingHelper.formatUnreadCount(unreadCount)
 
         binding.unreadCountIndicator.isVisible = hasUnreadCount
-        binding.unreadMentionIndicator.isVisible = (thread.unreadMentionCount != 0 && thread.recipient.address.isGroupOrCommunity)
+        binding.unreadMentionIndicator.isVisible = thread.unreadMentionCount != 0
         binding.markedUnreadIndicator.isVisible = isMarkedUnread
 
         val senderDisplayName = getTitle(thread.recipient)


### PR DESCRIPTION
This PR removes the condition of only showing the mention indicator (@) only for Groups or Communities.