### PR TITLE
[SES-4751] - Fix non-deterministic profile encryption

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/AvatarUploadManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/AvatarUploadManager.kt
@@ -93,6 +93,7 @@ class AvatarUploadManager @Inject constructor(
             val ciphertext = ByteArrayOutputStream().use { outputStream ->
                 ProfileCipherOutputStream(outputStream, key).use {
                     it.write(pictureData)
+                    it.flush()
                 }
 
                 outputStream.toByteArray()


### PR DESCRIPTION
It turns out `flush` is important.
