### PR TITLE
SES-5360 - reset expiry CTAs when user is back active

### DIFF
--- a/app/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
+++ b/app/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
@@ -153,6 +153,7 @@ interface TextSecurePreferences {
     fun setHasSeenProExpiring()
     fun hasSeenProExpired(): Boolean
     fun setHasSeenProExpired()
+    fun clearProExpiryView()
     fun watchPostProStatus(): StateFlow<Boolean>
     fun setShownCallWarning(): Boolean
     fun setShownCallNotification(): Boolean
@@ -992,6 +993,11 @@ class AppTextSecurePreferences @Inject constructor(
 
     override fun setHasSeenProExpired() {
         setBooleanPreference(HAS_SEEN_PRO_EXPIRED, true)
+    }
+
+    override fun clearProExpiryView() {
+        setBooleanPreference(HAS_SEEN_PRO_EXPIRED, false)
+        setBooleanPreference(HAS_SEEN_PRO_EXPIRING, false)
     }
 
     override fun watchPostProStatus(): StateFlow<Boolean> {

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeViewModel.kt
@@ -232,7 +232,10 @@ class HomeViewModel @Inject constructor(
                 var showExpiring: Boolean = false
                 var showExpired: Boolean = false
 
-                if(subscription.type is ProStatus.Active.Expiring
+                if(subscription.type is ProStatus.Active &&
+                    (prefs.hasSeenProExpiring() || prefs.hasSeenProExpired())){
+                    prefs.clearProExpiryView() // reset expiry view if the user is active again
+                } else if(subscription.type is ProStatus.Active.Expiring
                     && !prefs.hasSeenProExpiring()
                 ){
                     val validUntil = subscription.type.renewingAt


### PR DESCRIPTION
[SES-5360](https://optf.atlassian.net/browse/SES-5360) - Reset Expiry CTAs when the user is back to Pro Active