### PR TITLE
Refactor community room info polling

### DIFF
--- a/app/src/main/java/org/session/libsession/database/StorageProtocol.kt
+++ b/app/src/main/java/org/session/libsession/database/StorageProtocol.kt
@@ -14,7 +14,6 @@ import org.session.libsession.messaging.messages.visible.Attachment
 import org.session.libsession.messaging.messages.visible.Profile
 import org.session.libsession.messaging.messages.visible.Reaction
 import org.session.libsession.messaging.messages.visible.VisibleMessage
-import org.session.libsession.messaging.open_groups.OpenGroup
 import org.session.libsession.messaging.sending_receiving.attachments.AttachmentId
 import org.session.libsession.messaging.sending_receiving.attachments.DatabaseAttachment
 import org.session.libsession.messaging.sending_receiving.data_extraction.DataExtractionNotificationInfoMessage
@@ -67,12 +66,8 @@ interface StorageProtocol {
     fun getServerCapabilities(server: String): List<String>?
 
     // Open Groups
-    fun getAllOpenGroups(): Map<Long, OpenGroup>
-    fun getOpenGroup(threadId: Long): OpenGroup?
-    fun getOpenGroup(address: Address): OpenGroup?
     suspend fun addOpenGroup(urlAsString: String)
     fun setOpenGroupServerMessageID(messageID: MessageId, serverID: Long, threadID: Long)
-    fun getOpenGroup(room: String, server: String): OpenGroup?
 
     // Open Group Public Keys
     fun getOpenGroupPublicKey(server: String): String?
@@ -178,7 +173,14 @@ interface StorageProtocol {
     /**
      * Returns the ID of the `TSIncomingMessage` that was constructed.
      */
-    fun persist(message: VisibleMessage, quotes: QuoteModel?, linkPreview: List<LinkPreview?>, fromGroup: Address.GroupLike?, attachments: List<Attachment>, runThreadUpdate: Boolean): MessageId?
+    fun persist(
+        threadRecipient: Recipient,
+        message: VisibleMessage,
+        quotes: QuoteModel?,
+        linkPreview: List<LinkPreview?>,
+        attachments: List<Attachment>,
+        runThreadUpdate: Boolean
+    ): MessageId?
     fun markConversationAsRead(threadId: Long, lastSeenTime: Long, force: Boolean = false)
     fun markConversationAsUnread(threadId: Long)
     fun getLastSeen(threadId: Long): Long

--- a/app/src/main/java/org/session/libsession/database/StorageProtocol.kt
+++ b/app/src/main/java/org/session/libsession/database/StorageProtocol.kt
@@ -82,7 +82,6 @@ interface StorageProtocol {
     fun updateProfilePicture(groupID: String, newValue: ByteArray)
     fun removeProfilePicture(groupID: String)
     fun hasDownloadedProfilePicture(groupID: String): Boolean
-    fun setUserCount(room: String, server: String, newValue: Int)
 
     // Last Message Server ID
     fun getLastMessageServerID(room: String, server: String): Long?

--- a/app/src/main/java/org/session/libsession/messaging/messages/Destination.kt
+++ b/app/src/main/java/org/session/libsession/messaging/messages/Destination.kt
@@ -43,23 +43,19 @@ sealed class Destination {
                     LegacyClosedGroup(address.groupPublicKeyHex)
                 }
                 is Address.Community -> {
-                    val storage = MessagingModuleConfiguration.shared.storage
-                    val threadID = storage.getThreadId(address)!!
-                    storage.getOpenGroup(threadID)?.let {
-                        OpenGroup(roomToken = it.room, server = it.server, fileIds = fileIds)
-                    } ?: throw Exception("Missing open group for thread with ID: $threadID.")
+                    OpenGroup(roomToken = address.room, server = address.serverUrl, fileIds = fileIds)
                 }
                 is Address.CommunityBlindedId -> {
                     val serverPublicKey = MessagingModuleConfiguration.shared.configFactory
                         .withUserConfigs { configs ->
                             configs.userGroups.allCommunityInfo()
-                                .first { it.community.baseUrl == address.serverUrl.toString() }
+                                .first { it.community.baseUrl == address.serverUrl }
                                 .community
                                 .pubKeyHex
                         }
 
                     OpenGroupInbox(
-                        server = address.serverUrl.toString(),
+                        server = address.serverUrl,
                         serverPublicKey = serverPublicKey,
                         blindedPublicKey = address.blindedId.blindedId.hexString,
                     )

--- a/app/src/main/java/org/session/libsession/messaging/open_groups/OpenGroup.kt
+++ b/app/src/main/java/org/session/libsession/messaging/open_groups/OpenGroup.kt
@@ -9,6 +9,7 @@ import org.session.libsession.messaging.open_groups.OpenGroup.Companion.toAddres
 import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.GroupUtil
 
+@Deprecated("This class is no longer used except in migration. Use RoomInfo instead")
 @Serializable
 data class OpenGroup(
     val server: String,

--- a/app/src/main/java/org/session/libsession/messaging/open_groups/OpenGroupMessage.kt
+++ b/app/src/main/java/org/session/libsession/messaging/open_groups/OpenGroupMessage.kt
@@ -45,16 +45,16 @@ data class OpenGroupMessage(
         }
     }
 
-    fun sign(room: String, server: String): OpenGroupMessage? {
+    fun sign(server: String): OpenGroupMessage? {
         if (base64EncodedData.isNullOrEmpty()) return null
         val userEdKeyPair = MessagingModuleConfiguration.shared.storage.getUserED25519KeyPair() ?: return null
-        val openGroup = MessagingModuleConfiguration.shared.storage.getOpenGroup(room, server) ?: return null
+        val communityServerPubKey = MessagingModuleConfiguration.shared.storage.getOpenGroupPublicKey(server) ?: return null
         val serverCapabilities = MessagingModuleConfiguration.shared.storage.getServerCapabilities(server)
         val signature = if (serverCapabilities?.contains(Capability.BLIND.name.lowercase()) == true) {
             runCatching {
                 BlindKeyAPI.blind15Sign(
                     ed25519SecretKey = userEdKeyPair.secretKey.data,
-                    serverPubKey = openGroup.publicKey,
+                    serverPubKey = communityServerPubKey,
                     message = decode(base64EncodedData)
                 )
             }.onFailure {

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
@@ -318,10 +318,10 @@ object MessageSender {
         when(destination) {
             is Destination.OpenGroup -> {
                 serverCapabilities = storage.getServerCapabilities(destination.server).orEmpty()
-                storage.getOpenGroup(destination.roomToken, destination.server)?.let {
+                storage.getOpenGroupPublicKey(destination.server)?.let {
                     blindedPublicKey = BlindKeyAPI.blind15KeyPairOrNull(
                         ed25519SecretKey = userEdKeyPair.secretKey.data,
-                        serverPubKey = Hex.fromStringCondensed(it.publicKey),
+                        serverPubKey = Hex.fromStringCondensed(it),
                     )?.pubKey?.data
                 }
             }
@@ -334,10 +334,10 @@ object MessageSender {
             }
             is Destination.LegacyOpenGroup -> {
                 serverCapabilities = storage.getServerCapabilities(destination.server).orEmpty()
-                storage.getOpenGroup(destination.roomToken, destination.server)?.let {
+                storage.getOpenGroupPublicKey(destination.server)?.let {
                     blindedPublicKey = BlindKeyAPI.blind15KeyPairOrNull(
                         ed25519SecretKey = userEdKeyPair.secretKey.data,
-                        serverPubKey = Hex.fromStringCondensed(it.publicKey),
+                        serverPubKey = Hex.fromStringCondensed(it),
                     )?.pubKey?.data
                 }
             }

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
@@ -13,6 +13,7 @@ import network.loki.messenger.R
 import network.loki.messenger.libsession_util.ConfigBase.Companion.PRIORITY_HIDDEN
 import network.loki.messenger.libsession_util.ConfigBase.Companion.PRIORITY_VISIBLE
 import network.loki.messenger.libsession_util.ED25519
+import network.loki.messenger.libsession_util.util.BaseCommunityInfo
 import network.loki.messenger.libsession_util.util.BlindKeyAPI
 import network.loki.messenger.libsession_util.util.ExpiryMode
 import org.session.libsession.database.MessageDataProvider
@@ -34,7 +35,6 @@ import org.session.libsession.messaging.messages.control.TypingIndicator
 import org.session.libsession.messaging.messages.control.UnsendRequest
 import org.session.libsession.messaging.messages.visible.Attachment
 import org.session.libsession.messaging.messages.visible.VisibleMessage
-import org.session.libsession.messaging.open_groups.OpenGroup
 import org.session.libsession.messaging.open_groups.OpenGroupApi
 import org.session.libsession.messaging.sending_receiving.attachments.PointerAttachment
 import org.session.libsession.messaging.sending_receiving.data_extraction.DataExtractionNotificationInfoMessage
@@ -55,6 +55,7 @@ import org.session.libsession.utilities.GroupUtil.doubleEncodeGroupID
 import org.session.libsession.utilities.SSKEnvironment
 import org.session.libsession.utilities.recipients.MessageType
 import org.session.libsession.utilities.recipients.Recipient
+import org.session.libsession.utilities.recipients.RecipientData
 import org.session.libsession.utilities.recipients.getType
 import org.session.libsession.utilities.updateContact
 import org.session.libsession.utilities.upsertContact
@@ -100,15 +101,15 @@ class ReceivedMessageHandler @Inject constructor(
     @param:ManagerScope private val scope: CoroutineScope,
     private val configFactory: ConfigFactoryProtocol,
     private val conversationRepository: ConversationRepository,
-    private val messageRequestResponseHandler: Provider<MessageRequestResponseHandler>
+    private val messageRequestResponseHandler: Provider<MessageRequestResponseHandler>,
+    private val recipientRepository: RecipientRepository,
 ) {
 
     suspend fun handle(
         message: Message,
         proto: SignalServiceProtos.Content,
         threadId: Long,
-        groupv2Id: AccountId?,
-        fromCommunity: Address.Community?,
+        threadAddress: Address.Conversable,
     ) {
         // Do nothing if the message was outdated
         if (messageIsOutdated(message, threadId)) { return }
@@ -116,14 +117,14 @@ class ReceivedMessageHandler @Inject constructor(
         when (message) {
             is ReadReceipt -> handleReadReceipt(message)
             is TypingIndicator -> handleTypingIndicator(message)
-            is GroupUpdated -> handleGroupUpdated(message, groupv2Id)
+            is GroupUpdated -> handleGroupUpdated(message, (threadAddress as? Address.Group)?.accountId)
             is ExpirationTimerUpdate -> {
                 // For groupsv2, there are dedicated mechanisms for handling expiration timers, and
                 // we want to avoid the 1-to-1 message format which is unauthenticated in a group settings.
-                if (groupv2Id != null) {
+                if (threadAddress is Address.Group) {
                     Log.d("MessageReceiver", "Ignoring expiration timer update for closed group")
                 } // also ignore it for communities since they do not support disappearing messages
-                else if (fromCommunity != null) {
+                else if (threadAddress is Address.Community) {
                     Log.d("MessageReceiver", "Ignoring expiration timer update for communities")
                 } else {
                     handleExpirationTimerUpdate(message)
@@ -135,7 +136,7 @@ class ReceivedMessageHandler @Inject constructor(
             is VisibleMessage -> handleVisibleMessage(
                 message = message,
                 proto = proto,
-                context = visibleMessageContextFactory.create(threadId),
+                context = visibleMessageContextFactory.create(threadId, threadAddress),
                 runThreadUpdate = true,
                 runProfileUpdate = true
             )
@@ -402,12 +403,12 @@ class ReceivedMessageHandler @Inject constructor(
             }
 
             val messageID = context.storage.persist(
-                message,
-                quoteModel,
-                linkPreviews,
-                fromGroup = context.threadRecipient?.address as? Address.GroupLike,
-                attachments,
-                runThreadUpdate
+                threadRecipient = context.threadRecipient,
+                message = message,
+                quotes = quoteModel,
+                linkPreview = linkPreviews,
+                attachments = attachments,
+                runThreadUpdate = runThreadUpdate
             ) ?: return null
 
             // If we have previously "hidden" the sender, we should flip the flag back to visible
@@ -450,14 +451,16 @@ class ReceivedMessageHandler @Inject constructor(
                     profileUpdateHandler.get().handleProfileUpdate(
                         senderId = senderAddress.accountId,
                         updates = updates,
-                        fromCommunity = context.openGroup?.toCommunityInfo(),
+                        fromCommunity = (context.threadRecipient.data as? RecipientData.Community)?.let { data ->
+                            BaseCommunityInfo(baseUrl = data.serverUrl, room = data.room, pubKeyHex = data.serverPubKey)
+                        },
                     )
                 }
             }
 
             // Parse & persist attachments
             // Start attachment downloads if needed
-            if (messageID.mms && (context.threadRecipient?.autoDownloadAttachments == true || senderAddress.address == userPublicKey)) {
+            if (messageID.mms && (context.threadRecipient.autoDownloadAttachments == true || senderAddress.address == userPublicKey)) {
                 context.storage.getAttachmentsForMessage(messageID.id).iterator().forEach { attachment ->
                     attachment.attachmentId?.let { id ->
                         JobQueue.shared.add(attachmentDownloadJobFactory.create(
@@ -709,6 +712,7 @@ private fun SignalServiceProtos.Content.ExpirationType.expiryMode(durationSecond
 
 class VisibleMessageHandlerContext @AssistedInject constructor(
     @param:ApplicationContext val context: Context,
+    @Assisted val threadAddress: Address.Conversable,
     @Assisted val threadId: Long,
     val storage: StorageProtocol,
     val groupManagerV2: GroupManagerV2,
@@ -716,15 +720,11 @@ class VisibleMessageHandlerContext @AssistedInject constructor(
     val messageDataProvider: MessageDataProvider,
     val recipientRepository: RecipientRepository,
 ) {
-    val openGroup: OpenGroup? by lazy {
-        storage.getOpenGroup(threadId)
-    }
-
     val userBlindedKey: String? by lazy {
-        openGroup?.let {
+        (threadRecipient.data as? RecipientData.Community)?.let {
             val blindedKey = BlindKeyAPI.blind15KeyPairOrNull(
                 ed25519SecretKey = storage.getUserED25519KeyPair()!!.secretKey.data,
-                serverPubKey = Hex.fromStringCondensed(it.publicKey),
+                serverPubKey = Hex.fromStringCondensed(it.serverPubKey),
             ) ?: return@let null
 
             AccountId(
@@ -733,18 +733,18 @@ class VisibleMessageHandlerContext @AssistedInject constructor(
         }
     }
 
-    val userPublicKey: String? by lazy {
-        storage.getUserPublicKey()
+    val threadRecipient: Recipient by lazy {
+        recipientRepository.getRecipientSync(threadAddress)
     }
 
-    val threadRecipient: Recipient? by lazy {
-        storage.getRecipientForThread(threadId)
+    val userPublicKey: String? by lazy {
+        storage.getUserPublicKey()
     }
 
 
     @AssistedFactory
     interface Factory {
-        fun create(threadId: Long): VisibleMessageHandlerContext
+        fun create(threadId: Long, threadAddress: Address.Conversable): VisibleMessageHandlerContext
     }
 }
 
@@ -771,13 +771,14 @@ fun constructReactionRecords(
     out: MutableMap<MessageId, MutableList<ReactionRecord>>
 ) {
     if (reactions.isNullOrEmpty()) return
+    val communityAddress = context.threadAddress as? Address.Community ?: return
     val messageId = context.messageDataProvider.getMessageID(openGroupMessageServerID, context.threadId) ?: return
 
     val outList = out.getOrPut(messageId) { arrayListOf() }
 
     for ((emoji, reaction) in reactions) {
         val pendingUserReaction = OpenGroupApi.pendingReactions
-            .filter { it.server == context.openGroup?.server && it.room == context.openGroup?.room && it.messageId == openGroupMessageServerID && it.add }
+            .filter { it.server == communityAddress.serverUrl && it.room == communityAddress.room && it.messageId == openGroupMessageServerID && it.add }
             .sortedByDescending { it.seqNo }
             .any { it.emoji == emoji }
         val shouldAddUserReaction = pendingUserReaction || reaction.you || reaction.reactors.contains(context.userPublicKey)

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
@@ -301,7 +301,7 @@ class ReceivedMessageHandler @Inject constructor(
 
 
         // Handle group invite response if new closed group
-        val threadRecipientAddress = context.threadRecipient?.address
+        val threadRecipientAddress = context.threadAddress
         if (threadRecipientAddress is Address.Group && senderAddress is Address.Standard) {
             scope.launch {
                 try {
@@ -360,7 +360,7 @@ class ReceivedMessageHandler @Inject constructor(
         cancelTypingIndicatorsIfNeeded(message.sender!!)
 
         // Parse reaction if needed
-        val threadIsGroup = context.threadRecipient?.isGroupOrCommunityRecipient == true
+        val threadIsGroup = context.threadRecipient.isGroupOrCommunityRecipient
         message.reaction?.let { reaction ->
             if (reaction.react == true) {
                 reaction.serverId = message.openGroupServerMessageID?.toString() ?: message.serverHash.orEmpty()

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
@@ -352,7 +352,12 @@ class OpenGroupPoller @AssistedInject constructor(
                         message.syncTarget = syncTarget
                     }
                 }
-                val threadAddress = message.senderOrSync.toAddress() as Address.Conversable
+                val threadAddress = when (val addr = message.senderOrSync.toAddress()) {
+                    is Address.Blinded -> Address.CommunityBlindedId(serverUrl = server, blindedId = addr)
+                    is Address.Conversable -> addr
+                    else -> throw IllegalArgumentException("Unsupported address type: ${addr.debugString}")
+                }
+
                 val threadId = threadDatabase.getThreadIdIfExistsFor(threadAddress)
                 receivedMessageHandler.handle(
                     message = message,

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
@@ -1,5 +1,6 @@
 package org.session.libsession.messaging.sending_receiving.pollers
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.google.protobuf.ByteString
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -15,6 +16,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.session.libsession.database.StorageProtocol
+import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.jobs.BatchMessageReceiveJob
 import org.session.libsession.messaging.jobs.JobQueue
 import org.session.libsession.messaging.jobs.MessageReceiveParameters
@@ -27,17 +29,31 @@ import org.session.libsession.messaging.open_groups.Endpoint
 import org.session.libsession.messaging.open_groups.GroupMemberRole
 import org.session.libsession.messaging.open_groups.OpenGroup
 import org.session.libsession.messaging.open_groups.OpenGroupApi
+import org.session.libsession.messaging.open_groups.OpenGroupApi.BatchRequest
+import org.session.libsession.messaging.open_groups.OpenGroupApi.BatchRequestInfo
+import org.session.libsession.messaging.open_groups.OpenGroupApi.BatchResponse
+import org.session.libsession.messaging.open_groups.OpenGroupApi.Capability
+import org.session.libsession.messaging.open_groups.OpenGroupApi.DirectMessage
+import org.session.libsession.messaging.open_groups.OpenGroupApi.Message
+import org.session.libsession.messaging.open_groups.OpenGroupApi.RoomPollInfo
+import org.session.libsession.messaging.open_groups.OpenGroupApi.getOrFetchServerCapabilities
+import org.session.libsession.messaging.open_groups.OpenGroupApi.parallelBatch
 import org.session.libsession.messaging.open_groups.OpenGroupMessage
 import org.session.libsession.messaging.sending_receiving.MessageReceiver
 import org.session.libsession.messaging.sending_receiving.ReceivedMessageHandler
+import org.session.libsession.snode.utilities.await
 import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.Address.Companion.toAddress
 import org.session.libsession.utilities.ConfigFactoryProtocol
+import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.protos.SignalServiceProtos
 import org.session.libsignal.utilities.AccountId
 import org.session.libsignal.utilities.Base64
+import org.session.libsignal.utilities.HTTP.Verb.GET
+import org.session.libsignal.utilities.JsonUtil
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.database.BlindMappingRepository
+import org.thoughtcrime.securesms.database.CommunityDatabase
 import org.thoughtcrime.securesms.database.GroupMemberDatabase
 import org.thoughtcrime.securesms.database.LokiThreadDatabase
 import org.thoughtcrime.securesms.database.ThreadDatabase
@@ -66,6 +82,7 @@ class OpenGroupPoller @AssistedInject constructor(
     private val threadDatabase: ThreadDatabase,
     private val trimThreadJobFactory: TrimThreadJob.Factory,
     private val openGroupDeleteJobFactory: OpenGroupDeleteJob.Factory,
+    private val communityDatabase: CommunityDatabase,
     @Assisted private val server: String,
     @Assisted private val scope: CoroutineScope,
 ) {
@@ -132,63 +149,10 @@ class OpenGroupPoller @AssistedInject constructor(
     }
 
     private fun handleRoomPollInfo(
-        roomToken: String,
-        pollInfo: OpenGroupApi.RoomPollInfo,
-        publicKey: String
+        address: Address.Community,
+        pollInfoJson: Map<*, *>,
     ) {
-        val existingOpenGroup = storage.getOpenGroup(roomToken, server)
-
-        // If we don't have an existing group and don't have a 'createGroupIfMissingWithPublicKey'
-        // value then don't process the poll info
-        val publicKey = existingOpenGroup?.publicKey ?: publicKey
-        val name = pollInfo.details?.name ?: existingOpenGroup?.name
-        val infoUpdates = pollInfo.details?.infoUpdates ?: existingOpenGroup?.infoUpdates
-
-        val openGroup = OpenGroup(
-            server = server,
-            room = pollInfo.token,
-            name = name ?: "",
-            description = (pollInfo.details?.description ?: existingOpenGroup?.description),
-            publicKey = publicKey,
-            imageId = (pollInfo.details?.imageId ?: existingOpenGroup?.imageId),
-            canWrite = pollInfo.write,
-            infoUpdates = infoUpdates ?: 0,
-            isAdmin = pollInfo.admin,
-            isModerator = pollInfo.moderator,
-        )
-        // - Open Group changes
-        lokiThreadDatabase.setOpenGroupChat(
-            openGroup = openGroup,
-            threadID = threadDatabase.getThreadIdIfExistsFor(Address.Community(server, roomToken))
-        )
-
-        // - User Count
-        storage.setUserCount(roomToken, server, pollInfo.activeUsers)
-
-        val community = Address.Community(openGroup)
-
-        // - Moderators
-        pollInfo.details?.moderators?.let { list ->
-            groupMemberDatabase.updateGroupMembers(
-                community, GroupMemberRole.MODERATOR, list.map(::AccountId)
-            )
-        }
-        pollInfo.details?.hiddenModerators?.let { list ->
-            groupMemberDatabase.updateGroupMembers(
-                community, GroupMemberRole.HIDDEN_MODERATOR, list.map(::AccountId)
-            )
-        }
-        // - Admins
-        pollInfo.details?.admins?.let { list ->
-            groupMemberDatabase.updateGroupMembers(
-                community, GroupMemberRole.ADMIN, list.map(::AccountId)
-            )
-        }
-        pollInfo.details?.hiddenAdmins?.let { list ->
-            groupMemberDatabase.updateGroupMembers(
-                community, GroupMemberRole.HIDDEN_ADMIN, list.map(::AccountId)
-            )
-        }
+        communityDatabase.patchRoomInfo(address, JsonUtil.toJson(pollInfoJson))
     }
 
 
@@ -209,14 +173,13 @@ class OpenGroupPoller @AssistedInject constructor(
 
         val publicKey = allCommunities.first { it.community.baseUrl == server }.community.pubKeyHex
 
-        OpenGroupApi
-            .poll(rooms, server)
+        poll(rooms)
             .asSequence()
             .filterNot { it.body == null }
             .forEach { response ->
                 when (response.endpoint) {
                     is Endpoint.RoomPollInfo -> {
-                        handleRoomPollInfo(  response.endpoint.roomToken, response.body as OpenGroupApi.RoomPollInfo, publicKey)
+                        handleRoomPollInfo(Address.Community(server, response.endpoint.roomToken), response.body as Map<*, *>)
                     }
                     is Endpoint.RoomMessagesRecent -> {
                         handleMessages(server, response.endpoint.roomToken, response.body as List<OpenGroupApi.Message>)
@@ -236,6 +199,100 @@ class OpenGroupPoller @AssistedInject constructor(
 
         return rooms
     }
+
+    @Suppress("UNCHECKED_CAST")
+    suspend fun poll(rooms: List<String>): List<BatchResponse<*>> {
+        val lastInboxMessageId = storage.getLastInboxMessageId(server)
+        val lastOutboxMessageId = storage.getLastOutboxMessageId(server)
+        val requests = mutableListOf<BatchRequestInfo<*>>()
+
+        val serverCapabilities = getOrFetchServerCapabilities(server)
+
+        rooms.forEach { room ->
+            val address = Address.Community(serverUrl = server, room = room)
+            val latestRoomPollInfo = communityDatabase.getRoomInfo(address)
+            val infoUpdates = latestRoomPollInfo?.details?.infoUpdates ?: 0
+            val lastMessageServerId = storage.getLastMessageServerID(room, server) ?: 0L
+            requests.add(
+                BatchRequestInfo(
+                    request = BatchRequest(
+                        method = GET,
+                        path = "/room/$room/pollInfo/$infoUpdates"
+                    ),
+                    endpoint = Endpoint.RoomPollInfo(room, infoUpdates),
+                    responseType = object : TypeReference<Map<*, *>>(){}
+                )
+            )
+            requests.add(
+                if (lastMessageServerId == 0L) {
+                    BatchRequestInfo(
+                        request = BatchRequest(
+                            method = GET,
+                            path = "/room/$room/messages/recent?t=r&reactors=5"
+                        ),
+                        endpoint = Endpoint.RoomMessagesRecent(room),
+                        responseType = object : TypeReference<List<Message>>(){}
+                    )
+                } else {
+                    BatchRequestInfo(
+                        request = BatchRequest(
+                            method = GET,
+                            path = "/room/$room/messages/since/$lastMessageServerId?t=r&reactors=5"
+                        ),
+                        endpoint = Endpoint.RoomMessagesSince(room, lastMessageServerId),
+                        responseType = object : TypeReference<List<Message>>(){}
+                    )
+                }
+            )
+        }
+        val isAcceptingCommunityRequests = storage.isCheckingCommunityRequests()
+        if (serverCapabilities.contains(Capability.BLIND.name.lowercase()) && isAcceptingCommunityRequests) {
+            requests.add(
+                if (lastInboxMessageId == null) {
+                    BatchRequestInfo(
+                        request = BatchRequest(
+                            method = GET,
+                            path = "/inbox"
+                        ),
+                        endpoint = Endpoint.Inbox,
+                        responseType = object : TypeReference<List<DirectMessage>>() {}
+                    )
+                } else {
+                    BatchRequestInfo(
+                        request = BatchRequest(
+                            method = GET,
+                            path = "/inbox/since/$lastInboxMessageId"
+                        ),
+                        endpoint = Endpoint.InboxSince(lastInboxMessageId),
+                        responseType = object : TypeReference<List<DirectMessage>>() {}
+                    )
+                }
+            )
+            requests.add(
+                if (lastOutboxMessageId == null) {
+                    BatchRequestInfo(
+                        request = BatchRequest(
+                            method = GET,
+                            path = "/outbox"
+                        ),
+                        endpoint = Endpoint.Outbox,
+                        responseType = object : TypeReference<List<DirectMessage>>() {}
+                    )
+                } else {
+                    BatchRequestInfo(
+                        request = BatchRequest(
+                            method = GET,
+                            path = "/outbox/since/$lastOutboxMessageId"
+                        ),
+                        endpoint = Endpoint.OutboxSince(lastOutboxMessageId),
+                        responseType = object : TypeReference<List<DirectMessage>>() {}
+                    )
+                }
+            )
+        }
+        return parallelBatch(server, requests).await()
+    }
+
 
     private fun handleMessages(
         server: String,

--- a/app/src/main/java/org/session/libsession/utilities/recipients/ProStatus.kt
+++ b/app/src/main/java/org/session/libsession/utilities/recipients/ProStatus.kt
@@ -1,6 +1,7 @@
 package org.session.libsession.utilities.recipients
 
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonClassDiscriminator
 import org.session.libsession.utilities.serializable.InstantAsMillisSerializer
@@ -11,6 +12,7 @@ import java.time.Instant
 @JsonClassDiscriminator("status")
 sealed interface ProStatus {
     @Serializable
+    @SerialName("pro")
     data class Pro(
         /**
          * Whether the Pro badge should be visible or not.
@@ -25,6 +27,7 @@ sealed interface ProStatus {
     ) : ProStatus
 
     @Serializable
+    @SerialName("none")
     data object None : ProStatus
 }
 

--- a/app/src/main/java/org/session/libsession/utilities/recipients/Recipient.kt
+++ b/app/src/main/java/org/session/libsession/utilities/recipients/Recipient.kt
@@ -39,8 +39,8 @@ data class Recipient(
     val currentUserRole: GroupMemberRole get() = when (data) {
         is RecipientData.Group -> if (data.partial.isAdmin) GroupMemberRole.ADMIN else GroupMemberRole.STANDARD
         is RecipientData.Community -> when {
-            data.openGroup.isAdmin -> GroupMemberRole.ADMIN
-            data.openGroup.isModerator -> GroupMemberRole.MODERATOR
+            data.pollInfo.admin -> GroupMemberRole.ADMIN
+            data.pollInfo.moderator -> GroupMemberRole.MODERATOR
             else -> GroupMemberRole.STANDARD
         }
         is RecipientData.LegacyGroup -> if (data.isCurrentUserAdmin) GroupMemberRole.ADMIN else GroupMemberRole.STANDARD

--- a/app/src/main/java/org/session/libsession/utilities/recipients/Recipient.kt
+++ b/app/src/main/java/org/session/libsession/utilities/recipients/Recipient.kt
@@ -39,8 +39,8 @@ data class Recipient(
     val currentUserRole: GroupMemberRole get() = when (data) {
         is RecipientData.Group -> if (data.partial.isAdmin) GroupMemberRole.ADMIN else GroupMemberRole.STANDARD
         is RecipientData.Community -> when {
-            data.pollInfo.admin -> GroupMemberRole.ADMIN
-            data.pollInfo.moderator -> GroupMemberRole.MODERATOR
+            data.roomInfo?.admin == true -> GroupMemberRole.ADMIN
+            data.roomInfo?.moderator == true -> GroupMemberRole.MODERATOR
             else -> GroupMemberRole.STANDARD
         }
         is RecipientData.LegacyGroup -> if (data.isCurrentUserAdmin) GroupMemberRole.ADMIN else GroupMemberRole.STANDARD

--- a/app/src/main/java/org/session/libsession/utilities/recipients/RecipientNames.kt
+++ b/app/src/main/java/org/session/libsession/utilities/recipients/RecipientNames.kt
@@ -19,7 +19,7 @@ fun Recipient.displayName(
         is RecipientData.LegacyGroup -> data.name
         is RecipientData.Group -> data.partial.name
         is RecipientData.Generic -> data.displayName
-        is RecipientData.Community -> data.pollInfo.details.name
+        is RecipientData.Community -> data.roomInfo?.details?.name ?: data.room
         is RecipientData.BlindedContact -> data.displayName
     }
 

--- a/app/src/main/java/org/session/libsession/utilities/recipients/RecipientNames.kt
+++ b/app/src/main/java/org/session/libsession/utilities/recipients/RecipientNames.kt
@@ -19,7 +19,7 @@ fun Recipient.displayName(
         is RecipientData.LegacyGroup -> data.name
         is RecipientData.Group -> data.partial.name
         is RecipientData.Generic -> data.displayName
-        is RecipientData.Community -> data.openGroup.name
+        is RecipientData.Community -> data.pollInfo.details.name
         is RecipientData.BlindedContact -> data.displayName
     }
 

--- a/app/src/main/java/org/session/libsignal/database/LokiAPIDatabaseProtocol.kt
+++ b/app/src/main/java/org/session/libsignal/database/LokiAPIDatabaseProtocol.kt
@@ -27,7 +27,6 @@ interface LokiAPIDatabaseProtocol {
     fun clearReceivedMessageHashValuesByNamespaces(vararg namespaces: Int)
     fun getAuthToken(server: String): String?
     fun setAuthToken(server: String, newValue: String?)
-    fun setUserCount(room: String, server: String, newValue: Int)
     fun getLastMessageServerID(room: String, server: String): Long?
     fun setLastMessageServerID(room: String, server: String, newValue: Long)
     fun getLastDeletionServerID(room: String, server: String): Long?

--- a/app/src/main/java/org/thoughtcrime/securesms/ShareViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ShareViewModel.kt
@@ -98,7 +98,7 @@ class ShareViewModel @Inject constructor(
                     recipient.address is Address.LegacyGroup -> !deprecationManager.isDeprecated
 
                     // if the recipient is a community, check if it can write
-                    recipient.data is RecipientData.Community -> recipient.data.openGroup.canWrite
+                    recipient.data is RecipientData.Community -> recipient.data.pollInfo.write
 
                     else -> {
                         val name = if (recipient.isSelf) context.getString(R.string.noteToSelf)

--- a/app/src/main/java/org/thoughtcrime/securesms/ShareViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ShareViewModel.kt
@@ -102,7 +102,7 @@ class ShareViewModel @Inject constructor(
                     recipient.address is Address.LegacyGroup -> !deprecationManager.isDeprecated
 
                     // if the recipient is a community, check if it can write
-                    recipient.data is RecipientData.Community && recipient.data.roomInfo?.canWrite != true -> false
+                    recipient.data is RecipientData.Community && recipient.data.roomInfo?.write != true -> false
 
                     else -> {
                         val name = if (recipient.isSelf) context.getString(R.string.noteToSelf)

--- a/app/src/main/java/org/thoughtcrime/securesms/ShareViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ShareViewModel.kt
@@ -98,7 +98,7 @@ class ShareViewModel @Inject constructor(
                     recipient.address is Address.LegacyGroup -> !deprecationManager.isDeprecated
 
                     // if the recipient is a community, check if it can write
-                    recipient.data is RecipientData.Community -> recipient.data.pollInfo.write
+                    recipient.data is RecipientData.Community -> recipient.data.roomInfo?.write == true
 
                     else -> {
                         val name = if (recipient.isSelf) context.getString(R.string.noteToSelf)

--- a/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/configs/ConfigToDatabaseSync.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -37,12 +36,12 @@ import org.session.libsignal.crypto.ecc.DjbECPublicKey
 import org.session.libsignal.crypto.ecc.ECKeyPair
 import org.session.libsignal.utilities.AccountId
 import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.database.CommunityDatabase
 import org.thoughtcrime.securesms.database.DraftDatabase
 import org.thoughtcrime.securesms.database.GroupDatabase
 import org.thoughtcrime.securesms.database.GroupMemberDatabase
 import org.thoughtcrime.securesms.database.LokiAPIDatabase
 import org.thoughtcrime.securesms.database.LokiMessageDatabase
-import org.thoughtcrime.securesms.database.LokiThreadDatabase
 import org.thoughtcrime.securesms.database.MmsDatabase
 import org.thoughtcrime.securesms.database.MmsSmsDatabase
 import org.thoughtcrime.securesms.database.SmsDatabase
@@ -75,7 +74,7 @@ class ConfigToDatabaseSync @Inject constructor(
     private val draftDatabase: DraftDatabase,
     private val groupDatabase: GroupDatabase,
     private val groupMemberDatabase: GroupMemberDatabase,
-    private val lokiThreadDatabase: LokiThreadDatabase,
+    private val communityDatabase: CommunityDatabase,
     private val lokiAPIDatabase: LokiAPIDatabase,
     private val clock: SnodeClock,
     private val preferences: TextSecurePreferences,
@@ -228,9 +227,9 @@ class ConfigToDatabaseSync @Inject constructor(
         lokiAPIDatabase.removeLastMessageServerID(room = address.room, server = address.serverUrl)
         lokiAPIDatabase.removeLastInboxMessageId(address.serverUrl)
         lokiAPIDatabase.removeLastOutboxMessageId(address.serverUrl)
-        lokiThreadDatabase.removeOpenGroupChat(threadId)
         groupDatabase.delete(address.address)
         groupMemberDatabase.delete(address)
+        communityDatabase.deleteRoomInfo(address)
     }
 
     private fun deleteLegacyGroupData(address: Address.LegacyGroup) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/AttachmentDownloadHandler.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/AttachmentDownloadHandler.kt
@@ -19,7 +19,6 @@ import org.session.libsession.messaging.jobs.JobQueue
 import org.session.libsession.messaging.sending_receiving.attachments.AttachmentState
 import org.session.libsession.messaging.sending_receiving.attachments.DatabaseAttachment
 import org.session.libsignal.utilities.Log
-import org.thoughtcrime.securesms.database.RecipientRepository
 import org.thoughtcrime.securesms.util.flatten
 import org.thoughtcrime.securesms.util.timedBuffer
 
@@ -33,7 +32,6 @@ import org.thoughtcrime.securesms.util.timedBuffer
 class AttachmentDownloadHandler @AssistedInject constructor(
     private val storage: StorageProtocol,
     private val messageDataProvider: MessageDataProvider,
-    private val recipientRepository: RecipientRepository,
     @Assisted private val scope: CoroutineScope,
     private val downloadJobFactory: AttachmentDownloadJob.Factory
 ) {
@@ -103,7 +101,6 @@ class AttachmentDownloadHandler @AssistedInject constructor(
         return AttachmentDownloadJob.eligibleForDownload(
             threadID = threadID,
             storage = storage,
-            recipientRepository = recipientRepository,
             messageDataProvider = messageDataProvider,
             mmsId = attachment.mmsId,
         )

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -90,7 +90,6 @@ import org.session.libsession.messaging.messages.signal.OutgoingMediaMessage
 import org.session.libsession.messaging.messages.signal.OutgoingTextMessage
 import org.session.libsession.messaging.messages.visible.Reaction
 import org.session.libsession.messaging.messages.visible.VisibleMessage
-import org.session.libsession.messaging.open_groups.OpenGroup
 import org.session.libsession.messaging.open_groups.OpenGroupApi
 import org.session.libsession.messaging.sending_receiving.MessageSender
 import org.session.libsession.messaging.sending_receiving.attachments.Attachment
@@ -160,7 +159,6 @@ import org.thoughtcrime.securesms.crypto.MnemonicUtilities
 import org.thoughtcrime.securesms.database.AttachmentDatabase
 import org.thoughtcrime.securesms.database.GroupDatabase
 import org.thoughtcrime.securesms.database.LokiMessageDatabase
-import org.thoughtcrime.securesms.database.LokiThreadDatabase
 import org.thoughtcrime.securesms.database.MmsDatabase
 import org.thoughtcrime.securesms.database.MmsSmsDatabase
 import org.thoughtcrime.securesms.database.ReactionDatabase
@@ -247,7 +245,6 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
     @Inject lateinit var textSecurePreferences: TextSecurePreferences
     @Inject lateinit var threadDb: ThreadDatabase
     @Inject lateinit var mmsSmsDb: MmsSmsDatabase
-    @Inject lateinit var lokiThreadDb: LokiThreadDatabase
     @Inject lateinit var groupDb: GroupDatabase
     @Inject lateinit var smsDb: SmsDatabase
     @Inject lateinit var mmsDb: MmsDatabase
@@ -1378,7 +1375,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
 
     // Update placeholder / control messages in a conversation
     private fun updatePlaceholder(recipient: Recipient,
-                                  openGroup: OpenGroupApi.RoomPollInfo?,
+                                  openGroup: OpenGroupApi.RoomInfo?,
                                   groupThreadStatus: GroupThreadStatus,
                                   adapterItemCount: Int) {
         // Special state handling for kicked/destroyed groups

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1127,23 +1127,13 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
         // React to placeholder related changes
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                data class PlaceholderData(
-                    val recipient: Recipient,
-                    val openGroup: OpenGroup?,
-                    val groupThreadStatus: GroupThreadStatus,
-                )
-
                 combine(
                     viewModel.recipientFlow,
                     viewModel.openGroupFlow,
                     viewModel.groupV2ThreadState,
-                    lastCursorLoaded
+                    lastCursorLoaded,
                 ) { r, og, groupState, _ ->
-                    PlaceholderData(
-                        recipient = r,
-                        openGroup = og,
-                        groupThreadStatus = groupState,
-                    )
+                    Triple(r, og, groupState)
                 } .collectLatest { (r, og, groupState) ->
                     updatePlaceholder(
                         recipient = r,
@@ -1388,7 +1378,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
 
     // Update placeholder / control messages in a conversation
     private fun updatePlaceholder(recipient: Recipient,
-                                  openGroup: OpenGroup?,
+                                  openGroup: OpenGroupApi.RoomPollInfo?,
                                   groupThreadStatus: GroupThreadStatus,
                                   adapterItemCount: Int) {
         // Special state handling for kicked/destroyed groups
@@ -1417,9 +1407,9 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
             recipient.isLocalNumber -> getString(R.string.noteToSelfEmpty)
 
             // If this is a community which we cannot write to
-            openGroup != null && !openGroup.canWrite -> {
+            openGroup != null && !openGroup.write -> {
                 Phrase.from(applicationContext, R.string.conversationsEmpty)
-                    .put(CONVERSATION_NAME_KEY, openGroup.name)
+                    .put(CONVERSATION_NAME_KEY, openGroup.details.name)
                     .format()
             }
 
@@ -1742,14 +1732,16 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
 
             // Send it
             reactionMessage.reaction = Reaction.from(originalMessage.timestamp, originalAuthor.toString(), emoji, true)
-            if (recipient.isCommunityRecipient) {
+            if (recipient.address is Address.Community) {
 
                 val messageServerId = lokiMessageDb.getServerID(originalMessage.messageId) ?:
                     return Log.w(TAG, "Failed to find message server ID when adding emoji reaction")
 
-                viewModel.openGroup?.let {
-                    OpenGroupApi.addReaction(it.room, it.server, messageServerId, emoji)
-                }
+                OpenGroupApi.addReaction(
+                    room = recipient.address.room,
+                    server = recipient.address.serverUrl,
+                    messageId = messageServerId,
+                    emoji = emoji)
             } else {
                 MessageSender.send(reactionMessage, recipient.address)
             }
@@ -1782,14 +1774,12 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
             } else originalMessage.individualRecipient.address
 
             message.reaction = Reaction.from(originalMessage.timestamp, originalAuthor.toString(), emoji, false)
-            if (recipient.isCommunityRecipient) {
+            if (recipient.address is Address.Community) {
 
                 val messageServerId = lokiMessageDb.getServerID(originalMessage.messageId) ?:
                     return Log.w(TAG, "Failed to find message server ID when removing emoji reaction")
 
-                viewModel.openGroup?.let {
-                    OpenGroupApi.deleteReaction(it.room, it.server, messageServerId, emoji)
-                }
+                OpenGroupApi.deleteReaction(recipient.address.room, recipient.address.serverUrl, messageServerId, emoji)
             } else {
                 MessageSender.send(message, recipient.address)
             }
@@ -2048,7 +2038,6 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
         val sentTimestamp = SnodeAPI.nowWithOffset
         viewModel.implicitlyApproveRecipient()?.let { conversationApprovalJob = it }
         val text = getMessageBody()
-        val userPublicKey = textSecurePreferences.getLocalNumber()
         val isNoteToSelf = recipient.isLocalNumber
         if (seed in text && !isNoteToSelf && !hasPermissionToSendSeed) {
             showSessionDialog {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
@@ -27,8 +27,6 @@ import androidx.core.view.isVisible
 import androidx.vectordrawable.graphics.drawable.AnimatorInflaterCompat
 import com.squareup.phrase.Phrase
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
-import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
@@ -53,7 +51,6 @@ import org.session.libsession.utilities.recipients.RecipientData
 import org.thoughtcrime.securesms.components.emoji.EmojiImageView
 import org.thoughtcrime.securesms.components.emoji.RecentEmojiPageModel
 import org.thoughtcrime.securesms.components.menu.ActionItem
-import org.thoughtcrime.securesms.database.LokiThreadDatabase
 import org.thoughtcrime.securesms.database.MmsSmsDatabase
 import org.thoughtcrime.securesms.database.ThreadDatabase
 import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord
@@ -64,6 +61,8 @@ import org.thoughtcrime.securesms.repository.ConversationRepository
 import org.thoughtcrime.securesms.util.AnimationCompleteListener
 import org.thoughtcrime.securesms.util.DateUtils
 import org.thoughtcrime.securesms.util.applySafeInsetsPaddings
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 
 @AndroidEntryPoint
 class ConversationReactionOverlay : FrameLayout {
@@ -106,7 +105,6 @@ class ConversationReactionOverlay : FrameLayout {
     @Inject lateinit var mmsSmsDatabase: MmsSmsDatabase
     @Inject lateinit var repository: ConversationRepository
     @Inject lateinit var dateUtils: DateUtils
-    @Inject lateinit var lokiThreadDatabase: LokiThreadDatabase
     @Inject lateinit var threadDatabase: ThreadDatabase
     @Inject lateinit var textSecurePreferences: TextSecurePreferences
     @Inject lateinit var deprecationManager: LegacyGroupDeprecationManager
@@ -596,7 +594,7 @@ class ConversationReactionOverlay : FrameLayout {
         val containsControlMessage = message.isControlMessage
         
         val hasText = !message.body.isEmpty()
-        val openGroup = (threadRecipient.data as? RecipientData.Community)?.pollInfo
+        val openGroup = (threadRecipient.data as? RecipientData.Community)?.roomInfo
 
         val isDeprecatedLegacyGroup = recipient.isLegacyGroup &&
                 deprecationManager.isDeprecated

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationReactionOverlay.kt
@@ -596,7 +596,7 @@ class ConversationReactionOverlay : FrameLayout {
         val containsControlMessage = message.isControlMessage
         
         val hasText = !message.body.isEmpty()
-        val openGroup = (threadRecipient.data as? RecipientData.Community)?.openGroup
+        val openGroup = (threadRecipient.data as? RecipientData.Community)?.pollInfo
 
         val isDeprecatedLegacyGroup = recipient.isLegacyGroup &&
                 deprecationManager.isDeprecated
@@ -615,7 +615,7 @@ class ConversationReactionOverlay : FrameLayout {
         }
 
         // Reply
-        val canWrite = openGroup == null || openGroup.canWrite
+        val canWrite = openGroup == null || openGroup.write
         if (canWrite && !message.isPending && !message.isFailed && !message.isOpenGroupInvitation && !isDeleteOnly
             && !isDeprecatedLegacyGroup) {
             items += ActionItem(R.attr.menu_reply_icon, R.string.reply, { handleActionItemClicked(Action.REPLY) }, R.string.AccessibilityId_reply)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -210,12 +210,12 @@ class ConversationViewModel @AssistedInject constructor(
         (r.acceptsBlindedCommunityMessageRequests || r.isStandardRecipient) && !r.isLocalNumber && !r.approvedMe
     }
 
-    val openGroupFlow: StateFlow<OpenGroupApi.RoomPollInfo?> = recipientFlow
-        .map { (it.data as? RecipientData.Community)?.pollInfo }
+    val openGroupFlow: StateFlow<OpenGroupApi.RoomInfo?> = recipientFlow
+        .map { (it.data as? RecipientData.Community)?.roomInfo }
         .distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    val openGroup: OpenGroupApi.RoomPollInfo?
+    val openGroup: OpenGroupApi.RoomInfo?
         get() = openGroupFlow.value
 
     val isAdmin: StateFlow<Boolean> = recipientFlow.mapStateFlow(viewModelScope) {
@@ -447,7 +447,7 @@ class ConversationViewModel @AssistedInject constructor(
             )
 
             // the user does not have write access in the community
-            (recipient.data as? RecipientData.Community)?.pollInfo?.write == false -> InputBarState(
+            (recipient.data as? RecipientData.Community)?.roomInfo?.write == false -> InputBarState(
                 contentState = InputBarContentState.Disabled(
                     text = application.getString(R.string.permissionsWriteCommunity),
                 ),
@@ -506,7 +506,7 @@ class ConversationViewModel @AssistedInject constructor(
 
         if (conversation.isGroupOrCommunityRecipient && conversation.approved) {
             val title = if (conversation.address is Address.Community) {
-                val userCount = (conversation.data as? RecipientData.Community)?.pollInfo?.activeUsers
+                val userCount = (conversation.data as? RecipientData.Community)?.roomInfo?.activeUsers
                     ?: 0
                 application.resources.getQuantityString(R.plurals.membersActive, userCount, userCount)
             } else {
@@ -586,7 +586,7 @@ class ConversationViewModel @AssistedInject constructor(
 
         // - For communities you must have write access to the community
         val allowedForCommunity = (recipient.isCommunityRecipient &&
-                (recipient.data as? RecipientData.Community)?.pollInfo?.write == true)
+                (recipient.data as? RecipientData.Community)?.roomInfo?.write == true)
 
         // - For blinded recipients you must be a contact of the recipient - without which you CAN
         // send them SMS messages - but they will not get through if the recipient does not have

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -53,7 +53,6 @@ import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.groups.GroupManagerV2
 import org.session.libsession.messaging.groups.LegacyGroupDeprecationManager
 import org.session.libsession.messaging.open_groups.GroupMemberRole
-import org.session.libsession.messaging.open_groups.OpenGroup
 import org.session.libsession.messaging.open_groups.OpenGroupApi
 import org.session.libsession.messaging.sending_receiving.attachments.DatabaseAttachment
 import org.session.libsession.utilities.Address
@@ -211,12 +210,12 @@ class ConversationViewModel @AssistedInject constructor(
         (r.acceptsBlindedCommunityMessageRequests || r.isStandardRecipient) && !r.isLocalNumber && !r.approvedMe
     }
 
-    val openGroupFlow: StateFlow<OpenGroup?> = recipientFlow
-        .map { (it.data as? RecipientData.Community)?.openGroup }
+    val openGroupFlow: StateFlow<OpenGroupApi.RoomPollInfo?> = recipientFlow
+        .map { (it.data as? RecipientData.Community)?.pollInfo }
         .distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    val openGroup: OpenGroup?
+    val openGroup: OpenGroupApi.RoomPollInfo?
         get() = openGroupFlow.value
 
     val isAdmin: StateFlow<Boolean> = recipientFlow.mapStateFlow(viewModelScope) {
@@ -275,13 +274,17 @@ class ConversationViewModel @AssistedInject constructor(
     }
 
     val serverCapabilities: List<String>
-        get() = openGroup?.let { storage.getServerCapabilities(it.server) } ?: listOf()
+        get() = when (address) {
+            is Address.Community -> address.serverUrl
+            is Address.CommunityBlindedId -> address.serverUrl
+            else -> null
+        } ?.let { storage.getServerCapabilities(it) } ?: listOf()
 
     val blindedPublicKey: String?
-        get() = if (openGroup == null || edKeyPair == null || !serverCapabilities.contains(OpenGroupApi.Capability.BLIND.name.lowercase())) null else {
+        get() = if (recipient.data !is RecipientData.Community || edKeyPair == null || !serverCapabilities.contains(OpenGroupApi.Capability.BLIND.name.lowercase())) null else {
             BlindKeyAPI.blind15KeyPairOrNull(
                 ed25519SecretKey = edKeyPair!!.secretKey.data,
-                serverPubKey = Hex.fromStringCondensed(openGroup!!.publicKey),
+                serverPubKey = Hex.fromStringCondensed((recipient.data as RecipientData.Community).serverPubKey),
             )?.pubKey?.data
                 ?.let { AccountId(IdPrefix.BLINDED, it) }?.hexString
         }
@@ -444,7 +447,7 @@ class ConversationViewModel @AssistedInject constructor(
             )
 
             // the user does not have write access in the community
-            (recipient.data as? RecipientData.Community)?.openGroup?.canWrite == false -> InputBarState(
+            (recipient.data as? RecipientData.Community)?.pollInfo?.write == false -> InputBarState(
                 contentState = InputBarContentState.Disabled(
                     text = application.getString(R.string.permissionsWriteCommunity),
                 ),
@@ -503,14 +506,12 @@ class ConversationViewModel @AssistedInject constructor(
 
         if (conversation.isGroupOrCommunityRecipient && conversation.approved) {
             val title = if (conversation.address is Address.Community) {
-                val userCount = lokiAPIDb.getUserCount(
-                    room = conversation.address.room,
-                    server = conversation.address.serverUrl
-                ) ?: 0
+                val userCount = (conversation.data as? RecipientData.Community)?.pollInfo?.activeUsers
+                    ?: 0
                 application.resources.getQuantityString(R.plurals.membersActive, userCount, userCount)
             } else {
-                val userCount = if (conversation.isGroupV2Recipient) {
-                    storage.getMembers(conversation.address.toString()).size
+                val userCount = if (conversation.data is RecipientData.Group) {
+                    conversation.data.partial.members.size
                 } else { // legacy closed groups
                     groupDb.getGroupMemberAddresses(conversation.address.toGroupString(), true).size
                 }
@@ -585,7 +586,7 @@ class ConversationViewModel @AssistedInject constructor(
 
         // - For communities you must have write access to the community
         val allowedForCommunity = (recipient.isCommunityRecipient &&
-                (recipient.data as? RecipientData.Community)?.openGroup?.canWrite == true)
+                (recipient.data as? RecipientData.Community)?.pollInfo?.write == true)
 
         // - For blinded recipients you must be a contact of the recipient - without which you CAN
         // send them SMS messages - but they will not get through if the recipient does not have
@@ -1243,11 +1244,11 @@ class ConversationViewModel @AssistedInject constructor(
     private fun clearEmoji(emoji: String, messageId: MessageId){
         viewModelScope.launch(Dispatchers.Default) {
             reactionDb.deleteEmojiReactions(emoji, messageId)
-            openGroup?.let { openGroup ->
+            (address as? Address.Community)?.let { openGroup ->
                 lokiMessageDb.getServerID(messageId)?.let { serverId ->
                     OpenGroupApi.deleteAllReactions(
                         openGroup.room,
-                        openGroup.server,
+                        openGroup.serverUrl,
                         serverId,
                         emoji
                     )

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailsViewModel.kt
@@ -28,7 +28,6 @@ import network.loki.messenger.R
 import org.session.libsession.messaging.groups.LegacyGroupDeprecationManager
 import org.session.libsession.messaging.sending_receiving.attachments.DatabaseAttachment
 import org.session.libsession.utilities.Address
-import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsession.utilities.isLegacyGroup
 import org.session.libsession.utilities.recipients.Recipient
@@ -39,7 +38,6 @@ import org.thoughtcrime.securesms.ApplicationContext
 import org.thoughtcrime.securesms.MediaPreviewArgs
 import org.thoughtcrime.securesms.database.AttachmentDatabase
 import org.thoughtcrime.securesms.database.LokiMessageDatabase
-import org.thoughtcrime.securesms.database.LokiThreadDatabase
 import org.thoughtcrime.securesms.database.MmsSmsDatabase
 import org.thoughtcrime.securesms.database.RecipientRepository
 import org.thoughtcrime.securesms.database.ThreadDatabase
@@ -49,7 +47,8 @@ import org.thoughtcrime.securesms.database.model.MmsMessageRecord
 import org.thoughtcrime.securesms.mms.ImageSlide
 import org.thoughtcrime.securesms.mms.Slide
 import org.thoughtcrime.securesms.pro.ProStatusManager
-import org.thoughtcrime.securesms.pro.ProStatusManager.MessageProFeature.*
+import org.thoughtcrime.securesms.pro.ProStatusManager.MessageProFeature.AnimatedAvatar
+import org.thoughtcrime.securesms.pro.ProStatusManager.MessageProFeature.LongMessage
 import org.thoughtcrime.securesms.ui.GetString
 import org.thoughtcrime.securesms.ui.TitledText
 import org.thoughtcrime.securesms.util.AvatarUIData
@@ -76,7 +75,6 @@ class MessageDetailsViewModel @AssistedInject constructor(
     private val dateUtils: DateUtils,
     private val recipientRepository: RecipientRepository,
     private val proStatusManager: ProStatusManager,
-    private val configFactory: ConfigFactoryProtocol,
     private val upmFactory: UserProfileUtils.UserProfileUtilsFactory,
     attachmentDownloadHandlerFactory: AttachmentDownloadHandler.Factory,
 ) : ViewModel() {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/mention/MentionViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/mention/MentionViewModel.kt
@@ -105,10 +105,10 @@ class MentionViewModel @AssistedInject constructor(
                     else -> listOf(address.address)
                 }
 
-                val openGroup = (recipient.data as? RecipientData.Community)?.openGroup
+                val openGroup = (recipient.data as? RecipientData.Community)
 
                 val myId = if (openGroup != null) {
-                    requireNotNull(storage.getUserBlindedAccountId(openGroup.publicKey)).hexString
+                    requireNotNull(storage.getUserBlindedAccountId(openGroup.serverPubKey)).hexString
                 } else {
                     requireNotNull(storage.getUserPublicKey())
                 }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
@@ -49,7 +49,6 @@ import org.session.libsession.utilities.recipients.RecipientData
 import org.session.libsession.utilities.recipients.displayName
 import org.session.libsession.utilities.truncatedForDisplay
 import org.thoughtcrime.securesms.database.LokiAPIDatabase
-import org.thoughtcrime.securesms.database.LokiThreadDatabase
 import org.thoughtcrime.securesms.database.model.MessageId
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord

--- a/app/src/main/java/org/thoughtcrime/securesms/database/CommunityDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/CommunityDatabase.kt
@@ -1,0 +1,97 @@
+package org.thoughtcrime.securesms.database
+
+import android.content.Context
+import androidx.collection.LruCache
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import org.session.libsession.messaging.open_groups.OpenGroupApi
+import org.session.libsession.utilities.Address
+import org.session.libsignal.utilities.JsonUtil
+import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper
+import java.util.Optional
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+import kotlin.jvm.optionals.getOrNull
+
+@Singleton
+class CommunityDatabase @Inject constructor(
+    @ApplicationContext context: Context,
+    helper: Provider<SQLCipherOpenHelper>,
+) : Database(context, helper) {
+
+    private val cache = LruCache<Address.Community, Optional<OpenGroupApi.RoomPollInfo>>(24)
+
+    private val mutableChangeNotification = MutableSharedFlow<Address.Community>(
+        extraBufferCapacity = 24,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    val changeNotification: SharedFlow<Address.Community> get() = mutableChangeNotification
+
+    fun getRoomInfo(address: Address.Community): OpenGroupApi.RoomPollInfo? {
+        val existing = cache[address]
+
+        if (existing != null) {
+            return existing.getOrNull()
+        }
+
+        return readableDatabase.rawQuery("SELECT $COL_ROOM_INFO FROM $TABLE_NAME WHERE $COL_ADDRESS = ?", address)
+            .use { cursor ->
+                if (cursor.moveToNext()) {
+                    cursor.getString(0)?.let { text -> JsonUtil.fromJson(text, OpenGroupApi.RoomPollInfo::class.java) }
+                } else {
+                    null
+                }
+            }
+            .also {
+                cache.put(address, Optional.ofNullable(it))
+            }
+    }
+
+
+    fun patchRoomInfo(address: Address.Community, json: String) {
+        val sql = """
+            INSERT OR REPLACE INTO $TABLE_NAME ($COL_ADDRESS, $COL_ROOM_INFO) 
+                VALUES (
+                    ?, 
+                    json_patch(ifnull((SELECT $COL_ROOM_INFO FROM $TABLE_NAME WHERE $COL_ADDRESS = ?), "{}"), ?)
+                )
+            RETURNING $COL_ROOM_INFO"""
+
+        writableDatabase.rawQuery(sql, address, address, json).use { cursor ->
+            check(cursor.moveToNext()) {
+                "Unable to patch room info"
+            }
+            JsonUtil.fromJson(cursor.getString(0), OpenGroupApi.RoomPollInfo::class.java)
+        }.also {
+            if (cache[address] != it) {
+                cache.put(address, Optional.of(it))
+                mutableChangeNotification.tryEmit(address)
+            }
+        }
+    }
+
+    fun deleteRoomInfo(address: Address.Community) {
+        cache.put(address, Optional.empty()) // We know this item doesn't exist in the db which itself is also a cachable information
+        writableDatabase.delete(TABLE_NAME, "$COL_ADDRESS = ?", arrayOf(address.address))
+        mutableChangeNotification.tryEmit(address)
+    }
+
+
+    companion object {
+        private const val TABLE_NAME = "communities"
+
+        private const val COL_ADDRESS = "address"
+        private const val COL_ROOM_INFO = "room_info"
+
+        const val MIGRATE_CREATE_TABLE = """
+            CREATE TABLE $TABLE_NAME (
+                $COL_ADDRESS TEXT NOT NULL PRIMARY KEY COLLATE NOCASE,
+                $COL_ROOM_INFO TEXT
+            ) WITHOUT ROWID
+        """
+    }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/database/LokiAPIDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/LokiAPIDatabase.kt
@@ -71,7 +71,7 @@ class LokiAPIDatabase(context: Context, helper: Provider<SQLCipherOpenHelper>) :
         @JvmStatic val createLastDeletionServerIDTableCommand = "CREATE TABLE $lastDeletionServerIDTable ($lastDeletionServerIDTableIndex STRING PRIMARY KEY, $lastDeletionServerID INTEGER DEFAULT 0);"
         // User counts
         @Deprecated("This table is no longer used")
-        private val userCountTable = "loki_user_count_cache"
+        val userCountTable = "loki_user_count_cache"
         private val publicChatID = "public_chat_id"
         private val userCount = "user_count"
         @JvmStatic val createUserCountTableCommand = "CREATE TABLE $userCountTable ($publicChatID STRING PRIMARY KEY, $userCount INTEGER DEFAULT 0);"

--- a/app/src/main/java/org/thoughtcrime/securesms/database/LokiAPIDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/LokiAPIDatabase.kt
@@ -2,7 +2,6 @@ package org.thoughtcrime.securesms.database
 
 import android.content.ContentValues
 import android.content.Context
-import dagger.hilt.android.qualifiers.ApplicationContext
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.crypto.ecc.DjbECPrivateKey
 import org.session.libsignal.crypto.ecc.DjbECPublicKey
@@ -18,9 +17,7 @@ import org.session.libsignal.utilities.toHexString
 import org.thoughtcrime.securesms.crypto.IdentityKeyUtil
 import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper
 import java.util.Date
-import javax.inject.Inject
 import javax.inject.Provider
-import javax.inject.Singleton
 
 class LokiAPIDatabase(context: Context, helper: Provider<SQLCipherOpenHelper>) : Database(context, helper), LokiAPIDatabaseProtocol {
 
@@ -457,21 +454,6 @@ class LokiAPIDatabase(context: Context, helper: Provider<SQLCipherOpenHelper>) :
             )
             database.insertOrUpdate(LAST_LEGACY_MESSAGE_TABLE, values, LEGACY_THREAD_RECIPIENT_QUERY, wrap(threadRecipientAddress))
         }
-    }
-
-    fun getUserCount(room: String, server: String): Int? {
-        val database = readableDatabase
-        val index = "$server.$room"
-        return database.get(userCountTable, "$publicChatID = ?", wrap(index)) { cursor ->
-            cursor.getInt(userCount)
-        }?.toInt()
-    }
-
-    override fun setUserCount(room: String, server: String, newValue: Int) {
-        val database = writableDatabase
-        val index = "$server.$room"
-        val row = wrap(mapOf( publicChatID to index, userCount to newValue.toString() ))
-        database.insertOrUpdate(userCountTable, row, "$publicChatID = ?", wrap(index))
     }
 
     override fun getOpenGroupPublicKey(server: String): String? {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/LokiAPIDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/LokiAPIDatabase.kt
@@ -70,6 +70,7 @@ class LokiAPIDatabase(context: Context, helper: Provider<SQLCipherOpenHelper>) :
         private val lastDeletionServerID = "last_deletion_server_id"
         @JvmStatic val createLastDeletionServerIDTableCommand = "CREATE TABLE $lastDeletionServerIDTable ($lastDeletionServerIDTableIndex STRING PRIMARY KEY, $lastDeletionServerID INTEGER DEFAULT 0);"
         // User counts
+        @Deprecated("This table is no longer used")
         private val userCountTable = "loki_user_count_cache"
         private val publicChatID = "public_chat_id"
         private val userCount = "user_count"

--- a/app/src/main/java/org/thoughtcrime/securesms/database/LokiThreadDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/LokiThreadDatabase.kt
@@ -5,19 +5,11 @@ import android.content.Context
 import android.database.Cursor
 import androidx.collection.LruCache
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.takeWhile
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.session.libsession.messaging.open_groups.OpenGroup
+import org.session.libsession.utilities.Address
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper
 import javax.inject.Inject
@@ -77,6 +69,17 @@ class LokiThreadDatabase @Inject constructor(
         return result
     }
 
+    fun getOpenGroupChat(address: Address.Community): OpenGroup? {
+        return readableDatabase.rawQuery("SELECT $publicChat FROM $publicChatTable WHERE $publicChat ->> '$.server' = ? AND $publicChat ->> '$.room' = ?",
+            address.serverUrl, address.room).use { cursor ->
+                if (cursor.moveToNext()) {
+                    cursor.getString(0)?.let { text -> json.decodeFromString<OpenGroup>(text) }
+                } else {
+                    null
+                }
+        }
+    }
+
     fun getOpenGroupChat(threadID: Long): OpenGroup? {
         if (threadID < 0) {
             return null
@@ -124,23 +127,6 @@ class LokiThreadDatabase @Inject constructor(
 
         cacheByThreadId.remove(threadID)
         mutableChangeNotification.tryEmit(threadID)
-    }
-
-    /**
-     * Retrieves the OpenGroup for the given threadID and observes changes to it.
-     *
-     * If in the beginning the OpenGroup is not available, it returns null.
-     * If in the middle of the flow the OpenGroup is deleted, it will stop emitting updates.
-     */
-    fun retrieveAndObserveOpenGroup(scope: CoroutineScope, threadID: Long): StateFlow<OpenGroup>? {
-        val initialOpenGroup = getOpenGroupChat(threadID) ?: return null
-
-        return mutableChangeNotification
-            .filter { it == threadID }
-            .map { getOpenGroupChat(threadID)  }
-            .takeWhile { it != null }
-            .filterNotNull()
-            .stateIn(scope, SharingStarted.Eagerly, initialOpenGroup)
     }
 
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/LokiThreadDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/LokiThreadDatabase.kt
@@ -1,31 +1,11 @@
 package org.thoughtcrime.securesms.database
 
-import android.content.ContentValues
-import android.content.Context
-import android.database.Cursor
-import androidx.collection.LruCache
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.serialization.json.Json
-import org.session.libsession.messaging.open_groups.OpenGroup
-import org.session.libsession.utilities.Address
-import org.session.libsignal.utilities.Log
-import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper
-import javax.inject.Inject
-import javax.inject.Provider
-import javax.inject.Singleton
-
-@Singleton
-class LokiThreadDatabase @Inject constructor(
-    @ApplicationContext context: Context,
-    helper: Provider<SQLCipherOpenHelper>,
-    private val json: Json,
-) : Database(context, helper) {
+@Deprecated("Exist only for migration purposes")
+class LokiThreadDatabase {
 
     companion object {
         private val sessionResetTable = "loki_thread_session_reset_database"
-        private val publicChatTable = "loki_public_chat_database"
+        val publicChatTable = "loki_public_chat_database"
         val threadID = "thread_id"
         private val sessionResetStatus = "session_reset_status"
         val publicChat = "public_chat"
@@ -33,100 +13,6 @@ class LokiThreadDatabase @Inject constructor(
         val createSessionResetTableCommand = "CREATE TABLE $sessionResetTable ($threadID INTEGER PRIMARY KEY, $sessionResetStatus INTEGER DEFAULT 0);"
         @JvmStatic
         val createPublicChatTableCommand = "CREATE TABLE $publicChatTable ($threadID INTEGER PRIMARY KEY, $publicChat TEXT);"
-    }
-
-    private val mutableChangeNotification = MutableSharedFlow<Long>()
-
-    val changeNotification: SharedFlow<Long> get() = mutableChangeNotification
-
-    private val cacheByThreadId = LruCache<Long, OpenGroup>(32)
-
-    fun getAllOpenGroups(): Map<Long, OpenGroup> {
-        val database = readableDatabase
-        var cursor: Cursor? = null
-        val result = mutableMapOf<Long, OpenGroup>()
-        try {
-            cursor = database.rawQuery("select * from $publicChatTable", null)
-            while (cursor != null && cursor.moveToNext()) {
-                val threadID = cursor.getLong(threadID)
-                val string = cursor.getString(publicChat)
-                val openGroup = runCatching { json.decodeFromString<OpenGroup>(string) }
-                    .onFailure { Log.d("LokiThreadDatabase", "Error decoding open group json", it) }
-                    .getOrNull()
-                if (openGroup != null) result[threadID] = openGroup
-            }
-        } catch (e: Exception) {
-            // do nothing
-        } finally {
-            cursor?.close()
-        }
-
-        // Update the cache with the results
-        for ((id, group) in result) {
-            cacheByThreadId.put(id, group)
-        }
-
-        return result
-    }
-
-    fun getOpenGroupChat(address: Address.Community): OpenGroup? {
-        return readableDatabase.rawQuery("SELECT $publicChat FROM $publicChatTable WHERE $publicChat ->> '$.server' = ? AND $publicChat ->> '$.room' = ?",
-            address.serverUrl, address.room).use { cursor ->
-                if (cursor.moveToNext()) {
-                    cursor.getString(0)?.let { text -> json.decodeFromString<OpenGroup>(text) }
-                } else {
-                    null
-                }
-        }
-    }
-
-    fun getOpenGroupChat(threadID: Long): OpenGroup? {
-        if (threadID < 0) {
-            return null
-        }
-
-        // Check the cache first
-        cacheByThreadId[threadID]?.let {
-            return it
-        }
-
-        val database = readableDatabase
-        return database.get(publicChatTable, "${Companion.threadID} = ?", arrayOf(threadID.toString())) { cursor ->
-            runCatching { json.decodeFromString<OpenGroup>(cursor.getString(publicChat)) }
-                .onFailure { Log.d("LokiThreadDatabase", "Error decoding open group json", it) }
-                .getOrNull()
-        }
-    }
-
-    fun setOpenGroupChat(openGroup: OpenGroup, threadID: Long) {
-        if (threadID < 0) {
-            return
-        }
-
-        // Check if the group has really changed
-        val cache = cacheByThreadId[threadID]
-        if (cache == openGroup) {
-            return
-        } else {
-            cacheByThreadId.put(threadID, openGroup)
-        }
-
-        val database = writableDatabase
-        val contentValues = ContentValues(2)
-        contentValues.put(Companion.threadID, threadID)
-        contentValues.put(publicChat, json.encodeToString(openGroup))
-        database.insertOrUpdate(publicChatTable, contentValues, "${Companion.threadID} = ?", arrayOf(threadID.toString()))
-        mutableChangeNotification.tryEmit(threadID)
-    }
-
-    fun removeOpenGroupChat(threadID: Long) {
-        if (threadID < 0) return
-
-        val database = writableDatabase
-        database.delete(publicChatTable,"${Companion.threadID} = ?", arrayOf(threadID.toString()))
-
-        cacheByThreadId.remove(threadID)
-        mutableChangeNotification.tryEmit(threadID)
     }
 
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientRepository.kt
@@ -1,7 +1,6 @@
 package org.thoughtcrime.securesms.database
 
 import androidx.collection.LruCache
-import dagger.Lazy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -25,7 +24,6 @@ import network.loki.messenger.libsession_util.ConfigBase.Companion.PRIORITY_VISI
 import network.loki.messenger.libsession_util.ReadableGroupInfoConfig
 import network.loki.messenger.libsession_util.util.ExpiryMode
 import network.loki.messenger.libsession_util.util.GroupInfo
-import org.session.libsession.database.StorageProtocol
 import org.session.libsession.messaging.open_groups.GroupMemberRole
 import org.session.libsession.messaging.open_groups.OpenGroupApi
 import org.session.libsession.utilities.Address
@@ -114,12 +112,7 @@ class RecipientRepository @Inject constructor(
                     settingsFetcher = {
                         withContext(Dispatchers.Default) { recipientSettingsDatabase.getSettings(it) }
                     },
-                    communityFetcher = {
-                        withContext(Dispatchers.Default) { communityDatabase.getRoomInfo(it) }
-                    },
-                    fetchGroupMemberRoles = { groupId ->
-                        withContext(Dispatchers.Default) { groupMemberDatabase.getGroupMembers(groupId) }
-                    }
+                    communityFetcher = { withContext(Dispatchers.Default) { communityDatabase.getRoomInfo(it) } }
                 )
 
                 emit(value)
@@ -144,7 +137,6 @@ class RecipientRepository @Inject constructor(
         address: Address,
         settingsFetcher: (Address) -> RecipientSettings,
         communityFetcher: (Address.Community) -> OpenGroupApi.RoomInfo?,
-        fetchGroupMemberRoles: (Address.Community) -> Map<AccountId, GroupMemberRole>,
     ): Pair<Recipient, Flow<*>> {
         val recipientData =
             address.toBlinded()?.let { blindedIdMappingRepository.findMappings(it).firstOrNull()?.second }
@@ -365,8 +357,7 @@ class RecipientRepository @Inject constructor(
         return fetchRecipient(
             address = address,
             settingsFetcher = recipientSettingsDatabase::getSettings,
-            communityFetcher = communityDatabase::getRoomInfo,
-            fetchGroupMemberRoles = groupMemberDatabase::getGroupMembers
+            communityFetcher = communityDatabase::getRoomInfo
         ).first
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientRepository.kt
@@ -254,9 +254,8 @@ class RecipientRepository @Inject constructor(
                             ?: createGenericRecipient(address, settings)
 
                         changeSource = merge(
-                            lokiThreadDatabase.changeNotification,
                             recipientSettingsDatabase.changeNotification.filter { it == address },
-                            groupMemberDatabase.changeNotification.filter { it == address },
+                            communityDatabase.changeNotification.filter { it == address },
                             configFactory.userConfigsChanged(onlyConfigTypes = EnumSet.of(UserConfigType.USER_GROUPS)),
                         )
                     }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -243,9 +243,9 @@ open class Storage @Inject constructor(
             is Address.Community -> {
                 val og = recipient.data as? RecipientData.Community ?: return null
                 config.getOrConstructCommunity(
-                    baseUrl = og.openGroup.server,
-                    room = og.openGroup.room,
-                    pubKeyHex = og.openGroup.publicKey,
+                    baseUrl = recipient.address.serverUrl,
+                    room = recipient.address.room,
+                    pubKeyHex = og.serverPubKey,
                 )
             }
             is Address.CommunityBlindedId -> {
@@ -452,10 +452,6 @@ open class Storage @Inject constructor(
 
     override fun setLastDeletionServerID(room: String, server: String, newValue: Long) {
         lokiAPIDatabase.setLastDeletionServerID(room, server, newValue)
-    }
-
-    override fun setUserCount(room: String, server: String, newValue: Int) {
-        lokiAPIDatabase.setUserCount(room, server, newValue)
     }
 
     override fun setOpenGroupServerMessageID(messageID: MessageId, serverID: Long, threadID: Long) {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -21,7 +21,6 @@ import org.session.libsession.messaging.jobs.Job
 import org.session.libsession.messaging.jobs.JobQueue
 import org.session.libsession.messaging.jobs.MessageSendJob
 import org.session.libsession.messaging.messages.Message
-import org.session.libsession.messaging.messages.ProfileUpdateHandler
 import org.session.libsession.messaging.messages.control.GroupUpdated
 import org.session.libsession.messaging.messages.signal.IncomingEncryptedMessage
 import org.session.libsession.messaging.messages.signal.IncomingGroupMessage
@@ -34,7 +33,6 @@ import org.session.libsession.messaging.messages.visible.Attachment
 import org.session.libsession.messaging.messages.visible.Profile
 import org.session.libsession.messaging.messages.visible.Reaction
 import org.session.libsession.messaging.messages.visible.VisibleMessage
-import org.session.libsession.messaging.open_groups.OpenGroup
 import org.session.libsession.messaging.sending_receiving.attachments.AttachmentId
 import org.session.libsession.messaging.sending_receiving.attachments.DatabaseAttachment
 import org.session.libsession.messaging.sending_receiving.data_extraction.DataExtractionNotificationInfoMessage
@@ -97,16 +95,13 @@ open class Storage @Inject constructor(
     private val mmsSmsDatabase: MmsSmsDatabase,
     private val mmsDatabase: MmsDatabase,
     private val smsDatabase: SmsDatabase,
-    private val groupMemberDatabase: GroupMemberDatabase,
     private val reactionDatabase: ReactionDatabase,
-    private val lokiThreadDatabase: LokiThreadDatabase,
     private val notificationManager: MessageNotifier,
     private val messageDataProvider: MessageDataProvider,
     private val clock: SnodeClock,
     private val preferences: TextSecurePreferences,
     private val openGroupManager: Lazy<OpenGroupManager>,
     private val recipientRepository: RecipientRepository,
-    private val profileUpdateHandler: ProfileUpdateHandler,
 ) : Database(context, helper), StorageProtocol {
 
     override fun getUserPublicKey(): String? { return preferences.getLocalNumber() }
@@ -265,17 +260,18 @@ open class Storage @Inject constructor(
     }
 
     override fun persist(
+        threadRecipient: Recipient,
         message: VisibleMessage,
         quotes: QuoteModel?,
         linkPreview: List<LinkPreview?>,
-        fromGroup: Address.GroupLike?,
         attachments: List<Attachment>,
         runThreadUpdate: Boolean
     ): MessageId? {
         val messageID: MessageId?
         val senderAddress = fromSerialized(message.sender!!)
         val isUserSender = (message.sender!! == getUserPublicKey())
-        val isUserBlindedSender = message.threadID?.takeIf { it >= 0 }?.let(::getOpenGroup)?.publicKey
+        val isUserBlindedSender = (threadRecipient.data as? RecipientData.Community)
+            ?.serverPubKey
             ?.let {
                 BlindKeyAPI.sessionIdMatchesBlindedId(
                     sessionId = getUserPublicKey()!!,
@@ -286,7 +282,7 @@ open class Storage @Inject constructor(
 
         val targetAddress = if ((isUserSender || isUserBlindedSender) && !message.syncTarget.isNullOrEmpty()) {
             message.syncTarget!!.toAddress()
-        } else fromGroup ?: senderAddress
+        } else (threadRecipient.address as? Address.Group) ?: senderAddress
 
         if (message.threadID == null && !targetAddress.isCommunity) {
             // open group recipients should explicitly create threads
@@ -331,7 +327,7 @@ open class Storage @Inject constructor(
                 val signalServiceAttachments = attachments.mapNotNull {
                     it.toSignalPointer()
                 }
-                val mediaMessage = IncomingMediaMessage.from(message, senderAddress, expiresInMillis, expireStartedAt, Optional.fromNullable(fromGroup), signalServiceAttachments, quote, linkPreviews)
+                val mediaMessage = IncomingMediaMessage.from(message, senderAddress, expiresInMillis, expireStartedAt, Optional.fromNullable(threadRecipient.address as? Address.GroupLike), signalServiceAttachments, quote, linkPreviews)
                 mmsDatabase.insertSecureDecryptedMessageInbox(mediaMessage, message.threadID!!, message.receivedTimestamp ?: 0, runThreadUpdate)
             }
 
@@ -346,7 +342,7 @@ open class Storage @Inject constructor(
                 smsDatabase.insertMessageOutbox(message.threadID ?: -1, textMessage, message.sentTimestamp!!, runThreadUpdate)
             } else {
                 val textMessage = if (isOpenGroupInvitation) IncomingTextMessage.fromOpenGroupInvitation(message.openGroupInvitation, senderAddress, message.sentTimestamp, expiresInMillis, expireStartedAt)
-                else IncomingTextMessage.from(message, senderAddress, Optional.fromNullable(fromGroup), expiresInMillis, expireStartedAt)
+                else IncomingTextMessage.from(message, senderAddress, Optional.fromNullable(threadRecipient.address as? Address.GroupLike), expiresInMillis, expireStartedAt)
                 val encrypted = IncomingEncryptedMessage(textMessage, textMessage.messageBody)
                 smsDatabase.insertMessageInbox(encrypted, message.receivedTimestamp ?: 0, runThreadUpdate)
             }
@@ -423,14 +419,6 @@ open class Storage @Inject constructor(
         lokiAPIDatabase.setAuthToken(id, null)
     }
 
-    override fun getOpenGroup(threadId: Long): OpenGroup? {
-        return lokiThreadDatabase.getOpenGroupChat(threadId)
-    }
-
-    override fun getOpenGroup(address: Address): OpenGroup? {
-        return getThreadId(address)?.let(lokiThreadDatabase::getOpenGroupChat)
-    }
-
     override fun getOpenGroupPublicKey(server: String): String? {
         return configFactory.withUserConfigs { it.userGroups.allCommunityInfo() }
             .firstOrNull { it.community.baseUrl == server }
@@ -457,10 +445,6 @@ open class Storage @Inject constructor(
     override fun setOpenGroupServerMessageID(messageID: MessageId, serverID: Long, threadID: Long) {
         lokiMessageDatabase.setServerID(messageID, serverID)
         lokiMessageDatabase.setOriginalThreadID(messageID.id, serverID, threadID)
-    }
-
-    override fun getOpenGroup(room: String, server: String): OpenGroup? {
-        return getAllOpenGroups().values.firstOrNull { it.server == server && it.room == room }
     }
 
     override fun isDuplicateMessage(timestamp: Long): Boolean {
@@ -837,10 +821,6 @@ open class Storage @Inject constructor(
         return lokiAPIDatabase.getServerCapabilities(server)
     }
 
-    override fun getAllOpenGroups(): Map<Long, OpenGroup> {
-        return lokiThreadDatabase.getAllOpenGroups()
-    }
-
     override fun getAllGroups(includeInactive: Boolean): List<GroupRecord> {
         return groupDatabase.getAllGroups(includeInactive)
     }
@@ -966,13 +946,10 @@ open class Storage @Inject constructor(
                 }
 
                 is Address.Community -> {
-                    val openGroup = getOpenGroup(address) ?: return@withMutableUserConfigs
-                    val newGroupInfo = configs.userGroups.getOrConstructCommunityInfo(
-                        baseUrl = openGroup.server,
-                        room = openGroup.room,
-                        pubKeyHex = openGroup.publicKey,
-                    ).copy(priority = pinPriority)
-                    configs.userGroups.set(newGroupInfo)
+                    configs.userGroups.getCommunityInfo(baseUrl = address.serverUrl, room = address.room)
+                        ?.let {
+                            configs.userGroups.set(it.copy(priority = pinPriority))
+                        }
                 }
 
                 else -> {}

--- a/app/src/main/java/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
@@ -15,6 +15,7 @@ import org.session.libsignal.utilities.Log;
 import org.thoughtcrime.securesms.crypto.DatabaseSecret;
 import org.thoughtcrime.securesms.database.AttachmentDatabase;
 import org.thoughtcrime.securesms.database.BlindedIdMappingDatabase;
+import org.thoughtcrime.securesms.database.CommunityDatabase;
 import org.thoughtcrime.securesms.database.ConfigDatabase;
 import org.thoughtcrime.securesms.database.DraftDatabase;
 import org.thoughtcrime.securesms.database.EmojiSearchDatabase;
@@ -92,9 +93,10 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper {
   private static final int lokiV50                          = 71;
   private static final int lokiV51                          = 72;
   private static final int lokiV52                          = 73;
+  private static final int lokiV53                          = 74;
 
   // Loki - onUpgrade(...) must be updated to use Loki version numbers if Signal makes any database changes
-  private static final int    DATABASE_VERSION         = lokiV52;
+  private static final int    DATABASE_VERSION         = lokiV53;
   private static final int    MIN_DATABASE_VERSION     = lokiV7;
   public static final String  DATABASE_NAME            = "session.db";
 
@@ -244,6 +246,8 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper {
     db.execSQL(ExpirationConfigurationDatabase.DROP_TABLE_COMMAND);
     db.execSQL(SessionContactDatabase.getDropTableCommand());
     executeStatements(db, ThreadDatabase.CREATE_ADDRESS_INDEX);
+
+    db.execSQL(CommunityDatabase.MIGRATE_CREATE_TABLE);
   }
 
   @Override
@@ -562,6 +566,10 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper {
         db.execSQL(ExpirationConfigurationDatabase.DROP_TABLE_COMMAND);
         db.execSQL(SessionContactDatabase.getDropTableCommand());
         executeStatements(db, ThreadDatabase.CREATE_ADDRESS_INDEX);
+      }
+
+      if (oldVersion < lokiV53) {
+        db.execSQL(CommunityDatabase.MIGRATE_CREATE_TABLE);
       }
 
       db.setTransactionSuccessful();

--- a/app/src/main/java/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/helpers/SQLCipherOpenHelper.java
@@ -29,6 +29,7 @@ import org.thoughtcrime.securesms.database.LokiMessageDatabase;
 import org.thoughtcrime.securesms.database.LokiThreadDatabase;
 import org.thoughtcrime.securesms.database.LokiUserDatabase;
 import org.thoughtcrime.securesms.database.MmsDatabase;
+import org.thoughtcrime.securesms.database.MmsSmsDatabase;
 import org.thoughtcrime.securesms.database.PushDatabase;
 import org.thoughtcrime.securesms.database.ReactionDatabase;
 import org.thoughtcrime.securesms.database.RecipientDatabase;
@@ -97,10 +98,9 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper {
   private static final int lokiV50                          = 71;
   private static final int lokiV51                          = 72;
   private static final int lokiV52                          = 73;
-  private static final int lokiV53                          = 74;
 
   // Loki - onUpgrade(...) must be updated to use Loki version numbers if Signal makes any database changes
-  private static final int    DATABASE_VERSION         = lokiV53;
+  private static final int    DATABASE_VERSION         = lokiV52;
   private static final int    MIN_DATABASE_VERSION     = lokiV7;
   public static final String  DATABASE_NAME            = "session.db";
 
@@ -566,6 +566,7 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper {
         // the pre-migrated thread data.
         RecipientDatabase.migrateOldCommunityAddresses(db);
         ThreadDatabase.migrateLegacyCommunityAddresses(db);
+        MmsSmsDatabase.migrateLegacyCommunityAddresses(db);
 
         executeStatements(db, RecipientSettingsDatabase.Companion.getMIGRATION_CREATE_TABLE());
         db.execSQL(RecipientSettingsDatabase.MIGRATE_MOVE_DATA_FROM_OLD_TABLE);
@@ -575,9 +576,7 @@ public class SQLCipherOpenHelper extends SQLiteOpenHelper {
         db.execSQL(ExpirationConfigurationDatabase.DROP_TABLE_COMMAND);
         db.execSQL(SessionContactDatabase.getDropTableCommand());
         executeStatements(db, ThreadDatabase.CREATE_ADDRESS_INDEX);
-      }
 
-      if (oldVersion < lokiV53) {
         db.execSQL(CommunityDatabase.MIGRATE_CREATE_TABLE);
         CommunityDatabase.Companion.migrateFromOldTables(jsonProvider.get(), db);
         executeStatements(db, CommunityDatabase.Companion.getMIGRATE_DROP_OLD_TABLES());

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/AppModule.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/AppModule.kt
@@ -36,6 +36,7 @@ class AppModule {
     fun provideJson(modules: Set<@JvmSuppressWildcards SerializersModule>): Json {
         return Json {
             ignoreUnknownKeys = true
+            isLenient = true
             serializersModule += SerializersModule {
                 modules.forEach { include(it) }
             }

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/DatabaseComponent.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/DatabaseComponent.kt
@@ -37,7 +37,6 @@ interface DatabaseComponent {
     fun searchDatabase(): SearchDatabase
     fun lokiAPIDatabase(): LokiAPIDatabase
     fun lokiMessageDatabase(): LokiMessageDatabase
-    fun lokiThreadDatabase(): LokiThreadDatabase
     fun lokiUserDatabase(): LokiUserDatabase
     fun lokiBackupFilesDatabase(): LokiBackupFilesDatabase
     fun sessionJobDatabase(): SessionJobDatabase

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/DatabaseModule.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/DatabaseModule.kt
@@ -22,7 +22,6 @@ import org.thoughtcrime.securesms.database.GroupReceiptDatabase
 import org.thoughtcrime.securesms.database.LokiAPIDatabase
 import org.thoughtcrime.securesms.database.LokiBackupFilesDatabase
 import org.thoughtcrime.securesms.database.LokiMessageDatabase
-import org.thoughtcrime.securesms.database.LokiThreadDatabase
 import org.thoughtcrime.securesms.database.LokiUserDatabase
 import org.thoughtcrime.securesms.database.MediaDatabase
 import org.thoughtcrime.securesms.database.MmsSmsDatabase

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -570,7 +570,7 @@ class HomeActivity : ScreenLockActionBarActivity(),
                 Toast.makeText(this, R.string.copied, Toast.LENGTH_SHORT).show()
             }
             else if (threadRecipient.data is RecipientData.Community) {
-                val clip = ClipData.newPlainText("Community URL", threadRecipient.data.openGroup.joinURL)
+                val clip = ClipData.newPlainText("Community URL", threadRecipient.data.joinURL)
                 val manager = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
                 manager.setPrimaryClip(clip)
                 Toast.makeText(this, R.string.copied, Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -59,7 +59,6 @@ import org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2
 import org.thoughtcrime.securesms.conversation.v2.settings.notification.NotificationSettingsActivity
 import org.thoughtcrime.securesms.crypto.IdentityKeyUtil
 import org.thoughtcrime.securesms.database.GroupDatabase
-import org.thoughtcrime.securesms.database.LokiThreadDatabase
 import org.thoughtcrime.securesms.database.MmsSmsDatabase
 import org.thoughtcrime.securesms.database.RecipientRepository
 import org.thoughtcrime.securesms.database.Storage
@@ -83,8 +82,8 @@ import org.thoughtcrime.securesms.reviews.ui.InAppReview
 import org.thoughtcrime.securesms.reviews.ui.InAppReviewViewModel
 import org.thoughtcrime.securesms.showSessionDialog
 import org.thoughtcrime.securesms.tokenpage.TokenPageNotificationManager
-import org.thoughtcrime.securesms.ui.components.Avatar
 import org.thoughtcrime.securesms.ui.UINavigator
+import org.thoughtcrime.securesms.ui.components.Avatar
 import org.thoughtcrime.securesms.ui.setThemedContent
 import org.thoughtcrime.securesms.ui.theme.LocalDimensions
 import org.thoughtcrime.securesms.util.AvatarUtils
@@ -123,7 +122,6 @@ class HomeActivity : ScreenLockActionBarActivity(),
     @Inject lateinit var tokenPageNotificationManager: TokenPageNotificationManager
     @Inject lateinit var groupManagerV2: GroupManagerV2
     @Inject lateinit var deprecationManager: LegacyGroupDeprecationManager
-    @Inject lateinit var lokiThreadDatabase: LokiThreadDatabase
     @Inject lateinit var clock: SnodeClock
     @Inject lateinit var messageNotifier: MessageNotifier
     @Inject lateinit var dateUtils: DateUtils

--- a/app/src/main/java/org/thoughtcrime/securesms/migration/DatabaseMigrationManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/migration/DatabaseMigrationManager.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
 import net.zetetic.database.sqlcipher.SQLiteConnection
 import net.zetetic.database.sqlcipher.SQLiteDatabase
 import net.zetetic.database.sqlcipher.SQLiteDatabaseHook
@@ -21,6 +22,7 @@ import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper
 import org.thoughtcrime.securesms.dependencies.ManagerScope
 import org.thoughtcrime.securesms.dependencies.OnAppStartupComponent
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @Singleton
@@ -28,6 +30,7 @@ class DatabaseMigrationManager @Inject constructor(
     private val application: Application,
     private val prefs: TextSecurePreferences,
     private val databaseSecretProvider: DatabaseSecretProvider,
+    jsonProvider: Provider<Json>,
     @param:ManagerScope private val scope: CoroutineScope,
 ) : OnAppStartupComponent {
     private val dbSecret by lazy {
@@ -49,7 +52,7 @@ class DatabaseMigrationManager @Inject constructor(
             }
         }
 
-        SQLCipherOpenHelper(application, dbSecret)
+        SQLCipherOpenHelper(application, dbSecret, jsonProvider)
     }
 
     private val mutableMigrationState = MutableStateFlow<MigrationState>(MigrationState.Idle)

--- a/app/src/main/java/org/thoughtcrime/securesms/repository/ConversationRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/repository/ConversationRepository.kt
@@ -41,13 +41,13 @@ import org.session.libsession.utilities.isGroupV2
 import org.session.libsession.utilities.isLegacyGroup
 import org.session.libsession.utilities.isStandard
 import org.session.libsession.utilities.recipients.Recipient
+import org.session.libsession.utilities.recipients.RecipientData
 import org.session.libsession.utilities.upsertContact
 import org.session.libsession.utilities.userConfigsChanged
 import org.session.libsignal.utilities.AccountId
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.database.DraftDatabase
 import org.thoughtcrime.securesms.database.LokiMessageDatabase
-import org.thoughtcrime.securesms.database.LokiThreadDatabase
 import org.thoughtcrime.securesms.database.MmsSmsDatabase
 import org.thoughtcrime.securesms.database.RecipientRepository
 import org.thoughtcrime.securesms.database.RecipientSettingsDatabase
@@ -80,7 +80,7 @@ interface ConversationRepository {
     fun saveDraft(threadId: Long, text: String)
     fun getDraft(threadId: Long): String?
     fun clearDrafts(threadId: Long)
-    fun inviteContactsToCommunity(threadId: Long, contacts: Collection<Address>)
+    fun inviteContactsToCommunity(communityRecipient: Recipient, contacts: Collection<Address>)
     fun setBlocked(recipient: Address, blocked: Boolean)
     fun markAsDeletedLocally(messages: Set<MessageRecord>, displayedMessage: String)
     fun deleteMessages(messages: Set<MessageRecord>)
@@ -133,7 +133,6 @@ class DefaultConversationRepository @Inject constructor(
     private val messageDataProvider: MessageDataProvider,
     private val threadDb: ThreadDatabase,
     private val draftDb: DraftDatabase,
-    private val lokiThreadDb: LokiThreadDatabase,
     private val smsDb: SmsDatabase,
     private val mmsSmsDb: MmsSmsDatabase,
     private val storage: Storage,
@@ -247,14 +246,18 @@ class DefaultConversationRepository @Inject constructor(
         draftDb.clearDrafts(threadId)
     }
 
-    override fun inviteContactsToCommunity(threadId: Long, contacts: Collection<Address>) {
-        val openGroup = lokiThreadDb.getOpenGroupChat(threadId) ?: return
+    override fun inviteContactsToCommunity(
+        communityRecipient: Recipient,
+        contacts: Collection<Address>
+    ) {
+        val community = communityRecipient.data as? RecipientData.Community
+        val info = community?.roomInfo ?: return
         for (contact in contacts) {
             val message = VisibleMessage()
             message.sentTimestamp = clock.currentTimeMills()
             val openGroupInvitation = OpenGroupInvitation().apply {
-                name = openGroup.name
-                url = openGroup.joinURL
+                name = info.details.name
+                url = community.joinURL
             }
             message.openGroupInvitation = openGroupInvitation
             val contactThreadId = threadDb.getOrCreateThreadIdFor(contact)

--- a/app/src/main/java/org/thoughtcrime/securesms/repository/ConversationRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/repository/ConversationRepository.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.withContext
 import network.loki.messenger.libsession_util.util.ExpiryMode
 import network.loki.messenger.libsession_util.util.GroupInfo
+import nl.komponents.kovenant.all
 import org.session.libsession.database.MessageDataProvider
 import org.session.libsession.database.userAuth
 import org.session.libsession.messaging.groups.GroupManagerV2
@@ -46,6 +47,7 @@ import org.session.libsession.utilities.upsertContact
 import org.session.libsession.utilities.userConfigsChanged
 import org.session.libsignal.utilities.AccountId
 import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.database.CommunityDatabase
 import org.thoughtcrime.securesms.database.DraftDatabase
 import org.thoughtcrime.securesms.database.LokiMessageDatabase
 import org.thoughtcrime.securesms.database.MmsSmsDatabase
@@ -132,6 +134,7 @@ class DefaultConversationRepository @Inject constructor(
     private val textSecurePreferences: TextSecurePreferences,
     private val messageDataProvider: MessageDataProvider,
     private val threadDb: ThreadDatabase,
+    private val communityDatabase: CommunityDatabase,
     private val draftDb: DraftDatabase,
     private val smsDb: SmsDatabase,
     private val mmsSmsDb: MmsSmsDatabase,
@@ -214,7 +217,8 @@ class DefaultConversationRepository @Inject constructor(
             .flatMapLatest { allAddresses ->
                 merge(
                     configFactory.configUpdateNotifications,
-                    recipientDatabase.changeNotification,
+                    recipientDatabase.changeNotification.filter { it in allAddresses },
+                    communityDatabase.changeNotification.filter { it in allAddresses },
                     threadDb.updateNotifications
                 ).debounce(500)
                     .onStart { emit(Unit) }

--- a/app/src/test/java/org/thoughtcrime/securesms/conversation/disappearingmessages/DisappearingMessagesViewModelTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/conversation/disappearingmessages/DisappearingMessagesViewModelTest.kt
@@ -6,7 +6,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import network.loki.messenger.R
+import network.loki.messenger.libsession_util.util.Bytes
 import network.loki.messenger.libsession_util.util.ExpiryMode
+import network.loki.messenger.libsession_util.util.GroupInfo
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -96,13 +98,20 @@ class DisappearingMessagesViewModelTest : BaseViewModelTest() {
                     name = "Group Name",
                     avatar = null,
                     expiryMode = ExpiryMode.NONE,
-                    approved = true,
-                    priority = 1,
-                    isAdmin = true,
-                    destroyed = false,
-                    kicked = false,
+                    groupInfo = GroupInfo.ClosedGroupInfo(
+                        groupAccountId = GROUP_ADDRESS.address,
+                        adminKey = Bytes(ByteArray(32)),
+                        authData = Bytes(ByteArray(32)),
+                        priority = 1,
+                        invited = false,
+                        name = "Group Name",
+                        kicked = false,
+                        destroyed = false,
+                        joinedAtSecs = System.currentTimeMillis() / 1000L,
+                    ),
                     proStatus = ProStatus.None,
-                    members = listOf()
+                    members = listOf(),
+                    description = null,
                 ),
                 firstMember = Recipient(
                     address = STANDARD_ADDRESS,
@@ -166,13 +175,20 @@ class DisappearingMessagesViewModelTest : BaseViewModelTest() {
                     name = "Group Name",
                     avatar = null,
                     expiryMode = ExpiryMode.NONE,
-                    approved = true,
-                    priority = 1,
-                    isAdmin = false,
-                    destroyed = false,
-                    kicked = false,
+                    groupInfo = GroupInfo.ClosedGroupInfo(
+                        groupAccountId = GROUP_ADDRESS.address,
+                        adminKey = null,
+                        authData = Bytes(ByteArray(32)),
+                        priority = 1,
+                        invited = false,
+                        name = "Group Name",
+                        kicked = false,
+                        destroyed = false,
+                        joinedAtSecs = System.currentTimeMillis() / 1000L,
+                    ),
                     proStatus = ProStatus.None,
-                    members = listOf()
+                    members = listOf(),
+                    description = null,
                 ),
                 firstMember = Recipient(
                     address = STANDARD_ADDRESS,

--- a/app/src/test/java/org/thoughtcrime/securesms/conversation/v2/MentionViewModelTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/conversation/v2/MentionViewModelTest.kt
@@ -21,6 +21,7 @@ import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import org.session.libsession.messaging.open_groups.GroupMemberRole
 import org.session.libsession.messaging.open_groups.OpenGroup
+import org.session.libsession.messaging.open_groups.OpenGroupApi
 import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.Address.Companion.toAddress
 import org.session.libsession.utilities.recipients.ProStatus
@@ -64,20 +65,22 @@ class MentionViewModelTest : BaseViewModelTest() {
         MemberInfo("李云海", "151234567890123456789012345678901234567890123456789012345678901240", GroupMemberRole.ZOOMBIE, isMe = false),
     )
 
-    private val openGroup = OpenGroup(
-        server = "http://url",
-        room = "room",
-        name = "Open Group",
-        publicKey = "",
-        imageId = null,
-        infoUpdates = 0,
-        canWrite = true,
-        description = ""
-    )
 
     private val communityRecipient = Recipient(
-        address = Address.Community(openGroup),
-        data = RecipientData.Community(openGroup = openGroup, priority = PRIORITY_VISIBLE, roles = threadMembers.associate { AccountId(it.pubKey) to it.role })
+        address = Address.Community(serverUrl = "http://link", room = "room"),
+        data = RecipientData.Community(roomInfo = OpenGroupApi.RoomInfo(
+            details = OpenGroupApi.RoomInfoDetails(
+                moderators = threadMembers.filter { it.role == GroupMemberRole.MODERATOR }.map { it.pubKey },
+                admins = threadMembers.filter { it.role == GroupMemberRole.ADMIN }.map { it.pubKey },
+                hiddenAdmins = threadMembers.filter { it.role == GroupMemberRole.HIDDEN_ADMIN }.map { it.pubKey },
+                hiddenModerators = threadMembers.filter { it.role == GroupMemberRole.HIDDEN_MODERATOR }.map { it.pubKey },
+            )
+        ),
+            serverUrl = "http://link",
+            room = "room",
+            serverPubKey = "a1b2",
+            priority = PRIORITY_VISIBLE
+        )
     )
 
     @Before
@@ -91,7 +94,6 @@ class MentionViewModelTest : BaseViewModelTest() {
             groupDatabase = mock {
             },
             storage = mock {
-                on { getOpenGroup(threadID) } doReturn openGroup
                 on { getUserBlindedAccountId(any()) } doReturn myId
                 on { getUserPublicKey() } doReturn myId.hexString
             },


### PR DESCRIPTION
This PR refactors the community info fetching so that:

1. We store the original json that sent from the server to db directly
2. We can apply the json patching to the existing data so we can always view the "latest" community info
3. Remove a lot of scattered data saving for community (like admin list, active user count, etc)