### PR TITLE
Fixing issues with large images loading

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/ThumbnailView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/ThumbnailView.kt
@@ -209,10 +209,14 @@ open class ThumbnailView @JvmOverloads constructor(
             }.let { into(it) }
         }
 
-    private fun <T> RequestBuilder<T>.overrideDimensions() =
-        dimensDelegate.resourceSize().takeIf { 0 !in it }
-            ?.let { override(it[WIDTH], it[HEIGHT]) }
-            ?: override(getDefaultWidth(), getDefaultHeight())
+    private fun <T> RequestBuilder<T>.overrideDimensions(): RequestBuilder<T> {
+        val size = dimensDelegate.resourceSize()
+        if (0 !in size) return override(size[WIDTH], size[HEIGHT])
+        val w = getDefaultWidth()
+        val h = getDefaultHeight()
+        if (w > 0 && h > 0) return override(w, h)
+        return this
+    }
 }
 
 private fun <T> RequestBuilder<T>.missingThumbnailPicture(

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/DecryptableStreamLocalUriFetcher.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/DecryptableStreamLocalUriFetcher.java
@@ -1,49 +1,81 @@
 package org.thoughtcrime.securesms.mms;
 
-import android.content.ContentResolver;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+import com.bumptech.glide.Priority;
+import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.data.DataFetcher;
+
 import org.session.libsignal.utilities.Log;
-
-import com.bumptech.glide.load.data.StreamLocalUriFetcher;
-
 import org.thoughtcrime.securesms.util.MediaUtil;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 
-class DecryptableStreamLocalUriFetcher extends StreamLocalUriFetcher {
+class DecryptableStreamLocalUriFetcher implements DataFetcher<ByteBuffer> {
 
   private static final String TAG = DecryptableStreamLocalUriFetcher.class.getSimpleName();
 
-  private Context context;
+  private final Context context;
+  private final Uri uri;
 
   DecryptableStreamLocalUriFetcher(Context context, Uri uri) {
-    super(context.getContentResolver(), uri);
-    this.context      = context;
+    this.context = context;
+    this.uri = uri;
   }
 
   @Override
-  protected InputStream loadResource(Uri uri, ContentResolver contentResolver) throws FileNotFoundException {
+  public void loadData(@NonNull Priority priority, @NonNull DataCallback<? super ByteBuffer> callback) {
+    try {
+      callback.onDataReady(ByteBuffer.wrap(readAllBytes()));
+    } catch (IOException e) {
+      Log.w(TAG, e);
+      callback.onLoadFailed(e);
+    }
+  }
+
+  private byte[] readAllBytes() throws IOException {
     if (MediaUtil.hasVideoThumbnail(uri)) {
       Bitmap thumbnail = MediaUtil.getVideoThumbnail(context, uri);
-
       if (thumbnail != null) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         thumbnail.compress(Bitmap.CompressFormat.JPEG, 100, baos);
-        return new ByteArrayInputStream(baos.toByteArray());
+        return baos.toByteArray();
       }
     }
 
-    try {
-      return PartAuthority.getAttachmentStream(context, uri);
-    } catch (IOException ioe) {
-      Log.w(TAG, ioe);
-      throw new FileNotFoundException("PartAuthority couldn't load Uri resource.");
+    try (InputStream stream = PartAuthority.getAttachmentStream(context, uri)) {
+      ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+      byte[] chunk = new byte[8192];
+      int bytesRead;
+      while ((bytesRead = stream.read(chunk)) != -1) {
+        buffer.write(chunk, 0, bytesRead);
+      }
+      return buffer.toByteArray();
     }
+  }
+
+  @Override
+  public void cleanup() {}
+
+  @Override
+  public void cancel() {}
+
+  @NonNull
+  @Override
+  public Class<ByteBuffer> getDataClass() {
+    return ByteBuffer.class;
+  }
+
+  @NonNull
+  @Override
+  public DataSource getDataSource() {
+    return DataSource.LOCAL;
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/DecryptableStreamUriLoader.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/DecryptableStreamUriLoader.java
@@ -13,10 +13,10 @@ import com.bumptech.glide.load.model.MultiModelLoaderFactory;
 
 import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader.DecryptableUri;
 
-import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 
-public class DecryptableStreamUriLoader implements ModelLoader<DecryptableUri, InputStream> {
+public class DecryptableStreamUriLoader implements ModelLoader<DecryptableUri, ByteBuffer> {
 
   private final Context context;
 
@@ -26,7 +26,7 @@ public class DecryptableStreamUriLoader implements ModelLoader<DecryptableUri, I
 
   @Nullable
   @Override
-  public LoadData<InputStream> buildLoadData(@NonNull DecryptableUri decryptableUri, int width, int height, @NonNull Options options) {
+  public LoadData<ByteBuffer> buildLoadData(@NonNull DecryptableUri decryptableUri, int width, int height, @NonNull Options options) {
     return new LoadData<>(decryptableUri, new DecryptableStreamLocalUriFetcher(context, decryptableUri.uri));
   }
 
@@ -35,7 +35,7 @@ public class DecryptableStreamUriLoader implements ModelLoader<DecryptableUri, I
     return true;
   }
 
-  static class Factory implements ModelLoaderFactory<DecryptableUri, InputStream> {
+  static class Factory implements ModelLoaderFactory<DecryptableUri, ByteBuffer> {
 
     private final Context context;
 
@@ -44,7 +44,7 @@ public class DecryptableStreamUriLoader implements ModelLoader<DecryptableUri, I
     }
 
     @Override
-    public @NonNull ModelLoader<DecryptableUri, InputStream> build(@NonNull MultiModelLoaderFactory multiFactory) {
+    public @NonNull ModelLoader<DecryptableUri, ByteBuffer> build(@NonNull MultiModelLoaderFactory multiFactory) {
       return new DecryptableStreamUriLoader(context);
     }
 
@@ -83,4 +83,3 @@ public class DecryptableStreamUriLoader implements ModelLoader<DecryptableUri, I
     }
   }
 }
-

--- a/app/src/main/java/org/thoughtcrime/securesms/mms/SignalGlideModule.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mms/SignalGlideModule.java
@@ -37,6 +37,7 @@ import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader.DecryptableUri;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 
 @GlideModule
 public class SignalGlideModule extends AppGlideModule {
@@ -67,7 +68,7 @@ public class SignalGlideModule extends AppGlideModule {
     registry.append(RemoteFile.class, InputStream.class, new RemoteFileLoader.Factory(
             ((ApplicationContext) (context.getApplicationContext())).getRemoteFileLoader()
     ));
-    registry.append(DecryptableUri.class, InputStream.class, new DecryptableStreamUriLoader.Factory(context));
+    registry.append(DecryptableUri.class, ByteBuffer.class, new DecryptableStreamUriLoader.Factory(context));
     registry.append(ChunkedImageUrl.class, InputStream.class, new ChunkedImageUrlLoader.Factory());
     registry.replace(GlideUrl.class, InputStream.class, new OkHttpUrlLoader.Factory());
   }


### PR DESCRIPTION
Large encrypted images (PNG, WebP) failed to load as thumbnails. The root cause was a two-layer issue with how Glide handles our encrypted attachment streams:                                                                                              
   
  1. CipherInputStream (returned by our decryption layer) doesn't support mark/reset. Glide requires this to detect the image    
  format — it reads some header bytes, rewinds, then decodes.
  2. The obvious fix — buffering the decrypted bytes into a ByteArrayInputStream before handing to Glide — still failed for large images (~500KB+). Glide wraps any InputStream in its own RecyclableBufferedInputStream, which has a bug where its internal mark gets invalidated as the buffer grows to accommodate large files, even when the data is well within the 5MB mark limit.
                                                                                                                                 
  Fix:                                                                                                                            
  Switch the data type from InputStream to ByteBuffer throughout the DecryptableUri Glide pipeline (DecryptableStreamLocalUriFetcher, DecryptableStreamUriLoader, SignalGlideModule).
                                                                                                                                 
  When Glide receives a ByteBuffer, it uses ByteBufferRewinder which rewinds by calling ByteBuffer.position(0) — no              
  RecyclableBufferedInputStream, no mark/reset involved at all. This works reliably regardless of file size or image format.
                                                                                                                                 
  The fetcher now reads the full decrypted stream into a byte[] and wraps it as a ByteBuffer before passing it to Glide. All     
  existing callers already use DiskCacheStrategy.NONE, so there is no impact on caching behaviour.
                                                                                                                                 
  Also fixed ThumbnailView.overrideDimensions() previously always fell back to override(getDefaultWidth(), getDefaultHeight()) even when both values were 0, which could cause Glide to request a 0×0 image. It now only overrides dimensions when valid ones are available, otherwise lets Glide size from the view.    
