### PR TITLE
[SES-4630] - Fixed community request outbox not synced

### DIFF
--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
@@ -236,29 +236,31 @@ class OpenGroupPoller @AssistedInject constructor(
                 }
             )
         }
-        val isAcceptingCommunityRequests = storage.isCheckingCommunityRequests()
-        if (serverCapabilities.contains(Capability.BLIND.name.lowercase()) && isAcceptingCommunityRequests) {
-            requests.add(
-                if (lastInboxMessageId == null) {
-                    BatchRequestInfo(
-                        request = BatchRequest(
-                            method = GET,
-                            path = "/inbox"
-                        ),
-                        endpoint = Endpoint.Inbox,
-                        responseType = object : TypeReference<List<DirectMessage>>() {}
-                    )
-                } else {
-                    BatchRequestInfo(
-                        request = BatchRequest(
-                            method = GET,
-                            path = "/inbox/since/$lastInboxMessageId"
-                        ),
-                        endpoint = Endpoint.InboxSince(lastInboxMessageId),
-                        responseType = object : TypeReference<List<DirectMessage>>() {}
-                    )
-                }
-            )
+        if (serverCapabilities.contains(Capability.BLIND.name.lowercase())) {
+            if (storage.isCheckingCommunityRequests()) {
+                requests.add(
+                    if (lastInboxMessageId == null) {
+                        BatchRequestInfo(
+                            request = BatchRequest(
+                                method = GET,
+                                path = "/inbox"
+                            ),
+                            endpoint = Endpoint.Inbox,
+                            responseType = object : TypeReference<List<DirectMessage>>() {}
+                        )
+                    } else {
+                        BatchRequestInfo(
+                            request = BatchRequest(
+                                method = GET,
+                                path = "/inbox/since/$lastInboxMessageId"
+                            ),
+                            endpoint = Endpoint.InboxSince(lastInboxMessageId),
+                            responseType = object : TypeReference<List<DirectMessage>>() {}
+                        )
+                    }
+                )
+            }
+
             requests.add(
                 if (lastOutboxMessageId == null) {
                     BatchRequestInfo(


### PR DESCRIPTION
We should always query SOGS' outbox, regardless of we accept community request or not, as the outbox is the messages we **send**. This bug should have been here for a long time, except it's a wild west on prod where I think we also send a sync message to our swarm and it just accidentally works for this case but for very wrong reason. The root cause of the prod issue is the mismanagement of a blind address - given we have tidied up the addressing in the app it's no longer broken, so previously double-broken becomes broken... This PR address the another broken part.
