### PR TITLE
SES-4565 : Image Selection On The "All Media" Screen Can Open the Wrong Image

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.kt
@@ -320,6 +320,34 @@ class MediaPreviewActivity : ScreenLockActionBarActivity(),
         super.onNewIntent(intent)
         setIntent(intent)
         initializeResources()
+        handleNewPreviewTargetOrReload()
+    }
+
+    private fun handleNewPreviewTargetOrReload() {
+        val targetUri = initialMediaUri
+        val targetType = initialMediaType
+        val targetAddress = conversationAddress
+
+        if (!isContentTypeSupported(targetType) || targetUri == null || targetAddress == null) {
+            initializeMedia()
+            return
+        }
+
+        val sameThread = (targetAddress == this.conversationAddress)
+
+        val adapter = this.adapter
+        if (sameThread && adapter != null) {
+            val pos = adapter.findAdapterIndexByUri(targetUri)
+            if (pos != -1) {
+                binding.mediaPager.setCurrentItem(pos, false)
+                viewModel.setActiveAlbumRailItem(this, pos)
+                currentSelectedRecipient.value = adapter.getMediaItemFor(pos).recipientAddress
+                return
+            }
+        }
+
+        // Fallback: reload (new thread or item not currently in cursor)
+        initializeMedia()
     }
 
     fun onMediaPaused(videoUri: Uri, position: Long){
@@ -801,6 +829,18 @@ class MediaPreviewActivity : ScreenLockActionBarActivity(),
             mediaViews.values.forEach { mediaView ->
                 mediaView.setControlsYPosition(position)
             }
+        }
+
+        fun findAdapterIndexByUri(target: Uri): Int {
+            val cursorCount = itemCount
+            for (i in 0 until cursorCount) {
+                val cursorPosition = getCursorPosition(i)
+                cursor.moveToPosition(cursorPosition)
+                val record = MediaRecord.from(context, cursor)
+                val uri = record.attachment.dataUri
+                if (uri != null && uri == target) return i
+            }
+            return -1
         }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.kt
@@ -333,10 +333,8 @@ class MediaPreviewActivity : ScreenLockActionBarActivity(),
             return
         }
 
-        val sameThread = (targetAddress == this.conversationAddress)
-
         val adapter = this.adapter
-        if (sameThread && adapter != null) {
+        if (adapter != null) {
             val pos = adapter.findAdapterIndexByUri(targetUri)
             if (pos != -1) {
                 binding.mediaPager.setCurrentItem(pos, false)


### PR DESCRIPTION
[SES-4565](https://optf.atlassian.net/browse/SES-4565)

This PR fixes the issue on MediaPreviewActivity by handling new data received from a new intent coming from MediaOverViewActivity (All Media). 

After receiving new data, we find the position of the item based on its URI and then set that as the current pager page. If the look up fails, it calls `initializeMedia()` instead.



https://github.com/user-attachments/assets/29c82dbe-fedc-4074-b052-4fd01fe0fa7e

