### PR TITLE
Move keystore access further away from Application.onCreate

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.kt
@@ -35,6 +35,7 @@ import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import network.loki.messenger.BuildConfig
 import network.loki.messenger.R
 import network.loki.messenger.libsession_util.util.LogLevel
@@ -157,8 +158,13 @@ class ApplicationContext : Application(), DefaultLifecycleObserver, Configuratio
         // they are initialised.
         workerFactory.get()
 
-        startupComponents.get()
-            .onPostAppStarted()
+        // Defer the app started callback until next frame
+        GlobalScope.launch {
+            withContext(Dispatchers.Main) {
+                startupComponents.get()
+                    .onPostAppStarted()
+            }
+        }
     }
 
     override fun onStart(owner: LifecycleOwner) {


### PR DESCRIPTION
Defer the initialization of all `OnAppStartUpComponent` until next frame after ApplicationContext.onCreate, in the hope of avoiding too early access to Android keystore