### PR TITLE
Revert "Bump io.github.simophin:sqlite-web-viewer from 0.0.3 to 0.2.0…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -168,7 +168,7 @@ turbine = { module = "app.cash.turbine:turbine", version.ref = "turbineVersion" 
 huawei-push = { module = 'com.huawei.hms:push', version.ref = 'huaweiPushVersion' }
 google-play-review = { module = "com.google.android.play:review", version.ref = "googlePlayReviewVersion" }
 google-play-review-ktx = { module = "com.google.android.play:review-ktx", version.ref = "googlePlayReviewVersion" }
-sqlite-web-viewer = { module = "io.github.simophin:sqlite-web-viewer", version = "0.2.0" }
+sqlite-web-viewer = { module = "io.github.simophin:sqlite-web-viewer", version = "0.0.3" }
 protoc = { module = "com.google.protobuf:protoc", version = "4.31.1" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilVersion" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coilVersion" }


### PR DESCRIPTION
Reverting this for now as it requires bumping up the target SDK version to 36.