### PR TITLE
[SES-4642] - Fix group left notification message not sent

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/groups/GroupLeavingWorker.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/GroupLeavingWorker.kt
@@ -88,8 +88,9 @@ class GroupLeavingWorker @AssistedInject constructor(
                         )
 
                         // Wait for both messages to be sent
-                        statusChannel.receive().getOrThrow()
-                        statusChannel.receive().getOrThrow()
+                        repeat(2) {
+                            statusChannel.receive().getOrThrow()
+                        }
                     }
 
                     // If we are the only admin, leaving this group will destroy the group


### PR DESCRIPTION
This issue: a "XXX left the group" message not received (or not received reliably).

The root cause is we have tidied up the lifecycle of conversations including groups: essentially when the config data is removed, everything related to that resource will be cleaned up, this includes the group key used to encrypt the message to send to the group.

The "XXX left the group" message used to be send uncontrollably - meaning we fire it but never care if it's sent, but now we do because we are removing the resource from the config as soon as the "leave group process message" is sent. There's a non-trival chance that the notification message is not sent within this timeframe and thus gets cancelld by the group removal. This PR makes sure we send these two messages before we go ahead and remove the group from our config.
