### PR TITLE
Forced to add back message lookup by timestamp for unsend requests

### DIFF
--- a/app/src/main/java/org/session/libsession/database/StorageProtocol.kt
+++ b/app/src/main/java/org/session/libsession/database/StorageProtocol.kt
@@ -93,6 +93,8 @@ interface StorageProtocol {
     fun removeReceivedMessageTimestamps(timestamps: Set<Long>)
     fun getAttachmentsForMessage(mmsMessageId: Long): List<DatabaseAttachment>
     fun getMessageBy(threadId: Long, timestamp: Long, author: String): MessageRecord?
+    @Deprecated("We shouldn't be querying messages by timestamp alone. Use `getMessageBy` when possible ")
+    fun getMessageByTimestamp(timestamp: Long, author: String, getQuote: Boolean): MessageRecord?
     fun updateSentTimestamp(messageId: MessageId, newTimestamp: Long)
     fun markAsResyncing(messageId: MessageId)
     fun markAsSyncing(messageId: MessageId)

--- a/app/src/main/java/org/session/libsession/messaging/jobs/BatchMessageReceiveJob.kt
+++ b/app/src/main/java/org/session/libsession/messaging/jobs/BatchMessageReceiveJob.kt
@@ -253,7 +253,7 @@ class BatchMessageReceiveJob @AssistedInject constructor(
                         }
 
                         is UnsendRequest -> {
-                            val deletedMessage = receivedMessageHandler.handleUnsendRequest(message, threadId)
+                            val deletedMessage = receivedMessageHandler.handleUnsendRequest(message)
 
                             // If we removed a message then ensure it isn't in the 'messageIds'
                             if (deletedMessage != null) {

--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
@@ -128,7 +128,7 @@ class ReceivedMessageHandler @Inject constructor(
                 }
             }
             is DataExtractionNotification -> handleDataExtractionNotification(message)
-            is UnsendRequest -> handleUnsendRequest(message, threadId)
+            is UnsendRequest -> handleUnsendRequest(message)
             is MessageRequestResponse -> messageRequestResponseHandler.get().handleExplicitRequestResponseMessage(message)
             is VisibleMessage -> handleVisibleMessage(
                 message = message,
@@ -221,7 +221,7 @@ class ReceivedMessageHandler @Inject constructor(
     }
 
 
-    fun handleUnsendRequest(message: UnsendRequest, threadId: Long): MessageId? {
+    fun handleUnsendRequest(message: UnsendRequest): MessageId? {
         val userPublicKey = storage.getUserPublicKey()
         val userAuth = storage.userAuth ?: return null
         val isLegacyGroupAdmin: Boolean = message.groupPublicKey?.let { key ->
@@ -244,7 +244,7 @@ class ReceivedMessageHandler @Inject constructor(
 
         val timestamp = message.timestamp ?: return null
         val author = message.author ?: return null
-        val messageToDelete = storage.getMessageBy(threadId, timestamp, author) ?: return null
+        val messageToDelete = storage.getMessageByTimestamp(timestamp, author, false) ?: return null
         val messageIdToDelete = messageToDelete.messageId
         val messageType = messageToDelete.individualRecipient?.getType()
 

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -487,6 +487,12 @@ open class Storage @Inject constructor(
         return database.getMessageFor(threadId, timestamp, address)
     }
 
+    @Deprecated("We shouldn't be querying messages by timestamp alone. Use `getMessageBy` when possible ")
+    override fun getMessageByTimestamp(timestamp: Long, author: String, getQuote: Boolean): MessageRecord? {
+        val database = mmsSmsDatabase
+        return database.getMessageByTimestamp(timestamp, author, getQuote)
+    }
+
     override fun updateSentTimestamp(
         messageId: MessageId,
         newTimestamp: Long


### PR DESCRIPTION
[SES-4679](https://optf.atlassian.net/browse/SES-4679) - Making sure "Delete for everyone" is synced on linked device.
The issue was that we tried to get rid of all message lookups via timestamps only, but this isn't possible in the case of UnsendRequests sent to our own swarm to sync a linked device.