### PR TITLE
Fine tune caching policy

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,13 +24,16 @@ jobs:
             extra_build_command_options: '-Phuawei=1'
     steps:
       - uses: actions/checkout@v6
+
       - name: Restore gradle cache
         uses: actions/cache/restore@v5
         with:
           path: |
             ~/.gradle/caches
             .gradle
-          key: ${{ runner.os }}-gradle-dev-${{ matrix.variant }}
+          key: ${{ runner.os }}-gradle-dev-${{ matrix.variant }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-dev-${{ matrix.variant }}-
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -77,7 +80,9 @@ jobs:
           path: |
             ~/.gradle/caches
             .gradle
-          key: ${{ runner.os }}-test-dev
+          key: ${{ runner.os }}-test-dev-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-test-dev-
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5


### PR DESCRIPTION
So that we only save cache on dev build and all other branches' build will restore from dev cache.

This will improve the build time on PRs.
