### PR TITLE
[SES-5085] - Pro badge not showing for pro who accepting a MR

### DIFF
--- a/app/src/main/java/org/session/libsession/messaging/messages/visible/VisibleMessage.kt
+++ b/app/src/main/java/org/session/libsession/messaging/messages/visible/VisibleMessage.kt
@@ -30,24 +30,11 @@ data class VisibleMessage(
     var reaction: Reaction? = null,
     var hasMention: Boolean = false,
     var blocksMessageRequests: Boolean = false,
-    /**
-     * The pro features enabled for this message.
-     *
-     * Note:
-     * * When this message is an incoming message, the pro features will only be populated
-     * if we can prove that the sender has an active pro subscription.
-     *
-     * * When this message represents an outgoing message, this property can be populated by
-     * application code at their wishes but the actual translating to protobuf onto the wired will
-     * be checked against the current user's pro proof, if no active pro subscription is found,
-     * the pro features will not be sent in the protobuf messages.
-     */
-    var proFeatures: Set<ProFeature> = emptySet()
 ) : Message()  {
 
     // This empty constructor is needed for kryo serialization
     @Keep
-    constructor(): this(proFeatures = emptySet())
+    constructor(): this(text = null)
 
     override val isSelfSendValid: Boolean = true
 
@@ -126,19 +113,6 @@ data class VisibleMessage(
         // Sync target
         if (syncTarget != null) {
             dataMessage.syncTarget = syncTarget
-        }
-
-        // Pro features
-        if (proFeatures.any { it is ProMessageFeature }) {
-            builder.proMessageBuilder.setMsgBitset(
-                proFeatures.toProMessageBitSetValue()
-            )
-        }
-
-        if (proFeatures.any { it is ProProfileFeature }) {
-            builder.proMessageBuilder.setProfileBitset(
-                proFeatures.toProProfileBitSetValue()
-            )
         }
     }
     // endregion

--- a/app/src/main/java/org/thoughtcrime/securesms/pro/ProStatusManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/pro/ProStatusManager.kt
@@ -40,6 +40,7 @@ import network.loki.messenger.libsession_util.protocol.ProMessageFeature
 import network.loki.messenger.libsession_util.util.Conversation
 import network.loki.messenger.libsession_util.util.Util
 import network.loki.messenger.libsession_util.util.asSequence
+import org.session.libsession.messaging.messages.Message
 import org.session.libsession.messaging.messages.visible.VisibleMessage
 import org.session.libsession.network.SnodeClock
 import org.session.libsession.utilities.ConfigFactoryProtocol
@@ -441,7 +442,7 @@ class ProStatusManager @Inject constructor(
     /**
      * Adds Pro features, if any, to an outgoing visible message
      */
-    fun addProFeatures(visibleMessage: VisibleMessage) {
+    fun addProFeatures(message: Message) {
         if (proDataState.value.type !is ProStatus.Active) {
             return
         }
@@ -452,11 +453,12 @@ class ProStatusManager @Inject constructor(
             proFeatures += configs.userProfile.getProFeatures().asSequence()
         }
 
-        if (Util.countCodepoints(visibleMessage.text.orEmpty()) > MAX_CHARACTER_REGULAR){
+        if (message is VisibleMessage &&
+                Util.countCodepoints(message.text.orEmpty()) > MAX_CHARACTER_REGULAR){
             proFeatures += ProMessageFeature.HIGHER_CHARACTER_LIMIT
         }
 
-        visibleMessage.proFeatures = proFeatures
+        message.proFeatures = proFeatures
     }
 
     /**

--- a/app/src/main/java/org/thoughtcrime/securesms/repository/DefaultConversationRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/repository/DefaultConversationRepository.kt
@@ -557,7 +557,11 @@ class DefaultConversationRepository @Inject constructor(
                 }
 
                 withContext(Dispatchers.Default) {
-                    messageSender.send(message = MessageRequestResponse(true), address = recipient)
+                    messageSender.send(
+                        message = MessageRequestResponse(true)
+                            .also(proStatusManager::addProFeatures),
+                        address = recipient
+                    )
 
                     // add a control message for our user
                     storage.insertMessageRequestResponseFromYou(


### PR DESCRIPTION
The issue is because we don't put `ProFeatures` in the control messages, and the approving of a MR is a control message. Once we process the profile change in that control message, we won't touch the same profile version again. So if the original control message doesn't have pro feature then the user won't have any pro feature until another profile update happens.

I've moved the ProFeatures into the `Message` class so that at least for the request approved control message the pro badge is sent.
