### PR TITLE
SES-4569 : 'Follow Setting' button doesn't follow theming

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/ControlMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/ControlMessageView.kt
@@ -25,6 +25,7 @@ import org.session.libsession.utilities.StringSubstitutionConstants.APP_NAME_KEY
 import org.session.libsession.utilities.StringSubstitutionConstants.NAME_KEY
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsession.utilities.TextSecurePreferences.Companion.CALL_NOTIFICATIONS_ENABLED
+import org.session.libsession.utilities.ThemeUtil
 import org.session.libsession.utilities.getColorFromAttr
 import org.session.libsession.utilities.isGroup
 import org.session.libsession.utilities.isGroupOrCommunity
@@ -83,6 +84,12 @@ class ControlMessageView : LinearLayout {
         binding.iconImageView.isGone = true
         binding.expirationTimerView.isGone = true
         binding.followSetting.isGone = true
+
+        val isLight = ThemeUtil.isLightTheme(context)
+        if(isLight){
+            binding.followSetting.setTextColor(context.getColorFromAttr(android.R.attr.textColorPrimary))
+        }
+
         var messageBody: CharSequence = message.getDisplayBody(context)
 
         binding.root.contentDescription = null


### PR DESCRIPTION
[SES-4569](https://optf.atlassian.net/browse/SES-4569)

This PR adds a condition to use the primary text color for the "Follow Setting" text when in light theme and use the accent color instead for dark theme.


<img width="275" height="107" alt="Screenshot 2025-09-22 at 4 33 54 PM" src="https://github.com/user-attachments/assets/f487fd93-9a53-4212-ba49-0f698222d96a" />
<img width="254" height="95" alt="Screenshot 2025-09-22 at 4 35 25 PM" src="https://github.com/user-attachments/assets/b1bb936b-ae16-4945-aeb7-8410f381aaf0" />
