### PR TITLE
Wrong string for message details

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
@@ -402,8 +402,8 @@ fun MessageProFeatures(
                 padding = PaddingValues(),
                 data = CTAFeature.Icon(
                     text = when(it){
-                        ProStatusManager.MessageProFeature.ProBadge -> Phrase.from(LocalContext.current, R.string.proBadge)
-                            .put(APP_PRO_KEY, NonTranslatableStringConstants.PRO)
+                        ProStatusManager.MessageProFeature.ProBadge -> Phrase.from(LocalContext.current, R.string.appProBadge)
+                            .put(APP_PRO_KEY, NonTranslatableStringConstants.APP_PRO)
                             .format()
                             .toString()
                         ProStatusManager.MessageProFeature.LongMessage -> stringResource(id = R.string.proIncreasedMessageLengthFeature)


### PR DESCRIPTION
Quick fix to use the correct string in the message details