### PR TITLE
Synchronize the keystore creating process

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/crypto/KeyStoreHelper.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/crypto/KeyStoreHelper.java
@@ -71,7 +71,7 @@ public final class KeyStoreHelper {
     }
   }
 
-  private static SecretKey getOrCreateKeyStoreEntry() {
+  private synchronized static SecretKey getOrCreateKeyStoreEntry() {
     if (hasKeyStoreEntry()) return getKeyStoreEntry();
     else                    return createKeyStoreEntry();
   }


### PR DESCRIPTION
Fix a potential issue where a keystore entry is created twice causing different key is used for different component.
