### PR TITLE
SES-4614 : Read More Indicator Appears Erroneously

### DIFF
--- a/app/src/main/java/org/session/libsession/utilities/ViewUtils.kt
+++ b/app/src/main/java/org/session/libsession/utilities/ViewUtils.kt
@@ -34,14 +34,7 @@ fun TextView.needsCollapsing(
     availableWidthPx: Int,
     maxLines: Int
 ): Boolean {
-    // Pick the width the TextView will actually respect before draw
-    val rawWidth = when {
-        measuredWidth > 0 -> measuredWidth
-        // if maxWidth is set, we check it
-        maxWidth in 1 until Int.MAX_VALUE -> minOf(availableWidthPx, maxWidth)
-        else -> availableWidthPx
-    }
-    val contentWidth = (rawWidth - paddingLeft - paddingRight).coerceAtLeast(0)
+    val contentWidth = (availableWidthPx - paddingLeft - paddingRight).coerceAtLeast(0)
     if (contentWidth <= 0 || text.isNullOrEmpty()) return false
 
     val textForLayout = transformationMethod?.getTransformation(text, this) ?: text
@@ -67,7 +60,7 @@ fun TextView.needsCollapsing(
         .setAlignment(alignment)
         .setTextDirection(direction)
         .setMaxLines(maxLines)                                   // cap at maxLines
-        .setEllipsize(ellipsize ?: TextUtils.TruncateAt.END)     // compute ellipsis
+        .setEllipsize(ellipsize)     // compute ellipsis
 
     builder.setJustificationMode(justificationMode)
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -356,13 +356,9 @@ class VisibleMessageContentView : ConstraintLayout {
                 }
             }
 
-            val widthCap = binding.bodyTextView.maxWidth
-                .takeIf { it > 0 && it < Int.MAX_VALUE }
-                ?: resources.getDimensionPixelSize(R.dimen.max_bubble_width)
-
             // if the text was already manually expanded, we can skip this logic
             if(!isTextExpanded && binding.bodyTextView.needsCollapsing(
-                    availableWidthPx = widthCap,
+                    availableWidthPx = binding.bodyTextView.maxWidth,
                     maxLines = MAX_COLLAPSED_LINE_COUNT)
             ){
                 // show the "Read mode" button


### PR DESCRIPTION
[SES-4614](https://optf.atlassian.net/browse/SES-4614)

This PR fixes the issue by always using the max bubble width instead of measured width.

I wasn't able to recreate the issue using my own messages, but some messages in the test community shows the Read more when it shouldn't.

<img width="486" height="251" alt="Screenshot 2025-09-22 at 10 32 48 AM" src="https://github.com/user-attachments/assets/7063cc0f-09e7-4a56-84d5-2741efecd34a" />
