### PR TITLE
SES-4512 : Android: “Join Community” screen never shows Session-run communities (infinite loading)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/home/startconversation/community/JoinCommunityViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/startconversation/community/JoinCommunityViewModel.kt
@@ -51,6 +51,10 @@ class JoinCommunityViewModel @Inject constructor(
 
         viewModelScope.launch(Dispatchers.Default) {
             OpenGroupApi.defaultRooms.collect { defaultCommunities ->
+
+
+                Log.d("OpenGroupDebug", "VM received default rooms: ${defaultCommunities.size}")
+
                 _state.update { it.copy(defaultCommunities = State.Success(defaultCommunities)) }
             }
         }


### PR DESCRIPTION
Added fallback for serverPubKey.