### PR TITLE
SES-4530 : Read more button not displayed on message in some cases

### DIFF
--- a/app/src/main/java/org/session/libsession/utilities/ViewUtils.kt
+++ b/app/src/main/java/org/session/libsession/utilities/ViewUtils.kt
@@ -73,5 +73,5 @@ fun TextView.needsCollapsing(
     builder.setJustificationMode(justificationMode)
 
     val layout = builder.build()
-    return layout.lineCount > maxLines
+    return layout.lineCount >= maxLines // make sure to count truncated last line (line after the max)
 }


### PR DESCRIPTION
This PR fixed an issue where "Read more" button will not appear. This is caused by a missing case where if we send 26 lines of text (threshold is 25), the last line gets truncated causing it to become 25 lines, which returns a false.

This PR adds a check for this case.