### PR TITLE
SES-4533 : Crash when tapping “+” in message emoji reactions bar

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/reactions/any/ReactWithAnyEmojiDialogFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/reactions/any/ReactWithAnyEmojiDialogFragment.java
@@ -150,18 +150,18 @@ public final class ReactWithAnyEmojiDialogFragment extends BottomSheetDialogFrag
     callback.onReactWithAnyEmojiDialogDismissed();
   }
 
-    private void initializeViewModel() {
-        Bundle args = requireArguments();
-        final MessageId messageId = new MessageId(args.getLong(ARG_MESSAGE_ID), args.getBoolean(ARG_IS_MMS));
-        viewModel = new ViewModelProvider(
-                getViewModelStore(),
-                getDefaultViewModelProviderFactory(),
-                HiltViewModelExtensions.withCreationCallback(
-                        getDefaultViewModelCreationExtras(),
-                        (ReactWithAnyEmojiViewModel.Factory factory) -> factory.create(messageId)
-                )
-        ).get(ReactWithAnyEmojiViewModel.class);
-    }
+  private void initializeViewModel() {
+    Bundle args = requireArguments();
+    final MessageId messageId = new MessageId(args.getLong(ARG_MESSAGE_ID), args.getBoolean(ARG_IS_MMS));
+    viewModel = new ViewModelProvider(
+            getViewModelStore(),
+            getDefaultViewModelProviderFactory(),
+            HiltViewModelExtensions.withCreationCallback(
+                    getDefaultViewModelCreationExtras(),
+                    (ReactWithAnyEmojiViewModel.Factory factory) -> factory.create(messageId)
+            )
+    ).get(ReactWithAnyEmojiViewModel.class);
+  }
 
   @Override
   public void onEmojiSelected(String emoji) {

--- a/app/src/main/java/org/thoughtcrime/securesms/reactions/any/ReactWithAnyEmojiDialogFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/reactions/any/ReactWithAnyEmojiDialogFragment.java
@@ -33,9 +33,11 @@ import org.thoughtcrime.securesms.database.model.MessageRecord;
 import org.thoughtcrime.securesms.keyboard.emoji.KeyboardPageSearchView;
 import org.thoughtcrime.securesms.util.LifecycleDisposable;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import dagger.hilt.android.lifecycle.HiltViewModelExtensions;
 import network.loki.messenger.R;
 
+@AndroidEntryPoint
 public final class ReactWithAnyEmojiDialogFragment extends BottomSheetDialogFragment implements EmojiEventListener,
                                                                                                            EmojiPageViewGridAdapter.VariationSelectorListener
 {
@@ -148,18 +150,18 @@ public final class ReactWithAnyEmojiDialogFragment extends BottomSheetDialogFrag
     callback.onReactWithAnyEmojiDialogDismissed();
   }
 
-  private void initializeViewModel() {
-    Bundle                             args       = requireArguments();
-    final MessageId messageId = new MessageId(args.getLong(ARG_MESSAGE_ID), args.getBoolean(ARG_IS_MMS));
-    viewModel = new ViewModelProvider(
-            getViewModelStore(),
-            getDefaultViewModelProviderFactory(),
-            HiltViewModelExtensions.withCreationCallback(
-                    getDefaultViewModelCreationExtras(),
-                    (ReactWithAnyEmojiViewModel.Factory factory) -> factory.create(messageId)
-            )
-    ).get(ReactWithAnyEmojiViewModel.class);
-  }
+    private void initializeViewModel() {
+        Bundle args = requireArguments();
+        final MessageId messageId = new MessageId(args.getLong(ARG_MESSAGE_ID), args.getBoolean(ARG_IS_MMS));
+        viewModel = new ViewModelProvider(
+                getViewModelStore(),
+                getDefaultViewModelProviderFactory(),
+                HiltViewModelExtensions.withCreationCallback(
+                        getDefaultViewModelCreationExtras(),
+                        (ReactWithAnyEmojiViewModel.Factory factory) -> factory.create(messageId)
+                )
+        ).get(ReactWithAnyEmojiViewModel.class);
+    }
 
   @Override
   public void onEmojiSelected(String emoji) {


### PR DESCRIPTION
[SES-4533](https://optf.atlassian.net/browse/SES-4533)

The fragment is _not_ annotated for Hilt, so `getDefaultViewModelProviderFactory()` is not the Hilt VM factory. It falls back to the default, which tries to call a no-arg constructor and crashes.

This PR fixes the crash when opening the Emoji Picker (+) by annotating `ReactWithAnyEmojiDialogFragment` for Hilt (DI)

https://github.com/user-attachments/assets/3eecf4c3-a6ec-48b5-a57f-356ed4cebbd3



