### PR TITLE
SES-4337 : Scroll to bottom ignores open keyboard

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -642,7 +642,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
                     // when showing the keyboard, we should auto scroll the conversation recyclerview
                     // if we are near the bottom (within 50dp of bottom)
                     if (binding.conversationRecyclerView.isNearBottom) {
-                        binding.conversationRecyclerView.smoothScrollToPosition(adapter.itemCount)
+                        binding.conversationRecyclerView.handleScrollToBottom()
                     }
                 }
             }
@@ -800,7 +800,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
                     // scrolled to bottom has a leniency of 50dp, so if we are within the 50dp but not fully at the bottom, scroll down
                     if (binding.conversationRecyclerView.isNearBottom && !binding.conversationRecyclerView.isFullyScrolled) {
                         val last = (adapter.itemCount - 1).coerceAtLeast(0)
-                        binding.conversationRecyclerView.smoothScrollToPosition(last)
+                        binding.conversationRecyclerView.handleScrollToBottom()
                     }
                 }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -796,7 +796,6 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
                     // If there are new data updated, we'll try to stay scrolled at the bottom (if we were at the bottom).
                     // scrolled to bottom has a leniency of 50dp, so if we are within the 50dp but not fully at the bottom, scroll down
                     if (binding.conversationRecyclerView.isNearBottom && !binding.conversationRecyclerView.isFullyScrolled) {
-                        val last = (adapter.itemCount - 1).coerceAtLeast(0)
                         binding.conversationRecyclerView.handleScrollToBottom()
                     }
                 }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -205,6 +205,8 @@ import org.thoughtcrime.securesms.util.FilenameUtils
 import org.thoughtcrime.securesms.util.MediaUtil
 import org.thoughtcrime.securesms.util.PaddedImageSpan
 import org.thoughtcrime.securesms.util.SaveAttachmentTask
+import org.thoughtcrime.securesms.util.adapter.applyImeBottomPadding
+import org.thoughtcrime.securesms.util.adapter.handleScrollToBottom
 import org.thoughtcrime.securesms.util.drawToBitmap
 import org.thoughtcrime.securesms.util.fadeIn
 import org.thoughtcrime.securesms.util.fadeOut
@@ -559,18 +561,9 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
         restoreDraftIfNeeded()
         setUpUiStateObserver()
 
+        binding.conversationRecyclerView.applyImeBottomPadding()
         binding.scrollToBottomButton.setOnClickListener {
-            val layoutManager = binding.conversationRecyclerView.layoutManager as LinearLayoutManager
-            val targetPosition = adapter.itemCount - 1
-
-            if (layoutManager.isSmoothScrolling) {
-                // Tapping while smooth scrolling is in progress will instantly jump to the bottom.
-                binding.conversationRecyclerView.scrollToPosition(targetPosition)
-            } else {
-                // First tap: smooth scroll
-                linearSmoothScroller.targetPosition = targetPosition
-                layoutManager.startSmoothScroll(linearSmoothScroller)
-            }
+            binding.conversationRecyclerView.handleScrollToBottom()
         }
 
         // in case a phone call is in progress, this banner is visible and should bring the user back to the call

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -561,7 +561,6 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
         restoreDraftIfNeeded()
         setUpUiStateObserver()
 
-        binding.conversationRecyclerView.applyImeBottomPadding()
         binding.scrollToBottomButton.setOnClickListener {
             binding.conversationRecyclerView.handleScrollToBottom()
         }
@@ -800,7 +799,8 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
                     // If there are new data updated, we'll try to stay scrolled at the bottom (if we were at the bottom).
                     // scrolled to bottom has a leniency of 50dp, so if we are within the 50dp but not fully at the bottom, scroll down
                     if (binding.conversationRecyclerView.isNearBottom && !binding.conversationRecyclerView.isFullyScrolled) {
-                        binding.conversationRecyclerView.smoothScrollToPosition(adapter.itemCount)
+                        val last = (adapter.itemCount - 1).coerceAtLeast(0)
+                        binding.conversationRecyclerView.smoothScrollToPosition(last)
                     }
                 }
 
@@ -821,6 +821,7 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
 
     // called from onCreate
     private fun setUpRecyclerView() {
+        binding.conversationRecyclerView.applyImeBottomPadding()
         binding.conversationRecyclerView.adapter = adapter
         val layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
         binding.conversationRecyclerView.layoutManager = layoutManager

--- a/app/src/main/java/org/thoughtcrime/securesms/util/adapter/RecyclerViewUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/adapter/RecyclerViewUtils.kt
@@ -1,0 +1,43 @@
+package org.thoughtcrime.securesms.util.adapter
+
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.LinearSmoothScroller
+import androidx.recyclerview.widget.RecyclerView
+import kotlin.math.max
+
+fun RecyclerView.applyImeBottomPadding() {
+    clipToPadding = false
+    ViewCompat.setOnApplyWindowInsetsListener(this) { v, insets ->
+        val system = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom
+        val ime = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+        v.updatePadding(bottom = max(system, ime))
+        insets
+    }
+}
+
+fun RecyclerView.handleScrollToBottom(){
+    val layoutManager = this.layoutManager as LinearLayoutManager
+    val last = this.adapter?.itemCount?.minus(1) ?: return
+    val bottomOffset = this.paddingBottom
+
+    if (layoutManager.isSmoothScrolling) {
+        // second tap = instant align
+        layoutManager.scrollToPositionWithOffset(last, bottomOffset)
+        return
+    }
+
+    val scroller = object : LinearSmoothScroller(this.context) {
+        override fun getVerticalSnapPreference() = SNAP_TO_END
+        override fun calculateDtToFit(
+            viewStart: Int, viewEnd: Int, boxStart: Int, boxEnd: Int, snapPreference: Int
+        ): Int {
+            // default SNAP_TO_END is (boxEnd - viewEnd); subtract padding so it clears the IME
+            return (boxEnd - viewEnd) - bottomOffset
+        }
+    }
+    scroller.targetPosition = last
+    layoutManager.startSmoothScroll(scroller)
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/util/adapter/RecyclerViewUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/adapter/RecyclerViewUtils.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.RecyclerView
 import kotlin.math.max
 
+// Makes sure that the recyclerView is scrolled to the bottom
 fun RecyclerView.applyImeBottomPadding() {
     clipToPadding = false
     ViewCompat.setOnApplyWindowInsetsListener(this) { v, insets ->
@@ -18,6 +19,7 @@ fun RecyclerView.applyImeBottomPadding() {
     }
 }
 
+// Handle scroll logic
 fun RecyclerView.handleScrollToBottom(){
     val layoutManager = this.layoutManager as LinearLayoutManager
     val last = this.adapter?.itemCount?.minus(1) ?: return


### PR DESCRIPTION
This PR fixes a scrolling issue when the soft keyboard is visible and pressing the _scroll to bottom button_.

This PR adds some extension functions:
`RecyclerView.applyImeBottomPadding()` that applies padding relative to the IME
`RecyclerView.handleScrollToBottom()` that handles the scrolling logic and respects the soft keyboard


https://github.com/user-attachments/assets/ecc44fda-5b01-4cf4-b0b1-982df44f7fc2

