### PR TITLE
SES-4497 : Blocked Contacts settings subtitle smaller font size than rest of the settings

### DIFF
--- a/app/src/main/res/layout/blocked_contacts_preference.xml
+++ b/app/src/main/res/layout/blocked_contacts_preference.xml
@@ -26,7 +26,7 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="?android:textColorTertiary"
+            android:textColor="?android:textColorSecondary"
             android:textSize="@dimen/medium_font_size"
             android:text="@string/blockedContactsManageDescription" />
     </LinearLayout>


### PR DESCRIPTION
[Fix for QA](https://optf.atlassian.net/browse/SES-4497?focusedCommentId=19442)

This PR updates _Blocked Contact_'s subtitle's text color to match with the other options.

<img width="300" height="500" alt="Screenshot 2025-09-03 at 9 58 24 AM" src="https://github.com/user-attachments/assets/61b15027-3d09-4846-b989-eed7bf17b7b6" />
<img width="300" height="500" alt="Screenshot 2025-09-03 at 9 58 45 AM" src="https://github.com/user-attachments/assets/79880979-fbd2-4b51-b679-1d082c3e3100" />
<img width="300" height="500" alt="Screenshot 2025-09-03 at 9 59 07 AM" src="https://github.com/user-attachments/assets/52c37337-1694-44d9-93cb-31c7389b5e56" />
<img width="300" height="500" alt="Screenshot 2025-09-03 at 9 59 39 AM" src="https://github.com/user-attachments/assets/5a6a5b3b-4a12-488e-bdbf-1ebcae30a991" />
