### PR TITLE
[SES-3869] Fixed blinded contacts not deleted after accepting blind requests

### DIFF
--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/MessageRequestResponseHandler.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/MessageRequestResponseHandler.kt
@@ -139,6 +139,18 @@ class MessageRequestResponseHandler @Inject constructor(
                         }
                     }
                 }
+
+                // Also remove all blinded contacts
+                if (blindedConversationAddresses.isNotEmpty()) {
+                    configFactory.withMutableUserConfigs { configs ->
+                        for (address in blindedConversationAddresses) {
+                            configs.contacts.eraseBlinded(
+                                communityServerUrl = address.serverUrl,
+                                blindedId = address.blindedId.address
+                            )
+                        }
+                    }
+                }
             }
 
             else -> {

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/MessageRequestResponseHandler.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/MessageRequestResponseHandler.kt
@@ -128,27 +128,23 @@ class MessageRequestResponseHandler @Inject constructor(
                         moveConversation(fromThreadId = blindedThreadId, toThreadId = threadId)
                     }
 
-                // If we ever have any blinded conversations with this sender, we should make
-                // sure we have set "approved" to true for them, because when we started the blinded
-                // conversation, we didn't know their real standard addresses, so we didn't say
-                // we have approved them, but now that we do, we need to approve them.
-                if (existingBlindedThreadIDs.isNotEmpty()) {
-                    configFactory.withMutableUserConfigs { configs ->
+                configFactory.withMutableUserConfigs { configs ->
+                    // If we ever have any blinded conversations with this sender, we should make
+                    // sure we have set "approved" to true for them, because when we started the blinded
+                    // conversation, we didn't know their real standard addresses, so we didn't say
+                    // we have approved them, but now that we do, we need to approve them.
+                    if (existingBlindedThreadIDs.isNotEmpty()) {
                         configs.contacts.updateContact(messageSender.address) {
                             approved = true
                         }
                     }
-                }
 
-                // Also remove all blinded contacts
-                if (blindedConversationAddresses.isNotEmpty()) {
-                    configFactory.withMutableUserConfigs { configs ->
-                        for (address in blindedConversationAddresses) {
-                            configs.contacts.eraseBlinded(
-                                communityServerUrl = address.serverUrl,
-                                blindedId = address.blindedId.address
-                            )
-                        }
+                    // Also remove all blinded contacts
+                    for (address in blindedConversationAddresses) {
+                        configs.contacts.eraseBlinded(
+                            communityServerUrl = address.serverUrl,
+                            blindedId = address.blindedId.address
+                        )
                     }
                 }
             }


### PR DESCRIPTION
This is a change that I forgot to add in after the blinded contact in config was merged in: basically, when your blind community message requests are accepted, they are supposed to be merged in one convo that was addressed by the contact's 05 address. This part is all good, but we also need to make sure we deleted those blinded contact from our configs so they don't produce empty threads.
