### PR TITLE
Fix/ses 4464 reply

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
@@ -384,7 +384,7 @@ data class MessageDetailsState(
     val proBadgeClickable: Boolean = false,
 ) {
     val fromTitle = GetString(R.string.from)
-    val canReply: Boolean get() = !readOnly && record?.isOpenGroupInvitation != true
+    val canReply: Boolean get() = !readOnly && record?.isOpenGroupInvitation != true && error == null
     val canDelete: Boolean get() = !readOnly
 }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsScreen.kt
@@ -201,7 +201,6 @@ fun ConversationSettings(
                 Text(
                     modifier = Modifier
                         .qaTag(R.string.qa_conversation_settings_account_id)
-                        .safeContentWidth()
                         .pointerInput(Unit) {
                             detectTapGestures(
                                 onLongPress = { onLongPress() }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/settings/ConversationSettingsScreen.kt
@@ -215,7 +215,7 @@ fun ConversationSettings(
                         },
                     text = data.displayAccountId,
                     textAlign = TextAlign.Center,
-                    style = LocalType.current.base.monospace(),
+                    style = LocalType.current.xl.monospace(),
                     color = LocalColors.current.text
                 )
             }


### PR DESCRIPTION
[SES-4464](https://optf.atlassian.net/browse/SES-4464) - Hide the reply button when the message isn't successfully sent in the Message Details screen