### PR TITLE
Fix/new message compose

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/home/startconversation/community/JoinCommunityScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/startconversation/community/JoinCommunityScreen.kt
@@ -183,6 +183,7 @@ private fun CommunityScreen(
                     .fillMaxWidth()
                     .qaTag(R.string.AccessibilityId_communityJoin),
                 enabled = state.isJoinButtonEnabled,
+                disabledColor = LocalColors.current.textSecondary,
                 onClick = {
                     sendCommand(JoinCommunityViewModel.Commands.JoinCommunity(
                         state.communityUrl

--- a/app/src/main/java/org/thoughtcrime/securesms/home/startconversation/home/StartConversation.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/startconversation/home/StartConversation.kt
@@ -74,6 +74,7 @@ internal fun StartConversationScreen(
                     text = annotatedStringResource(newMessageTitleTxt),
                     textStyle = LocalType.current.xl,
                     iconRes = R.drawable.ic_message_square,
+                    iconSize = LocalDimensions.current.iconMedium2,
                     modifier = Modifier.qaTag(R.string.AccessibilityId_messageNew),
                     onClick = {
                         navigateTo(StartConversationDestination.NewMessage)
@@ -89,6 +90,7 @@ internal fun StartConversationScreen(
                     text = annotatedStringResource(R.string.groupCreate),
                     textStyle = LocalType.current.xl,
                     iconRes = R.drawable.ic_users_group_custom,
+                    iconSize = LocalDimensions.current.iconMedium2,
                     modifier = Modifier.qaTag(R.string.AccessibilityId_groupCreate),
                     onClick = {
                         navigateTo(StartConversationDestination.CreateGroup)
@@ -104,6 +106,7 @@ internal fun StartConversationScreen(
                     text = annotatedStringResource(R.string.communityJoin),
                     textStyle = LocalType.current.xl,
                     iconRes = R.drawable.ic_globe,
+                    iconSize = LocalDimensions.current.iconMedium2,
                     modifier = Modifier.qaTag(R.string.AccessibilityId_communityJoin),
                     onClick = {
                         navigateTo(StartConversationDestination.JoinCommunity)
@@ -119,6 +122,7 @@ internal fun StartConversationScreen(
                     text = annotatedStringResource(R.string.sessionInviteAFriend),
                     textStyle = LocalType.current.xl,
                     iconRes = R.drawable.ic_user_round_plus,
+                    iconSize = LocalDimensions.current.iconMedium2,
                     modifier = Modifier.qaTag(R.string.AccessibilityId_sessionInviteAFriendButton),
                     onClick = {
                         navigateTo(StartConversationDestination.InviteFriend)

--- a/app/src/main/java/org/thoughtcrime/securesms/home/startconversation/newmessage/NewMessage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/startconversation/newmessage/NewMessage.kt
@@ -139,6 +139,7 @@ private fun EnterAccountId(
                     .fillMaxWidth()
                     .qaTag(R.string.next),
                 enabled = state.isNextButtonEnabled,
+                disabledColor = LocalColors.current.textSecondary,
                 onClick = callbacks::onContinue
             ) {
                 LoadingArcOr(state.loading) {

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsScreen.kt
@@ -66,7 +66,6 @@ import network.loki.messenger.BuildConfig
 import network.loki.messenger.R
 import org.session.libsession.utilities.NonTranslatableStringConstants
 import org.session.libsession.utilities.NonTranslatableStringConstants.NETWORK_NAME
-import org.thoughtcrime.securesms.conversation.v2.settings.ConversationSettingsViewModel.Commands.ShowProBadgeCTA
 import org.thoughtcrime.securesms.debugmenu.DebugActivity
 import org.thoughtcrime.securesms.home.PathActivity
 import org.thoughtcrime.securesms.messagerequests.MessageRequestsActivity
@@ -269,7 +268,7 @@ fun Settings(
                 text = uiState.username,
                 iconRes = if(uiState.showProBadge) R.drawable.ic_pro_badge else null,
                 onIconClick = null,
-                iconSize = 58.sp to 24.sp,
+                iconSize = 53.sp to 24.sp,
                 style = LocalType.current.h5,
             )
 

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsScreen.kt
@@ -59,12 +59,14 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import network.loki.messenger.BuildConfig
 import network.loki.messenger.R
 import org.session.libsession.utilities.NonTranslatableStringConstants
 import org.session.libsession.utilities.NonTranslatableStringConstants.NETWORK_NAME
+import org.thoughtcrime.securesms.conversation.v2.settings.ConversationSettingsViewModel.Commands.ShowProBadgeCTA
 import org.thoughtcrime.securesms.debugmenu.DebugActivity
 import org.thoughtcrime.securesms.home.PathActivity
 import org.thoughtcrime.securesms.messagerequests.MessageRequestsActivity
@@ -107,6 +109,7 @@ import org.thoughtcrime.securesms.ui.ProBadgeText
 import org.thoughtcrime.securesms.ui.RadioOption
 import org.thoughtcrime.securesms.ui.components.AcccentOutlineCopyButton
 import org.thoughtcrime.securesms.ui.components.AccentOutlineButton
+import org.thoughtcrime.securesms.ui.components.AnnotatedTextWithIcon
 import org.thoughtcrime.securesms.ui.components.AppBarCloseIcon
 import org.thoughtcrime.securesms.ui.components.Avatar
 import org.thoughtcrime.securesms.ui.components.BaseBottomSheet
@@ -116,6 +119,7 @@ import org.thoughtcrime.securesms.ui.components.SessionOutlinedTextField
 import org.thoughtcrime.securesms.ui.components.SmallCircularProgressIndicator
 import org.thoughtcrime.securesms.ui.components.annotatedStringResource
 import org.thoughtcrime.securesms.ui.qaTag
+import org.thoughtcrime.securesms.ui.safeContentWidth
 import org.thoughtcrime.securesms.ui.theme.LocalColors
 import org.thoughtcrime.securesms.ui.theme.LocalDimensions
 import org.thoughtcrime.securesms.ui.theme.LocalType
@@ -252,8 +256,10 @@ fun Settings(
             Spacer(modifier = Modifier.height(LocalDimensions.current.spacing))
 
             // name
-            ProBadgeText(
+            AnnotatedTextWithIcon(
                 modifier = Modifier.qaTag(R.string.AccessibilityId_displayName)
+                    .fillMaxWidth()
+                    .safeContentWidth()
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null
@@ -261,7 +267,10 @@ fun Settings(
                         sendCommand(ShowUsernameDialog)
                     },
                 text = uiState.username,
-                showBadge = uiState.showProBadge,
+                iconRes = if(uiState.showProBadge) R.drawable.ic_pro_badge else null,
+                onIconClick = null,
+                iconSize = 58.sp to 24.sp,
+                style = LocalType.current.h5,
             )
 
             Spacer(modifier = Modifier.height(LocalDimensions.current.smallSpacing))

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/ProSettingsHomeScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/ProSettingsHomeScreen.kt
@@ -254,6 +254,7 @@ fun ProStats(
             verticalArrangement = Arrangement.spacedBy(LocalDimensions.current.smallSpacing)
         ){
             Row(
+                verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(LocalDimensions.current.xsSpacing)
             ) {
                 // groups updated
@@ -281,6 +282,7 @@ fun ProStats(
             }
 
             Row(
+                verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(LocalDimensions.current.xsSpacing)
             ) {
                 // Pro Badges
@@ -324,7 +326,7 @@ fun ProStatItem(
         Image(
             painter = painterResource(id = icon),
             contentDescription = null,
-            modifier = Modifier.size(LocalDimensions.current.iconRowItem),
+            modifier = Modifier.size(LocalDimensions.current.iconMedium2),
             colorFilter = ColorFilter.tint(LocalColors.current.accent)
         )
 

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/Components.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/Components.kt
@@ -264,7 +264,7 @@ fun ItemButton(
     modifier: Modifier = Modifier,
     textStyle: TextStyle = LocalType.current.h8,
     iconTint: Color? = null,
-    iconSize: Dp = LocalDimensions.current.iconRowItem,
+    iconSize: Dp = LocalDimensions.current.iconMedium,
     subtitle: String? = null,
     @StringRes subtitleQaTag: Int? = null,
     enabled: Boolean = true,
@@ -1058,7 +1058,7 @@ fun IconActionRowItem(
     textStyle: TextStyle = LocalType.current.h8,
     subtitleStyle: TextStyle = LocalType.current.small,
     iconColor: Color = LocalColors.current.text,
-    iconSize: Dp = LocalDimensions.current.iconRowItem,
+    iconSize: Dp = LocalDimensions.current.iconMedium,
     minHeight: Dp = LocalDimensions.current.minItemButtonHeight,
     paddingValues: PaddingValues = PaddingValues(horizontal = LocalDimensions.current.smallSpacing),
 ){

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/components/BottomSheets.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/components/BottomSheets.kt
@@ -20,13 +20,17 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.window.DialogWindowProvider
+import androidx.core.view.WindowCompat
 import network.loki.messenger.R
 import org.thoughtcrime.securesms.ui.qaTag
 import org.thoughtcrime.securesms.ui.theme.LocalColors
@@ -58,9 +62,22 @@ fun BaseBottomSheet(
             topEnd = LocalDimensions.current.xsSpacing
         ),
         dragHandle = dragHandle,
-        containerColor = LocalColors.current.backgroundSecondary,
-        content = content
-    )
+        containerColor = LocalColors.current.backgroundSecondary
+    ){
+        // make sure the status and navigation bars follow our theme color's light vs dark
+        val view = LocalView.current
+        val isLight = LocalColors.current.isLight
+        (view.parent as? DialogWindowProvider)?.window?.let { window ->
+            SideEffect {
+                // Set status bar color
+                WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = isLight
+                // Set navigation bar color
+                WindowCompat.getInsetsController(window, view).isAppearanceLightNavigationBars = isLight
+            }
+        }
+
+        content()
+    }
 }
 
 

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/components/BottomSheets.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/components/BottomSheets.kt
@@ -81,7 +81,7 @@ fun BaseBottomSheet(
                 WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = isLight
                 // Set navigation bar color
                 WindowCompat.getInsetsController(window, view).isAppearanceLightNavigationBars = isLight
-                
+
                 onDispose { window.isNavigationBarContrastEnforced = prev }
             } else {
                 onDispose { }

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/components/BottomSheets.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/components/BottomSheets.kt
@@ -1,5 +1,8 @@
 package org.thoughtcrime.securesms.ui.components
 
+import android.app.Activity
+import android.graphics.Color
+import android.os.Build
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
@@ -20,6 +23,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
@@ -67,12 +71,20 @@ fun BaseBottomSheet(
         // make sure the status and navigation bars follow our theme color's light vs dark
         val view = LocalView.current
         val isLight = LocalColors.current.isLight
-        (view.parent as? DialogWindowProvider)?.window?.let { window ->
-            SideEffect {
+
+        DisposableEffect(Unit) {
+            val window = (view.parent as? DialogWindowProvider)?.window
+            if (window != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                val prev = window.isNavigationBarContrastEnforced
+                window.isNavigationBarContrastEnforced = false
                 // Set status bar color
                 WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = isLight
                 // Set navigation bar color
                 WindowCompat.getInsetsController(window, view).isAppearanceLightNavigationBars = isLight
+                
+                onDispose { window.isNavigationBarContrastEnforced = prev }
+            } else {
+                onDispose { }
             }
         }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/components/Button.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/components/Button.kt
@@ -162,8 +162,13 @@ fun Button(
     Button(text, onClick, ButtonType.Outline(LocalColors.current.accentText), modifier, enabled, minWidth = minWidth)
 }
 
-@Composable fun AccentOutlineButton(modifier: Modifier = Modifier, enabled: Boolean = true, onClick: () -> Unit, content: @Composable RowScope.() -> Unit) {
-    Button(onClick, ButtonType.Outline(LocalColors.current.accentText), modifier, enabled, content = content)
+@Composable fun AccentOutlineButton(modifier: Modifier = Modifier, enabled: Boolean = true,
+                                    disabledColor: Color = LocalColors.current.disabled,
+                                    onClick: () -> Unit, content: @Composable RowScope.() -> Unit) {
+    Button(onClick, ButtonType.Outline(
+        contentColor = LocalColors.current.accentText,
+        disabledColor = disabledColor
+    ), modifier, enabled, content = content)
 }
 
 @Composable fun SlimOutlineButton(modifier: Modifier = Modifier, color: Color = LocalColors.current.text, enabled: Boolean = true, onClick: () -> Unit, content: @Composable RowScope.() -> Unit) {

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/components/ButtonType.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/components/ButtonType.kt
@@ -26,18 +26,19 @@ interface ButtonType {
 
     class Outline(
         private val contentColor: Color,
-        private val borderColor: Color = contentColor
+        private val borderColor: Color = contentColor,
+        private val disabledColor: Color? = null
     ): ButtonType {
         @Composable
         override fun border(enabled: Boolean) = BorderStroke(
             width = LocalDimensions.current.borderStroke,
-            color = if (enabled) borderColor else LocalColors.current.disabled
+            color = if (enabled) borderColor else disabledColor ?: LocalColors.current.disabled
         )
         @Composable
         override fun buttonColors() = ButtonDefaults.buttonColors(
             contentColor = contentColor,
             containerColor = Color.Transparent,
-            disabledContentColor = LocalColors.current.disabled,
+            disabledContentColor = disabledColor ?: LocalColors.current.disabled,
             disabledContainerColor = Color.Transparent
         )
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/components/Text.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/components/Text.kt
@@ -259,7 +259,7 @@ fun AnnotatedTextWithIcon(
     style: TextStyle = LocalType.current.base,
     color: Color = Color.Unspecified,
     iconSize: Pair<TextUnit, TextUnit> = 12.sp to 12.sp,
-    iconPaddingValues: PaddingValues = PaddingValues(1.dp),
+    iconPaddingValues: PaddingValues = PaddingValues(start = style.lineHeight.value.dp * 0.2f),
     onIconClick: (() -> Unit)? = null
 ) {
     var inlineContent: Map<String, InlineTextContent> = mapOf()

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/theme/Dimensions.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/theme/Dimensions.kt
@@ -32,7 +32,7 @@ data class Dimensions(
     val iconSmall: Dp = 20.dp,
     val iconMedium: Dp = 24.dp,
     val iconMediumAvatar: Dp = 26.dp,
-    val iconRowItem: Dp = 24.dp,
+    val iconMedium2: Dp = 32.dp,
     val iconLargeAvatar: Dp = 36.dp,
     val iconLarge: Dp = 46.dp,
     val iconXLarge: Dp = 60.dp,

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -16,8 +16,8 @@
        <item name="colorDividerBackground">@color/gray50</item>
        <item name="colorPrimaryVariant">?colorPrimary</item>
        <item name="bottomSheetDialogTheme">@style/Theme.Session.BottomSheet</item>
-       <item name="android:backgroundDimEnabled">true</item>
-       <item name="android:backgroundDimAmount">0.6</item>
+       <item name="android:backgroundDimEnabled">false</item>
+       <item name="android:backgroundDimAmount">0</item>
        <item name="dialogCornerRadius">@dimen/dialog_corner_radius</item>
        <item name="android:alertDialogTheme">@style/ThemeOverlay.Session.AlertDialog</item>
        <item name="alertDialogTheme">@style/ThemeOverlay.Session.AlertDialog</item>


### PR DESCRIPTION
[SES-4619](https://optf.atlassian.net/browse/SES-4619) - Created a new styling option for disabled state of outline buttons. I'm using that new style in the "new conversation" menu as the bg is a secondary bg color so the default disaled colour from our theme is not contrasted enough to pass accessibility.
[SES-4620](https://optf.atlassian.net/browse/SES-4620) - Reworked our display logic for compose bottom sheet to better handle the three dot system bars and avoid wrong colouring
[SES-4621](https://optf.atlassian.net/browse/SES-4621) - New conversation menu items rectified with proper icon size
[SES-4616](https://optf.atlassian.net/browse/SES-4616) - Removed unnecessary dimming in activities, which was visible during transitions
[SES-4550](https://optf.atlassian.net/browse/SES-4550) - Reusing our existing code to handle long names in Settings page