### PR TITLE
Fix message view scrolling issues

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -403,11 +403,6 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
             lifecycleCoroutineScope = lifecycleScope
         )
         adapter.visibleMessageViewDelegate = this
-
-        // Register an AdapterDataObserver to scroll us to the bottom of the RecyclerView for if
-        // we're already near the the bottom and the data changes.
-        adapter.registerAdapterDataObserver(ConversationAdapterDataObserver(binding.conversationRecyclerView, adapter))
-
         adapter
     }
 
@@ -816,6 +811,12 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
                                 }
                             }
                         }
+                    }
+                } else {
+                    // If there are new data updated, we'll try to stay scrolled at the bottom (if we were at the bottom).
+                    // scrolled to bottom has a leniency of 50dp, so if we are within the 50dp but not fully at the bottom, scroll down
+                    if (binding.conversationRecyclerView.isNearBottom && !binding.conversationRecyclerView.isFullyScrolled) {
+                        binding.conversationRecyclerView.smoothScrollToPosition(adapter.itemCount)
                     }
                 }
 
@@ -2722,7 +2723,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
 
     private fun moveToMessagePosition(position: Int, highlight: Boolean, onMessageNotFound: Runnable?) {
         if (position >= 0) {
-            binding.conversationRecyclerView.scrollToPosition(position)
+            binding.conversationRecyclerView.smoothScrollToPosition(position)
 
             if (highlight) {
                 runOnUiThread {
@@ -2754,17 +2755,4 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
             }
         }
     }
-
-    // AdapterDataObserver implementation to scroll us to the bottom of the ConversationRecyclerView
-    // when we're already near the bottom and we send or receive a message.
-    inner class ConversationAdapterDataObserver(val recyclerView: ConversationRecyclerView, val adapter: ConversationAdapter) : RecyclerView.AdapterDataObserver() {
-        override fun onChanged() {
-            super.onChanged()
-            // scrolled to bottom has a leniency of 50dp, so if we are within the 50dp but not fully at the bottom, scroll down
-            if (recyclerView.isNearBottom && !recyclerView.isFullyScrolled) {
-                recyclerView.smoothScrollToPosition(adapter.itemCount)
-            }
-        }
-    }
-
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/GeneralUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/GeneralUtilities.kt
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.util
 
 import android.content.res.Resources
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlin.math.roundToInt
 
@@ -32,17 +33,6 @@ val RecyclerView.isNearBottom: Boolean
 
 val RecyclerView.isFullyScrolled: Boolean
     get() {
-        return scrollAmount == 0
+        return (layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition() ==
+                adapter!!.itemCount - 1
     }
-
-val RecyclerView.scrollAmount: Int
-    get() {
-        val scrollOffset = computeVerticalScrollOffset().coerceAtLeast(0)
-        val scrollExtent = computeVerticalScrollExtent()
-        val scrollRange = computeVerticalScrollRange()
-
-
-        // We're at the bottom if the offset + extent equals the range
-        return scrollOffset + scrollExtent - scrollRange
-    }
-


### PR DESCRIPTION
Basically make sure that:

1. When you receive a new message while you stayed at the bottom, stay scrolled to the bottom.
2. When opening the app, there shouldn't be any overscroll jumping
