### PR TITLE
Use correct ed25519 keys for fileserver

### DIFF
--- a/app/src/main/java/org/session/libsession/messaging/file_server/FileServer.kt
+++ b/app/src/main/java/org/session/libsession/messaging/file_server/FileServer.kt
@@ -9,9 +9,9 @@ import org.session.libsession.utilities.serializable.HttpSerializer
 data class FileServer(
     @Serializable(with = HttpSerializer::class)
     val url: HttpUrl,
-    val publicKeyHex: String
+    val ed25519PublicKeyHex: String
 ) {
-    constructor(url: String, publicKeyHex: String) : this(url.toHttpUrl(), publicKeyHex)
+    constructor(url: String, ed25519PublicKeyHex: String) : this(url.toHttpUrl(), ed25519PublicKeyHex)
 }
 
 val HttpUrl.isOfficial: Boolean

--- a/app/src/main/java/org/thoughtcrime/securesms/debugmenu/DebugMenuViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/debugmenu/DebugMenuViewModel.kt
@@ -495,11 +495,11 @@ class DebugMenuViewModel @Inject constructor(
         private val TEST_FILE_SERVERS: List<FileServer> = listOf(
             FileServer(
                 url = "http://potatofiles.getsession.org",
-                publicKeyHex = "fc097b06821c98a2db75ce02e521cef5fd9d3446e42e81d843c4c8c4e9260f48",
+                ed25519PublicKeyHex = "ff86dcd4b26d1bfec944c59859494248626d6428efc12168749d65a1b92f5e28",
             ),
             FileServer(
                 url = "http://superduperfiles.oxen.io",
-                publicKeyHex = "16d6c60aebb0851de7e6f4dc0a4734671dbf80f73664c008596511454cb6576d",
+                ed25519PublicKeyHex = "929e33ded05e653fec04b49645117f51851f102a947e04806791be416ed76602",
             )
         )
     }

--- a/app/src/test/java/org/session/libsession/messaging/file_server/FileServerApiTest.kt
+++ b/app/src/test/java/org/session/libsession/messaging/file_server/FileServerApiTest.kt
@@ -28,7 +28,7 @@ class FileServerApiTest {
                     usesDeterministicEncryption = true,
                     fileServer = FileServer(
                         url = "http://fileserver".toHttpUrl(),
-                        publicKeyHex = "1234"
+                        ed25519PublicKeyHex = "1234"
                     )
                 )
             ),
@@ -40,7 +40,7 @@ class FileServerApiTest {
                     usesDeterministicEncryption = true,
                     fileServer = FileServer(
                         url = "http://fileserver".toHttpUrl(),
-                        publicKeyHex = "1234"
+                        ed25519PublicKeyHex = "1234"
                     )
                 )
             ),
@@ -52,7 +52,7 @@ class FileServerApiTest {
                     usesDeterministicEncryption = false,
                     fileServer = FileServer(
                         url = "http://fileserver".toHttpUrl(),
-                        publicKeyHex = "1234"
+                        ed25519PublicKeyHex = "1234"
                     )
                 )
             ),
@@ -73,7 +73,7 @@ class FileServerApiTest {
                     usesDeterministicEncryption = false,
                     fileServer = FileServer(
                         "http://fileabc.getsession.org",
-                        FileServerApi.DEFAULT_FILE_SERVER.publicKeyHex
+                        FileServerApi.DEFAULT_FILE_SERVER.ed25519PublicKeyHex
                     )
                 ),
             ),


### PR DESCRIPTION
This PR makes sure we reference fileserver's key in ED25519 format, and when we need to make an onion request, we convert it to X25519