### PR TITLE
Filter group messages from blocked senders

### DIFF
--- a/app/src/main/java/org/session/libsession/messaging/sending_receiving/MessageParser.kt
+++ b/app/src/main/java/org/session/libsession/messaging/sending_receiving/MessageParser.kt
@@ -227,7 +227,7 @@ class MessageParser @Inject constructor(
         return parseMessage(
             decodedEnvelope = decoded,
             relaxSignatureCheck = false,
-            checkForBlockStatus = false,
+            checkForBlockStatus = true,
             isForGroup = true,
             senderIdPrefix = IdPrefix.STANDARD,
             currentUserId = currentUserId,


### PR DESCRIPTION
## Summary
- Android was passing `checkForBlockStatus = false` in `parseGroupMessage`, so messages from blocked contacts in groups were always processed and displayed
- iOS and Desktop both discard visible messages from blocked senders in groups — Android was the odd one out
- Fix: set `checkForBlockStatus = true` in `parseGroupMessage` so the existing `isUserBlocked + shouldDiscardIfBlocked` guard applies to group messages

## Test plan
- [ ] Block contact B on device A (and vice versa)
- [ ] Both are members of the same closed group
- [ ] B sends a message to the group
- [ ] Verify A does **not** see B's message in the group
- [ ] Verify unblocked members' messages still appear normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)