### PR TITLE
[SES-4626] - Blinded message request improvement

### DIFF
--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/MessageRequestResponseHandler.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/MessageRequestResponseHandler.kt
@@ -1,12 +1,15 @@
 package org.session.libsession.messaging.sending_receiving
 
+import org.session.libsession.messaging.messages.Message
 import org.session.libsession.messaging.messages.ProfileUpdateHandler
 import org.session.libsession.messaging.messages.ProfileUpdateHandler.Updates.Companion.toUpdates
 import org.session.libsession.messaging.messages.control.MessageRequestResponse
 import org.session.libsession.messaging.messages.signal.IncomingMediaMessage
+import org.session.libsession.messaging.messages.visible.VisibleMessage
 import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.Address.Companion.toAddress
 import org.session.libsession.utilities.ConfigFactoryProtocol
+import org.session.libsession.utilities.recipients.Recipient
 import org.session.libsession.utilities.updateContact
 import org.session.libsession.utilities.upsertContact
 import org.session.libsignal.utilities.Log
@@ -30,23 +33,82 @@ class MessageRequestResponseHandler @Inject constructor(
     private val blindMappingRepository: BlindMappingRepository,
 ) {
 
-    suspend fun handle(message: MessageRequestResponse) {
-        val messageSender = recipientRepository.getRecipient(
-            requireNotNull(message.sender) {
-                "MessageRequestResponse must have a sender"
-            }.toAddress()
-        )
+    suspend fun handle(message: Message) {
+        val fetchSenderAndReceiver = suspend {
+            val messageSender = recipientRepository.getRecipient(
+                requireNotNull(message.sender) {
+                    "MessageRequestResponse must have a sender"
+                }.toAddress()
+            )
 
-        if (messageSender.address !is Address.Standard) {
-            Log.e(TAG, "MessageRequestResponse sender must be a standard address, but got: ${messageSender.address.debugString}")
-            return
+            if (messageSender.address !is Address.Standard) {
+                Log.e(TAG, "MessageRequestResponse sender must be a standard address, but got: ${messageSender.address.debugString}")
+                null
+            } else {
+                messageSender to recipientRepository.getRecipient(
+                    requireNotNull(message.recipient) {
+                        "MessageRequestResponse must have a receiver"
+                    }.toAddress()
+                )
+            }
         }
 
-        val messageReceiver = recipientRepository.getRecipient(
-            requireNotNull(message.recipient) {
-                "MessageRequestResponse must have a receiver"
-            }.toAddress()
-        )
+        if (message is MessageRequestResponse) {
+            val (sender, receiver) = fetchSenderAndReceiver() ?: return
+            // Always handle explicit request response
+            handleRequestResponse(
+                messageSender = sender,
+                messageReceiver = receiver,
+                messageTimestampMs = message.sentTimestamp!!,
+            )
+
+            // Always process the profile update if any. We don't need
+            // to process profile for other kind of messages as they should be handled elsewhere
+            message.profile?.toUpdates()?.let { updates ->
+                profileUpdateHandler.get().handleProfileUpdate(
+                    senderId = (sender.address as Address.Standard).accountId,
+                    updates = updates,
+                    fromCommunity = null
+                )
+            }
+        } else if (message is VisibleMessage) {
+            val (sender, receiver) = fetchSenderAndReceiver() ?: return
+
+            val allBlindedAddresses = blindMappingRepository.calculateReverseMappings(
+                contactAddress = sender.address as Address.Standard
+            )
+
+            // Do we have an existing message request (including blinded requests)?
+            val hasMessageRequest = configFactory.withUserConfigs { configs ->
+                val existingContact = configs.contacts.get(sender.address.accountId.hexString)
+                if (existingContact != null && existingContact.approved && !existingContact.approvedMe) {
+                    return@withUserConfigs true
+                }
+
+                allBlindedAddresses.any { (_, blindedId) ->
+                    configs.contacts.getBlinded(blindedId.blindedId.hexString) != null
+                }
+            }
+
+            if (hasMessageRequest) {
+                handleRequestResponse(
+                    messageSender = sender,
+                    messageReceiver = receiver,
+                    messageTimestampMs = message.sentTimestamp!!,
+                )
+            }
+        }
+    }
+
+
+    private fun handleRequestResponse(
+        messageSender: Recipient,
+        messageReceiver: Recipient,
+        messageTimestampMs: Long,
+    ) {
+        check(messageSender.address is Address.Standard) {
+            "The sender address must be a standard address"
+        }
 
         Log.d(TAG, "Handling MessageRequestResponse from " +
                 "${messageSender.address.debugString} to ${messageReceiver.address.debugString}")
@@ -71,17 +133,6 @@ class MessageRequestResponseHandler @Inject constructor(
                     }
                 }
 
-
-                // Process the profile update if any
-                message.profile?.toUpdates()?.let { updates ->
-                    profileUpdateHandler.get().handleProfileUpdate(
-                        senderId = messageSender.address.accountId,
-                        updates = updates,
-                        fromCommunity = null
-                    )
-                }
-
-
                 val threadId by lazy {
                     threadDatabase.getOrCreateThreadIdFor(messageSender.address)
                 }
@@ -92,7 +143,7 @@ class MessageRequestResponseHandler @Inject constructor(
                     mmsDatabase.insertSecureDecryptedMessageInbox(
                         retrieved = IncomingMediaMessage(
                             messageSender.address,
-                            message.sentTimestamp!!,
+                            messageTimestampMs,
                             -1,
                             0L,
                             0L,
@@ -153,7 +204,6 @@ class MessageRequestResponseHandler @Inject constructor(
 
             }
         }
-
     }
 
     private fun moveConversation(fromThreadId: Long, toThreadId: Long) {

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
@@ -130,7 +130,7 @@ class ReceivedMessageHandler @Inject constructor(
             }
             is DataExtractionNotification -> handleDataExtractionNotification(message)
             is UnsendRequest -> handleUnsendRequest(message)
-            is MessageRequestResponse -> messageRequestResponseHandler.get().handle(message)
+            is MessageRequestResponse -> messageRequestResponseHandler.get().handleExplicitRequestResponseMessage(message)
             is VisibleMessage -> handleVisibleMessage(
                 message = message,
                 proto = proto,
@@ -297,7 +297,7 @@ class ReceivedMessageHandler @Inject constructor(
         // Do nothing if the message was outdated
         if (messageIsOutdated(message, context.threadId)) { return null }
 
-        messageRequestResponseHandler.get().handle(message)
+        messageRequestResponseHandler.get().handleVisibleMessage(message)
 
         // Handle group invite response if new closed group
         val threadRecipientAddress = context.threadAddress

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
@@ -100,9 +100,7 @@ class ReceivedMessageHandler @Inject constructor(
     private val profileUpdateHandler: Provider<ProfileUpdateHandler>,
     @param:ManagerScope private val scope: CoroutineScope,
     private val configFactory: ConfigFactoryProtocol,
-    private val conversationRepository: ConversationRepository,
     private val messageRequestResponseHandler: Provider<MessageRequestResponseHandler>,
-    private val recipientRepository: RecipientRepository,
 ) {
 
     suspend fun handle(
@@ -286,7 +284,7 @@ class ReceivedMessageHandler @Inject constructor(
         return messageIdToDelete
     }
 
-    fun handleVisibleMessage(
+    suspend fun handleVisibleMessage(
         message: VisibleMessage,
         proto: SignalServiceProtos.Content,
         context: VisibleMessageHandlerContext,
@@ -299,6 +297,7 @@ class ReceivedMessageHandler @Inject constructor(
         // Do nothing if the message was outdated
         if (messageIsOutdated(message, context.threadId)) { return null }
 
+        messageRequestResponseHandler.get().handle(message)
 
         // Handle group invite response if new closed group
         val threadRecipientAddress = context.threadAddress

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -657,9 +657,9 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
             viewModel.uiEvents.collect { event ->
                 when (event) {
                     is ConversationUiEvent.NavigateToConversation -> {
-                        finish()
                         startActivity(
                             createIntent(this@ConversationActivityV2, event.address)
+                                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NO_ANIMATION)
                         )
                     }
 
@@ -1075,13 +1075,13 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
             // Wait for exit signal
             viewModel.shouldExit.first()
 
-            Toast.makeText(
-                this@ConversationActivityV2,
-                getString(R.string.conversationsDeleted),
-                Toast.LENGTH_LONG
-            ).show()
-
             if (!isFinishing) {
+                Toast.makeText(
+                    this@ConversationActivityV2,
+                    getString(R.string.conversationsDeleted),
+                    Toast.LENGTH_LONG
+                ).show()
+
                 finish()
             }
         }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -308,6 +309,13 @@ class ConversationViewModel @AssistedInject constructor(
 
         // then wait until it is removed
         repository.conversationListAddressesFlow.first { !it.contains(address) }
+
+        // Wait for a bit so the unblinding navigation could take place first (basically
+        // when a unblinding occurs, i.e. a blinded request has been accepted, the
+        // blinded thread will be deleted. It would have come through here and we show "conversation
+        // deleted" then quit, which is not ideal - so there's another coroutine that
+        // try to navigate to the new conversation and we will make sure that coroutine goes first.
+        delay(500L)
         emit(Unit)
     }
 


### PR DESCRIPTION
This PR addresses two issues:

1. "Accepting a message request" can be both explicit and implicit, we have always handled the explicit case but the implicit case is not handled correctly - as now the blinded MR needs special handling so if the implicit case (`VisibleMessage`) is not handled, it will trigger bugs described in SES-4626.
2. Improve UI logic around transitioning into the new conversation: no toast is shown and minimal animation is performed.

