### PR TITLE
SES-4560 : Message request acceptance - Control message doesn't show

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -1056,7 +1056,7 @@ open class Storage @Inject constructor(
             Optional.absent(),
             Optional.absent()
         )
-        mmsDatabase.insertSecureDecryptedMessageInbox(message, threadId, runThreadUpdate = false)
+        mmsDatabase.insertSecureDecryptedMessageInbox(message, threadId, runThreadUpdate = true)
     }
 
     override fun insertCallMessage(senderPublicKey: String, callMessageType: CallMessageType, sentTimestamp: Long) {


### PR DESCRIPTION
This PR fixes a issue with the control message for approving message requests by updating the thread after inserting the control message into the db.