### PR TITLE
The background poller can never start if the user swipe off or force …

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/BackgroundPollWorker.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/BackgroundPollWorker.kt
@@ -48,7 +48,7 @@ class BackgroundPollWorker @AssistedInject constructor(
         private const val TAG = "BackgroundPollWorker"
         private const val REQUEST_TARGETS = "REQUEST_TARGETS"
 
-        fun schedulePeriodic(context: Context, targets: Collection<Target> = Target.entries) {
+        fun schedulePeriodic(context: Context, policy: ExistingPeriodicWorkPolicy, targets: Collection<Target> = Target.entries) {
             Log.v(TAG, "Scheduling periodic work.")
             val interval = 15.minutes
             val builder = PeriodicWorkRequestBuilder<BackgroundPollWorker>(interval.inWholeSeconds, TimeUnit.SECONDS)
@@ -62,7 +62,7 @@ class BackgroundPollWorker @AssistedInject constructor(
             val workRequest = builder.build()
             WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                 TAG,
-                ExistingPeriodicWorkPolicy.REPLACE,
+                policy,
                 workRequest
             )
         }


### PR DESCRIPTION
Swiping off the app or force stopping will bypass the background polling logic.
We can schedule the background poller as soon as the user logs in instead as it won't interfere with out regular polling logic, and this way it is guaranteed to be active when the app is force closed.