### PR TITLE
SES-4622 : Opening a Notification can scroll conversation to top

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -205,6 +205,7 @@ import org.thoughtcrime.securesms.util.PaddedImageSpan
 import org.thoughtcrime.securesms.util.SaveAttachmentTask
 import org.thoughtcrime.securesms.util.adapter.applyImeBottomPadding
 import org.thoughtcrime.securesms.util.adapter.handleScrollToBottom
+import org.thoughtcrime.securesms.util.adapter.runWhenLaidOut
 import org.thoughtcrime.securesms.util.drawToBitmap
 import org.thoughtcrime.securesms.util.fadeIn
 import org.thoughtcrime.securesms.util.fadeOut
@@ -1162,14 +1163,22 @@ class ConversationActivityV2 : ScreenLockActionBarActivity(), InputBarDelegate,
     private fun scrollToFirstUnreadMessageOrBottom() {
         // if there are no unread messages, go straight to the very bottom of the list
         if (unreadCount == 0) {
-            layoutManager?.scrollToPositionWithOffset(adapter.itemCount - 1, Int.MIN_VALUE)
+            binding.conversationRecyclerView.runWhenLaidOut {
+                layoutManager?.scrollToPositionWithOffset(adapter.itemCount - 1, Int.MIN_VALUE)
+            }
             return
         }
 
         val lastSeenTimestamp = threadDb.getLastSeenAndHasSent(viewModel.threadId).first()
         val lastSeenItemPosition = adapter.findLastSeenItemPosition(lastSeenTimestamp) ?: return
 
-        layoutManager?.scrollToPositionWithOffset(lastSeenItemPosition, ((layoutManager?.height ?: 0) / 2))
+        binding.conversationRecyclerView.runWhenLaidOut {
+            layoutManager?.scrollToPositionWithOffset(
+                lastSeenItemPosition,
+                ((layoutManager?.height ?: 0) / 2)
+            )
+        }
+
     }
 
     private fun highlightViewAtPosition(position: Int) {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/adapter/RecyclerViewUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/adapter/RecyclerViewUtils.kt
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.util.adapter
 
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.doOnPreDraw
 import androidx.core.view.updatePadding
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearSmoothScroller
@@ -43,4 +44,12 @@ fun RecyclerView.handleScrollToBottom() {
     }
     scroller.targetPosition = last
     layoutManager.startSmoothScroll(scroller)
+}
+
+fun RecyclerView.runWhenLaidOut(block: () -> Unit) {
+    if (isLaidOut && !isLayoutRequested) {
+        post(block)
+    } else {
+        doOnPreDraw { post(block) }
+    }
 }


### PR DESCRIPTION
The bug happens in **lower android versions** when `Reply` is clicked and focused in the notification tray, and then clicking the notification to open the conversation. This is because of the IME and opening the conversation screen will hide it. For lower android versions, our pending scroll can get discarded because the layout change.

This PR adds `RecyclerView.runWhenLaidOut` which guarantees a block runs after the list has a stable layout.

https://github.com/user-attachments/assets/d7a98d35-df4d-466b-9f5b-396828b5f851

