### PR TITLE
Avatar cleanup

### DIFF
--- a/app/src/main/java/org/session/libsession/avatars/AvatarCacheCleaner.kt
+++ b/app/src/main/java/org/session/libsession/avatars/AvatarCacheCleaner.kt
@@ -6,9 +6,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.recipients.RemoteFile
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.attachments.RemoteFileDownloadWorker
+import org.thoughtcrime.securesms.database.MmsSmsDatabase
+import org.thoughtcrime.securesms.database.RecipientSettingsDatabase
 import org.thoughtcrime.securesms.dependencies.ManagerScope
 import org.thoughtcrime.securesms.glide.RecipientAvatarDownloadManager
 import java.io.File
@@ -18,7 +21,9 @@ import javax.inject.Singleton
 @Singleton
 class AvatarCacheCleaner @Inject constructor(
     private val application: Application,
-    private val avatarDownloadManager: RecipientAvatarDownloadManager, // we can reuse some logic here
+    private val recipientAvatarDownloadManager: RecipientAvatarDownloadManager,
+    private val recipientSettingsDatabase: RecipientSettingsDatabase,
+    private val mmsSmsDatabase: MmsSmsDatabase,
     @param:ManagerScope private val coroutineScope: CoroutineScope
 ) {
 
@@ -31,25 +36,43 @@ class AvatarCacheCleaner @Inject constructor(
      * in the current config. Returns number of files deleted.
      */
     suspend fun cleanUpAvatars(): Int = withContext(Dispatchers.IO) {
-        // 1) Build the set of still-wanted RemoteFiles (contacts + groups)
-        val wantedRemotes: Set<RemoteFile> = avatarDownloadManager.getAllAvatars()
+        // 1) Build the set of still-wanted Avatars from:
+        // -> Config
+        // -> RecipientSettingsDatabase
 
-        // 2) Map to actual files (same hashing/location as downloader)
-        val wantedFiles: Set<File> = wantedRemotes
+        // config
+        val avatarsFromConfig: Set<RemoteFile> = recipientAvatarDownloadManager.getAllAvatars()
+        // recipient_settings
+        val recipientAvatars : Map<Address, RemoteFile> = recipientSettingsDatabase.getAllReferencedAvatarFiles()
+        // mms and sms used to check for active references
+        val localActiveAddresses : Set<Address> = mmsSmsDatabase.getAllReferencedAddresses()
+        .mapTo(mutableSetOf()) { Address.fromSerialized(it) }
+
+        // 2) Keep only those recipient avatars whose address exists in a community/group
+        // Filter here since we don't delete rows from recipient_settings
+        val keepFromRecipients: Set<RemoteFile> =
+            recipientAvatars
+                .asSequence()
+                .filter { (address, _) -> address in localActiveAddresses }
+                .map { it.value }
+                .toSet()
+
+        // 3) Union of everything we want to keep
+        val filesToKeep: Set<RemoteFile> =
+            (avatarsFromConfig + keepFromRecipients).toSet()
+
+        // 4) Map to actual files (same hashing/location as downloader)
+        val wantedFiles: Set<File> = filesToKeep
             .map { RemoteFileDownloadWorker.computeFileName(application, it) }
             .toSet()
 
-        // 3) Delete everything not wanted in cache/remote_files
+        // 5) Delete everything not wanted in cache/remote_files
         val dir = File(application.cacheDir, "remote_files")
         val files = dir.listFiles().orEmpty()
         var deleted = 0
         for (file in files) {
             if (file !in wantedFiles && file.delete()) deleted++
         }
-
-        // 4) Clear Glide cache. Might need this now but we should remove after we fully migrate to Coil
-        // Note to keep this off the main thread
-        Glide.get(application).clearDiskCache()
 
         deleted
     }

--- a/app/src/main/java/org/session/libsession/avatars/AvatarCacheCleaner.kt
+++ b/app/src/main/java/org/session/libsession/avatars/AvatarCacheCleaner.kt
@@ -1,0 +1,66 @@
+package org.session.libsession.avatars
+
+import android.app.Application
+import com.bumptech.glide.Glide
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.session.libsession.utilities.recipients.RemoteFile
+import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.attachments.RemoteFileDownloadWorker
+import org.thoughtcrime.securesms.dependencies.ManagerScope
+import org.thoughtcrime.securesms.glide.RecipientAvatarDownloadManager
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AvatarCacheCleaner @Inject constructor(
+    private val application: Application,
+    private val avatarDownloadManager: RecipientAvatarDownloadManager, // we can reuse some logic here
+    @param:ManagerScope private val coroutineScope: CoroutineScope
+) {
+
+    companion object {
+        const val TAG = "AvatarCacheCleaner"
+    }
+
+    /**
+     * Deletes avatar files under cache/remote_files that are no longer referenced
+     * in the current config. Returns number of files deleted.
+     */
+    suspend fun cleanUpAvatars(): Int = withContext(Dispatchers.IO) {
+        // 1) Build the set of still-wanted RemoteFiles (contacts + groups)
+        val wantedRemotes: Set<RemoteFile> = avatarDownloadManager.getAllAvatars()
+
+        // 2) Map to actual files (same hashing/location as downloader)
+        val wantedFiles: Set<File> = wantedRemotes
+            .map { RemoteFileDownloadWorker.computeFileName(application, it) }
+            .toSet()
+
+        // 3) Delete everything not wanted in cache/remote_files
+        val dir = File(application.cacheDir, "remote_files")
+        val files = dir.listFiles().orEmpty()
+        var deleted = 0
+        for (f in files) {
+            if (f !in wantedFiles && f.delete()) deleted++
+        }
+
+        // 4) Clear Glide cache. Might need this now but we should remove after we fully migrate to Coil
+        // Note to keep this off the main thread
+        Glide.get(application).clearDiskCache()
+
+        deleted
+    }
+
+    fun launchAvatarCleanup(cancelInFlight: Boolean = false) {
+        coroutineScope.launch(Dispatchers.IO) {
+            if (cancelInFlight) {
+                RemoteFileDownloadWorker.cancelAll(application)
+            }
+            val deleted = cleanUpAvatars()
+            Log.d(TAG, "Avatar cache removed: $deleted files")
+        }
+    }
+}

--- a/app/src/main/java/org/session/libsession/avatars/AvatarCacheCleaner.kt
+++ b/app/src/main/java/org/session/libsession/avatars/AvatarCacheCleaner.kt
@@ -43,8 +43,8 @@ class AvatarCacheCleaner @Inject constructor(
         val dir = File(application.cacheDir, "remote_files")
         val files = dir.listFiles().orEmpty()
         var deleted = 0
-        for (f in files) {
-            if (f !in wantedFiles && f.delete()) deleted++
+        for (file in files) {
+            if (file !in wantedFiles && file.delete()) deleted++
         }
 
         // 4) Clear Glide cache. Might need this now but we should remove after we fully migrate to Coil

--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -449,6 +449,22 @@ public class MmsSmsDatabase extends Database {
     return queryTables(PROJECTION, selection, order, null);
   }
 
+  public Set<String> getAllReferencedAddresses() {
+    final String[] projection = new String[] { "DISTINCT " + MmsSmsColumns.ADDRESS };
+    final String selection =
+            "NOT " + MmsSmsColumns.IS_DELETED +
+                    " AND " + MmsSmsColumns.ADDRESS + " IS NOT NULL" +
+                    " AND " + MmsSmsColumns.ADDRESS + " != ''";
+
+    Set<String> out = new HashSet<>();
+    try (Cursor cursor = queryTables(projection, selection, null, null)) {
+      while (cursor != null && cursor.moveToNext()) {
+        out.add(cursor.getString(0));
+      }
+    }
+    return out;
+  }
+
   /** Builds the comma-separated list of base types that represent
    *  *outgoing* messages (same helper as before). */
   private String buildOutgoingTypesList() {


### PR DESCRIPTION
Relates to [SES-4387](https://optf.atlassian.net/browse/SES-4387)

Add an avatar cleanup function that checks all references using the existing function `getAllAvatars()`.

Currently only cleans up files after leaving the group.