### PR TITLE
SES-4388 : Auto scrolling issues

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -334,11 +334,11 @@ class ConversationViewModel @AssistedInject constructor(
 
     init {
         viewModelScope.launch {
-            combine(
-                recipientFlow,
+            combine(recipientFlow,
                 legacyGroupDeprecationManager.deprecationState,
-                ::getInputBarState
-            ).collectLatest {
+                _searchOpened) { r, dep, searchOpen ->
+                getInputBarState(r, dep, searchOpen)
+            }.collectLatest {
                 _inputBarState.value = it
             }
         }
@@ -430,12 +430,13 @@ class ConversationViewModel @AssistedInject constructor(
 
     private fun getInputBarState(
         recipient: Recipient,
-        deprecationState: LegacyGroupDeprecationManager.DeprecationState
+        deprecationState: LegacyGroupDeprecationManager.DeprecationState,
+        searchOpen: Boolean
     ): InputBarState {
         val currentCharLimitState = _inputBarState.value.charLimitState
         return when {
             // prioritise cases that demand the input to be hidden
-            !shouldShowInput(recipient, deprecationState) -> InputBarState(
+            searchOpen || !shouldShowInput(recipient, deprecationState) -> InputBarState(
                 contentState = InputBarContentState.Hidden,
                 enableAttachMediaControls = false,
                 charLimitState = currentCharLimitState

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/components/ConversationAppBar.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/components/ConversationAppBar.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsTopHeight
@@ -163,7 +164,7 @@ fun ConversationAppBar(
                 true -> {
                     Row(
                         modifier = Modifier
-                            .windowInsetsTopHeight(WindowInsets.systemBars)
+                            .statusBarsPadding()
                             .padding(horizontal = LocalDimensions.current.smallSpacing)
                             .heightIn(min = LocalDimensions.current.appBarHeight),
                         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/org/thoughtcrime/securesms/util/adapter/RecyclerViewUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/adapter/RecyclerViewUtils.kt
@@ -20,13 +20,15 @@ fun RecyclerView.applyImeBottomPadding() {
 }
 
 // Handle scroll logic
-fun RecyclerView.handleScrollToBottom() {
+fun RecyclerView.handleScrollToBottom(fastScroll: Boolean = false) {
     val layoutManager = this.layoutManager as LinearLayoutManager
     val last = this.adapter?.itemCount?.minus(1)?.coerceAtLeast(0) ?: return
 
+    if (last < 0) return
+
     val bottomOffset = this.paddingBottom
 
-    if (layoutManager.isSmoothScrolling) {
+    if (layoutManager.isSmoothScrolling || fastScroll) {
         // second tap = instant align
         layoutManager.scrollToPositionWithOffset(last, bottomOffset)
         return
@@ -41,6 +43,7 @@ fun RecyclerView.handleScrollToBottom() {
             return (boxEnd - viewEnd) - bottomOffset
         }
     }
+
     scroller.targetPosition = last
     layoutManager.startSmoothScroll(scroller)
 }


### PR DESCRIPTION
[SES-4388](https://optf.atlassian.net/browse/SES-4388)

Fixes based on the issues found [here](https://optf.atlassian.net/browse/QA-2536).

This PR changes how insets and heights are set for the spacer. The changes here removes double applied space for lower android versions (tested on Android 9) while retaining its behavior for newer versions.

This also includes a `fastScroll` flag for `handleScrollToBottom` since it might take a while to scroll to the bottom when sending attachments if the user is scrolled all the way up and it might mess with the `isNearBottom` flag. 

Sending a message will now scroll to the bottom immediately, like for attachments.

Also includes fixes to the inputBar issues for lower android versions.

