### PR TITLE
Better error handling for errors in SOGS

### DIFF
--- a/app/src/main/java/org/session/libsession/snode/OnionRequestAPI.kt
+++ b/app/src/main/java/org/session/libsession/snode/OnionRequestAPI.kt
@@ -417,9 +417,9 @@ object OnionRequestAPI {
                     // 404 is probably file server missing a file, don't rebuild path or mark a snode as bad here
                     Log.d("Loki","Request returned a non penalizing code ${exception.statusCode} with message: $message")
                 }
-                else if (destination is Destination.Server
-                    && exception is HTTPRequestFailedAtDestinationException
-                    && (exception.statusCode in 500..504)) {
+                else if (destination is Destination.Server &&
+                    (exception.statusCode in 500..504) &&
+                    (exception is HTTPRequestFailedAtDestinationException || exception.body?.contains(destination.host) == true)) {
                     Log.d("Loki","Destination server error - Non path penalizing. Request returned code ${exception.statusCode} with message: $message")
                 } else if (message == "Loki Server error") {
                     Log.d("Loki", "message was $message")

--- a/app/src/main/java/org/session/libsession/snode/OnionRequestAPI.kt
+++ b/app/src/main/java/org/session/libsession/snode/OnionRequestAPI.kt
@@ -418,7 +418,8 @@ object OnionRequestAPI {
                     Log.d("Loki","Request returned a non penalizing code ${exception.statusCode} with message: $message")
                 }
                 else if (destination is Destination.Server
-                    && (exception.statusCode == 500 || exception.statusCode == 504)) {
+                    && exception is HTTPRequestFailedAtDestinationException
+                    && (exception.statusCode in 500..504)) {
                     Log.d("Loki","Destination server error - Non path penalizing. Request returned code ${exception.statusCode} with message: $message")
                 } else if (message == "Loki Server error") {
                     Log.d("Loki", "message was $message")

--- a/app/src/main/java/org/session/libsignal/utilities/HTTP.kt
+++ b/app/src/main/java/org/session/libsignal/utilities/HTTP.kt
@@ -73,8 +73,8 @@ object HTTP {
 
     open class HTTPRequestFailedException(
         val statusCode: Int,
-        val json: Map<*, *>?,
-        val body: String?,
+        val json: Map<*, *>? = null,
+        val body: String? = null,
         message: String = "HTTP request failed with status code $statusCode"
     ) : kotlin.Exception(message)
     class HTTPNoNetworkException : HTTPRequestFailedException(0, null, "No network connection")
@@ -135,7 +135,7 @@ object HTTP {
                     in 200..299 -> response.body.bytes()
                     else -> {
                         Log.d("Loki", "${verb.rawValue} request to $url failed with status code: $statusCode.")
-                        throw HTTPRequestFailedException(statusCode, json = null, body = response.body.string())
+                        throw HTTPRequestFailedException(statusCode, body = response.body.string())
                     }
                 }
             }
@@ -148,9 +148,8 @@ object HTTP {
 
                 // Override the actual error so that we can correctly catch failed requests in OnionRequestAPI
                 throw HTTPRequestFailedException(
-                    0,
-                    null,
-                    "HTTP request failed due to: ${exception.message}"
+                    statusCode = 0,
+                    message = "HTTP request failed due to: ${exception.message}"
                 )
             } else {
                 throw exception

--- a/app/src/main/java/org/thoughtcrime/securesms/util/AvatarUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/AvatarUtils.kt
@@ -28,6 +28,7 @@ import org.session.libsession.utilities.recipients.displayName
 import org.session.libsignal.utilities.IdPrefix
 import org.thoughtcrime.securesms.database.RecipientRepository
 import org.thoughtcrime.securesms.pro.ProStatusManager
+import org.thoughtcrime.securesms.ui.theme.classicDark3
 import java.math.BigInteger
 import java.security.MessageDigest
 import java.util.Locale
@@ -101,7 +102,13 @@ class AvatarUtils @Inject constructor(
         // custom image
         val (remoteFile, customIcon, color) = when {
             // use custom image if there is one
-            recipient.avatar != null -> Triple(recipient.avatar!!, null, defaultColor)
+            recipient.avatar != null -> Triple(
+                recipient.avatar!!,
+                // for communities, have an icon fallback in case the image errors out
+                if(recipient.isCommunityRecipient) R.drawable.session_logo else null,
+                // communities should always have a neutral fallback bg
+                if(recipient.isCommunityRecipient) classicDark3 else defaultColor
+            )
 
             // communities without a custom image should use a default image
             recipient.isCommunityRecipient -> Triple(null, R.drawable.session_logo, null)


### PR DESCRIPTION
`HTTPRequestFailedAtDestinationException` after we have successfully decrypted a response with the `destinationSymmetricKey` which is a good indication that we failed at the end of the process, and therefore we can extend the range of non penalising errors from bad SOGS