### PR TITLE
Added blinded contact to contact list and search result should include unapproved recipients

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -163,7 +163,7 @@ class HomeActivity : ScreenLockActionBarActivity(),
                     is GlobalSearchAdapter.Model.Contact -> ConversationActivityV2
                         .createIntent(
                             this,
-                            address = Address.fromSerialized(model.contact.hexString) as Address.Conversable
+                            address = model.contact
                         )
 
                     is GlobalSearchAdapter.Model.GroupConversation -> ConversationActivityV2
@@ -181,13 +181,13 @@ class HomeActivity : ScreenLockActionBarActivity(),
                 push(intent)
             },
             onContactLongPressed = { model ->
-                onSearchContactLongPress(model.contact.hexString, model.name)
+                onSearchContactLongPress(model.contact, model.name)
             }
         )
     }
 
-    private fun onSearchContactLongPress(accountId: String, contactName: String) {
-        val bottomSheet = SearchContactActionBottomSheet.newInstance(accountId, contactName)
+    private fun onSearchContactLongPress(address: Address, contactName: String) {
+        val bottomSheet = SearchContactActionBottomSheet.newInstance(address, contactName)
         bottomSheet.show(supportFragmentManager, bottomSheet.tag)
     }
 
@@ -408,12 +408,13 @@ class HomeActivity : ScreenLockActionBarActivity(),
         homeViewModel.onCancelSearchClicked()
     }
 
-    override fun onBlockContact(accountId: String) {
-        homeViewModel.blockContact(accountId)
+    override fun onBlockContact(address: Address) {
+        if (address is Address.Standard) {
+            homeViewModel.blockContact(address.address)
+        }
     }
 
-    override fun onDeleteContact(accountId: String) {
-        val address = accountId.toAddress()
+    override fun onDeleteContact(address: Address) {
         if (address is Address.WithAccountId) {
             homeViewModel.deleteContact(address)
         }

--- a/app/src/main/java/org/thoughtcrime/securesms/home/search/GlobalSearchAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/search/GlobalSearchAdapter.kt
@@ -11,8 +11,10 @@ import network.loki.messenger.databinding.ViewGlobalSearchHeaderBinding
 import network.loki.messenger.databinding.ViewGlobalSearchResultBinding
 import network.loki.messenger.databinding.ViewGlobalSearchSubheaderBinding
 import org.session.libsession.messaging.MessagingModuleConfiguration
+import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.GroupRecord
 import org.session.libsession.utilities.recipients.Recipient
+import org.session.libsession.utilities.recipients.displayName
 import org.session.libsignal.utilities.AccountId
 import org.thoughtcrime.securesms.search.model.MessageResult
 import org.thoughtcrime.securesms.ui.GetString
@@ -160,9 +162,9 @@ class GlobalSearchAdapter(
         }
 
         data class SavedMessages(val currentUserPublicKey: String): Model // Note: "Note to Self" counts as SavedMessages rather than a Contact where `isSelf` is true.
-        data class Contact(val contact: AccountId, val name: String, val isSelf: Boolean, val showProBadge: Boolean) : Model {
+        data class Contact(val contact: Address.Conversable, val name: String, val isSelf: Boolean, val showProBadge: Boolean) : Model {
             constructor(contact: Recipient, isSelf: Boolean, showProBadge: Boolean):
-                    this(AccountId(contact.address.address), contact.searchName, isSelf, showProBadge)
+                    this(contact.address as Address.Conversable, contact.displayName(false), isSelf, showProBadge)
         }
         data class GroupConversation(
             val isLegacy: Boolean,

--- a/app/src/main/java/org/thoughtcrime/securesms/home/search/GlobalSearchAdapterUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/search/GlobalSearchAdapterUtils.kt
@@ -140,7 +140,7 @@ fun ContentView.bindModel(query: String?, model: ContactModel) = binding.run {
     searchResultTimestamp.isVisible = false
     searchResultSubtitle.text = null
     val recipient = MessagingModuleConfiguration.shared.recipientRepository.getRecipientSync(
-        Address.fromSerialized(model.contact.hexString)
+        model.contact
     )
     searchResultProfilePicture.setThemedContent {
         Avatar(


### PR DESCRIPTION
1. The contact list on search screen should include blinded contact (a.k.a blinded community request target). This bring a side effect of handling the long press on the contact items: it has to support a blinded contact now and blinded contact can't use "block"
2. When searching for a "conversation", we should include the ones that are unapproved.