### PR TITLE
SES-4530 : Read more button not displayed on message in some cases

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -356,9 +356,13 @@ class VisibleMessageContentView : ConstraintLayout {
                 }
             }
 
+            val widthCap = binding.bodyTextView.maxWidth
+                .takeIf { it > 0 && it < Int.MAX_VALUE }
+                ?: resources.getDimensionPixelSize(R.dimen.max_bubble_width)
+
             // if the text was already manually expanded, we can skip this logic
             if(!isTextExpanded && binding.bodyTextView.needsCollapsing(
-                    availableWidthPx = context.resources.getDimensionPixelSize(R.dimen.max_bubble_width),
+                    availableWidthPx = widthCap,
                     maxLines = MAX_COLLAPSED_LINE_COUNT)
             ){
                 // show the "Read mode" button


### PR DESCRIPTION
[SES-4530](https://optf.atlassian.net/browse/SES-4530)

Previously, some messages were truncated at 26 lines but the “Read more” button didn’t appear. 

The previous code compared only the line count (e.g., lineCount > maxLines). If the text fit into exactly 25 lines in that measurement, the check returned false—even when the real TextView ellipsized the 25th line (i.e., truncation happened within the last line, not by creating a 26th line).

This PR makes the button appear when the TextView truly truncates, and decides visibility before first draw to avoid re-layout flicker.


https://github.com/user-attachments/assets/1a5b0265-c980-4828-b599-bc36b50c74c0

