### PR TITLE
SES-4515 : Calls settings dialog shows {session_foundation} placeholder instead of name

### DIFF
--- a/app/src/main/java/org/session/libsession/utilities/StringSubKeys.kt
+++ b/app/src/main/java/org/session/libsession/utilities/StringSubKeys.kt
@@ -56,4 +56,6 @@ object StringSubstitutionConstants {
     const val MONTHLY_PRICE_KEY: StringSubKey              = "monthly_price"
     const val PRICE_KEY: StringSubKey                      = "price"
     const val PERCENT_KEY: StringSubKey                    = "percent"
+
+    const val SESSION_FOUNDATION_KEY: StringSubKey         = "session_foundation"
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/CallToggleListener.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/CallToggleListener.kt
@@ -5,7 +5,9 @@ import androidx.fragment.app.Fragment
 import androidx.preference.Preference
 import com.squareup.phrase.Phrase
 import network.loki.messenger.R
+import org.session.libsession.utilities.NonTranslatableStringConstants.SESSION_FOUNDATION
 import org.session.libsession.utilities.StringSubstitutionConstants.APP_NAME_KEY
+import org.session.libsession.utilities.StringSubstitutionConstants.SESSION_FOUNDATION_KEY
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsession.utilities.TextSecurePreferences.Companion.setBooleanPreference
 import org.thoughtcrime.securesms.permissions.Permissions
@@ -20,10 +22,15 @@ internal class CallToggleListener(
     override fun onPreferenceChange(preference: Preference, newValue: Any): Boolean {
         if (newValue == false) return true
 
+
+        val text = Phrase.from(context.requireContext(), R.string.callsVoiceAndVideoModalDescription)
+            .put(SESSION_FOUNDATION_KEY, SESSION_FOUNDATION)
+            .format()
+
         // check if we've shown the info dialog and check for microphone permissions
         context.showSessionDialog {
             title(R.string.callsVoiceAndVideoBeta)
-            text(R.string.callsVoiceAndVideoModalDescription)
+            text(text)
             button(R.string.enable, R.string.AccessibilityId_enable) { requestMicrophonePermission() }
             cancelButton()
         }


### PR DESCRIPTION
[SES-4515](https://optf.atlassian.net/browse/SES-4515)

Fixed missing string substitution for `{session_foundation}`.

<img width="267" height="231" alt="Screenshot 2025-09-08 at 12 20 45 PM" src="https://github.com/user-attachments/assets/bc985cf6-f67a-4a11-a535-abda3fd562f0" />
