### PR TITLE
SES-4649 : Continue button is not visible with increased font size when onboarding (notification selection screen)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/onboarding/messagenotifications/MessageNotifications.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/onboarding/messagenotifications/MessageNotifications.kt
@@ -1,5 +1,7 @@
 package org.thoughtcrime.securesms.onboarding.messagenotifications
 
+import android.R.attr.checked
+import android.R.attr.onClick
 import androidx.annotation.StringRes
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
@@ -7,8 +9,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -54,52 +59,65 @@ internal fun MessageNotificationsScreen(
         return
     }
 
-    if (state.showingBackWarningDialogText != null)  {
-        OnboardingBackPressAlertDialog(dismissDialog,
+    if (state.showingBackWarningDialogText != null) {
+        OnboardingBackPressAlertDialog(
+            dismissDialog,
             textId = state.showingBackWarningDialogText,
             quit = quit
         )
     }
 
-    Column {
-        Spacer(Modifier.weight(1f))
-        Column(modifier = Modifier.padding(horizontal = LocalDimensions.current.mediumSpacing)) {
-            Text(stringResource(R.string.notificationsMessage), style = LocalType.current.h4)
-            Spacer(Modifier.height(LocalDimensions.current.smallSpacing))
-            Text(
-                Phrase.from(stringResource(R.string.onboardingMessageNotificationExplanation))
-                    .put(APP_NAME_KEY, stringResource(R.string.app_name))
-                    .format().toString(),
-                style = LocalType.current.base
-            )
-            Spacer(Modifier.height(LocalDimensions.current.spacing))
+    val scroll = rememberScrollState()
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .verticalScroll(scroll),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(modifier = Modifier.padding(horizontal = LocalDimensions.current.mediumSpacing)) {
+                Text(stringResource(R.string.notificationsMessage), style = LocalType.current.h4)
+                Spacer(Modifier.height(LocalDimensions.current.smallSpacing))
+                Text(
+                    Phrase.from(stringResource(R.string.onboardingMessageNotificationExplanation))
+                        .put(APP_NAME_KEY, stringResource(R.string.app_name))
+                        .format().toString(),
+                    style = LocalType.current.base
+                )
+                Spacer(Modifier.height(LocalDimensions.current.spacing))
+
+                NotificationRadioButton(
+                    R.string.notificationsFastMode,
+                    if (BuildConfig.FLAVOR == "huawei") R.string.notificationsFastModeDescriptionHuawei
+                    else R.string.notificationsFastModeDescription,
+                    modifier = Modifier
+                        .qaTag(R.string.AccessibilityId_notificationsFastMode)
+                        .fillMaxWidth(),
+                    tag = R.string.recommended,
+                    checked = state.pushEnabled,
+                    onClick = { setEnabled(true) }
+                )
+
+                // spacing between buttons is provided by ripple/downstate of NotificationRadioButton
+
+                val explanationTxt =
+                    Phrase.from(stringResource(R.string.notificationsSlowModeDescription))
+                        .put(APP_NAME_KEY, stringResource(R.string.app_name))
+                        .format().toString()
+
+                NotificationRadioButton(
+                    stringResource(R.string.notificationsSlowMode),
+                    explanationTxt,
+                    modifier = Modifier
+                        .qaTag(R.string.AccessibilityId_notificationsSlowMode)
+                        .fillMaxWidth(),
+                    checked = state.pushDisabled,
+                    onClick = { setEnabled(false) }
+                )
+            }
         }
-
-        NotificationRadioButton(
-            R.string.notificationsFastMode,
-            if(BuildConfig.FLAVOR == "huawei") R.string.notificationsFastModeDescriptionHuawei
-            else R.string.notificationsFastModeDescription,
-            modifier = Modifier.qaTag(R.string.AccessibilityId_notificationsFastMode),
-            tag = R.string.recommended,
-            checked = state.pushEnabled,
-            onClick = { setEnabled(true) }
-        )
-
-        // spacing between buttons is provided by ripple/downstate of NotificationRadioButton
-
-        val explanationTxt = Phrase.from(stringResource(R.string.notificationsSlowModeDescription))
-            .put(APP_NAME_KEY, stringResource(R.string.app_name))
-            .format().toString()
-
-        NotificationRadioButton(
-            stringResource(R.string.notificationsSlowMode),
-            explanationTxt,
-            modifier = Modifier.qaTag(R.string.AccessibilityId_notificationsSlowMode),
-            checked = state.pushDisabled,
-            onClick = { setEnabled(false) }
-        )
-
-        Spacer(Modifier.weight(1f))
 
         ContinueAccentOutlineButton(Modifier.align(Alignment.CenterHorizontally), onContinue)
     }
@@ -116,12 +134,12 @@ private fun NotificationRadioButton(
 ) {
     // Pass-through from this string ID version to the version that takes strings
     NotificationRadioButton(
-        titleTxt       = stringResource(titleId),
+        titleTxt = stringResource(titleId),
         explanationTxt = stringResource(explanationId),
-        modifier       = modifier,
-        tag            = tag,
-        checked        = checked,
-        onClick        = onClick
+        modifier = modifier,
+        tag = tag,
+        checked = checked,
+        onClick = onClick
     )
 }
 
@@ -138,7 +156,9 @@ private fun NotificationRadioButton(
         onClick = onClick,
         modifier = modifier,
         selected = checked,
-        contentPadding = PaddingValues(horizontal = LocalDimensions.current.mediumSpacing, vertical = 7.dp)
+        contentPadding = PaddingValues(
+            vertical = 7.dp
+        )
     ) {
         Box(
             modifier = Modifier
@@ -150,7 +170,11 @@ private fun NotificationRadioButton(
                 ),
         ) {
             Column(
-                modifier = Modifier.padding(horizontal = LocalDimensions.current.smallSpacing, vertical = LocalDimensions.current.xsSpacing)) {
+                modifier = Modifier.padding(
+                    horizontal = LocalDimensions.current.smallSpacing,
+                    vertical = LocalDimensions.current.xsSpacing
+                )
+            ) {
                 Text(
                     titleTxt,
                     style = LocalType.current.h8


### PR DESCRIPTION
[SES-4649](https://optf.atlassian.net/browse/SES-4649)

This PR updates the Message notifications screen to pin the button to the bottom of the screen and make the options scrollable. This fixes an issue with devices using the maximum text and display scaling.

Max scaling

https://github.com/user-attachments/assets/1b7b6c19-56ee-4194-a3cd-e42ebbc388f8

Default
<img width="287" height="615" alt="Screenshot 2025-10-02 at 2 19 27 PM" src="https://github.com/user-attachments/assets/7ab7af7a-76fd-4d53-ba4c-e52b73fcf043" />
