### PR TITLE
Release tooling improvements

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,114 @@
-How to use `build-and-release.py`:
+# Session Android — release & CI scripts
 
-You need to install `uv` and `gh` to use this script.
+Helper scripts for cutting a release, pushing builds to Google Play / F-Droid,
+and the Drone CI artifact plumbing.
+
+Most of the Python scripts need `gh` (GitHub CLI) and read their secrets from the
+OS keyring (see `_keyring.py`). `build-and-release.py` additionally needs
+`fdroid` and the Google API client libraries; `play-store.py` needs the Google
+API client libraries.
+
+## Release pipeline (run in this order)
+
+A full release is four scripts, run in sequence:
+
+1. **`prepare-release.py <version>`** — forks a `release/<version>` branch off
+   `master` (or `--from <branch>`), commits a `canonicalVersionCode` /
+   `canonicalVersionName` bump, pushes it, and creates a GitHub **draft** release
+   targeting the branch. Then it stops — you merge/cherry-pick the payload into
+   the branch yourself. `--dry-run` shows the plan without touching anything.
+
+2. **`update-release-notes.py <version>`** — regenerates the draft's changelog
+   from the branch's merged-PR titles (GitHub's own "What's Changed" generator)
+   and overwrites the release body. Re-run whenever the branch changes; run it
+   **before** the PGP-signing step, since it clobbers the whole body.
+
+3. **`build-and-release.py`** — builds the signed release artifacts for all
+   distribution flavors: `play` (AAB + split APKs), `fdroid`, and `huawei`.
+   Signing creds come from the keyring (`release-creds`, a TOML blob). Unless
+   `--build-only` is given it also opens an F-Droid release PR
+   (`session-foundation/session-fdroid`) and uploads the artifacts to the GitHub
+   draft release. `--build-type` overrides the default `release`.
+
+4. **`play-store.py upload`** — uploads the built AAB to Google Play (see below),
+   then you publish the draft (`gh release edit <version> --draft=false`).
+
+## Dev / test build to the internal track
+
+When you just want a real, signed build on the **internal** testing track —
+e.g. to exercise real Google Play Billing purchases against a dev Pro backend —
+skip the whole pipeline above (no release branch, version-name bump, notes,
+F-Droid PR, or GitHub draft). Because the build is release-signed and lives on a
+track, Play Billing works; as a license tester the purchases are real (backend
+validates the token) but uncharged.
+
+1. Build a signed `play` AAB, using the signing creds from the keyring:
+
+   ```sh
+   scripts/build-and-release.py --play-only
+   ```
+
+   `--play-only` skips the `fdroid`/`huawei` flavors and every upload/PR step, so
+   it needs neither `fdroid`/`gh` nor huawei creds — just the `release-creds`
+   entry. (If you'd rather not use the keyring at all, you can build the bundle
+   straight from gradle with `./gradlew :app:bundlePlayRelease -PSESSION_STORE_FILE=…
+   -PSESSION_STORE_PASSWORD=… -PSESSION_KEY_ALIAS=… -PSESSION_KEY_PASSWORD=…`.)
+
+2. Make sure `versionCode` is higher than anything already on the track — check
+   with `play-store.py status`, and bump `canonicalVersionCode` in
+   `app/build.gradle.kts` if needed (a throwaway local bump is fine here).
+
+3. Upload to the internal track:
+
+   ```sh
+   scripts/play-store.py upload                            # internal, as a draft
+   scripts/play-store.py upload --track internal --submit  # live to testers (no review)
+   ```
+
+4. Opt in as a tester (Play Console → internal testing → testers list + the
+   opt-in URL) and install from Play on a device signed into that account.
+
+Once one build is on the track you don't need to re-upload for every change: a
+locally-built, identically-signed `./gradlew :app:installPlayRelease` with the
+**same** versionCode installs over adb and Play Billing keeps working — only
+bump + re-upload when you deliberately move the versionCode.
+
+## Google Play
+
+**`play-store.py`** — command-line control of the Google Play release via the
+Play Developer API (service-account key from the keyring, name
+`play-service-account`). Subcommands:
+
+- `status` — list each track's releases (version codes, status, rollout %).
+- `upload [AAB]` — upload a bundle to a track; **defaults to the `internal`
+  track as a draft**. `--track {internal,alpha,beta,production}`, `--submit`
+  (full rollout) or `--rollout FRACTION` (staged), `--dry-run`.
+- `rollout {FRACTION|complete|halt}` — change an existing staged rollout without
+  re-uploading (defaults to `--track production`).
+- `share [APK|AAB]` — upload to **Internal App Sharing** and print an install
+  link. Unlike a track release this consumes **no** versionCode (re-upload the
+  same code freely) and needs no release/rollout/track management, so it's the
+  fast loop for iterating on a build that still needs Google's signature (e.g. to
+  exercise Play Billing): `build-and-release.py --play-only` → `play-store.py
+  share` → open the printed link on the device.
+
+## Secrets
+
+**`_keyring.py`** — thin cross-platform wrapper over the `keyring` library. Used
+as a helper by the release scripts (`get_secret`), and as a CLI to store secrets
+once so they never sit on disk in plaintext:
+
+```sh
+python3 scripts/_keyring.py set release-creds        < release-creds.toml
+python3 scripts/_keyring.py set play-service-account < service-account.json
+# ...then delete the plaintext files. `get` / `del` subcommands also exist.
+```
+
+## Drone CI (invoked by CI, not run by hand)
+
+- **`drone-static-upload.sh`** — packages the universal APK into a
+  `session-android-<tag-or-datetime-commit>-universal.tar.xz` and SFTP-uploads it
+  to `oxen.rocks` (needs `SSH_KEY` in the environment).
+- **`drone-upload-exists.sh`** — for a PR build, polls `oxen.rocks` for up to 30
+  minutes for an already-uploaded artifact matching the PR's fork/branch, so CI
+  can skip a redundant rebuild. Exits 0 if found.

--- a/scripts/build-and-release.py
+++ b/scripts/build-and-release.py
@@ -49,27 +49,39 @@ def build_releases(project_root: str,
                    extra_gradle_opts: str = '',
                    build_type: string = 'release',
                    build_bundle: bool = False,
-                   split_apks: bool = False) -> BuildResult:
+                   split_apks: bool = False,
+                   libsession_util_path: str = None) -> BuildResult:
     (keystore_fd, keystore_file) = tempfile.mkstemp(prefix='keystore_', suffix='.jks', dir=build_dir)
     try:
         with os.fdopen(keystore_fd, 'wb') as f:
             f.write(base64.b64decode(credentials.keystore_b64))
 
-        gradle_commands = f"""./gradlew \
-                    -P{credentials_property_prefix}_STORE_FILE='{keystore_file}'\
-                    -P{credentials_property_prefix}_STORE_PASSWORD='{credentials.keystore_password}' \
-                    -P{credentials_property_prefix}_KEY_ALIAS='{credentials.key_alias}' \
-                    -P{credentials_property_prefix}_KEY_PASSWORD='{credentials.key_password}' {extra_gradle_opts}"""
+        # Build the glue (and its native libsession-util) from source at this path instead of the
+        # published AAR; settings.gradle.kts reads this system property (see its comment there).
+        lib_source_opt = (f" -Dsession.libsession_util.project.path='{libsession_util_path}'"
+                          if libsession_util_path else "")
+        # Pass signing secrets via ORG_GRADLE_PROJECT_* env vars, NOT -P command-line args: argv is
+        # world-readable (`ps`, /proc/<pid>/cmdline) and gets echoed into subprocess exceptions on
+        # failure, whereas /proc/<pid>/environ is owner-only. Gradle maps ORG_GRADLE_PROJECT_<name>
+        # to the `<name>` project property, so the app's signingConfig reads these unchanged.
+        gradle_env = {
+            **os.environ,
+            f'ORG_GRADLE_PROJECT_{credentials_property_prefix}_STORE_FILE': keystore_file,
+            f'ORG_GRADLE_PROJECT_{credentials_property_prefix}_STORE_PASSWORD': credentials.keystore_password,
+            f'ORG_GRADLE_PROJECT_{credentials_property_prefix}_KEY_ALIAS': credentials.key_alias,
+            f'ORG_GRADLE_PROJECT_{credentials_property_prefix}_KEY_PASSWORD': credentials.key_password,
+        }
+        gradle_commands = f"./gradlew{lib_source_opt} {extra_gradle_opts}"
         
         if build_bundle:
             bundle_path = os.path.join(project_root, f'app/build/outputs/bundle/{flavor}{build_type.capitalize()}/app-{flavor}-{build_type}.aab')
             subprocess.run(f"""{gradle_commands} -PsplitApks=false \
-                    bundle{flavor.capitalize()}{build_type.capitalize()} --stacktrace""", shell=True, check=True, cwd=project_root)
+                    bundle{flavor.capitalize()}{build_type.capitalize()} --stacktrace""", shell=True, check=True, cwd=project_root, env=gradle_env)
         else:
             bundle_path = None
 
         subprocess.run(f"""{gradle_commands} \
-                    assemble{flavor.capitalize()}{build_type.capitalize()} -PsplitApks={str(split_apks).lower()} --stacktrace""", shell=True, check=True, cwd=project_root)
+                    assemble{flavor.capitalize()}{build_type.capitalize()} -PsplitApks={str(split_apks).lower()} --stacktrace""", shell=True, check=True, cwd=project_root, env=gradle_env)
 
         apk_output_dir = os.path.join(project_root, f'app/build/outputs/apk/{flavor}/{build_type}')
 
@@ -239,17 +251,23 @@ parser = argparse.ArgumentParser(
  )
 
 parser.add_argument('--build-only', action='store_true', help='If set, will only build APKs and skip all upload/fdroid actions')
+parser.add_argument('--play-only', action='store_true', help='Build only the signed play AAB (for a dev/test upload to the internal track); skips the fdroid and huawei flavors and all upload/PR steps')
 parser.add_argument('--build-type', help='Build with specified build type. Default: release', default = 'release')
+parser.add_argument('--libsession', metavar='PATH', help="Build libsession-util-android (and its native libsession-util) from source at this path (the glue repo root), instead of the published AAR. Passed to Gradle as -Dsession.libsession_util.project.path; overrides any local.properties setting.")
 
 args = parser.parse_args()
 
-# Make sure gh command is available
-if shutil.which('gh') is None:
+# Resolve to an absolute path: settings.gradle.kts resolves a relative path against the app's
+# rootDir, so an absolute path is unambiguous regardless of where the glue is checked out.
+lib_util_path = os.path.abspath(args.libsession) if args.libsession else None
+
+# Make sure gh command is available (not needed for a play-only build)
+if not args.play_only and shutil.which('gh') is None:
     print('`gh` command not found. It is required to automate fdroid releases. Please install it from https://cli.github.com/', file=sys.stderr)
     sys.exit(1)
 
-# Make sure fdroid command is available
-if shutil.which('fdroid') is None:
+# Make sure fdroid command is available (not needed for a play-only build)
+if not args.play_only and shutil.which('fdroid') is None:
     print('`fdroid` command not found. Install fdroidserver via your system package manager:\n'
           '  Debian/Ubuntu:  apt install fdroidserver\n'
           '  Homebrew:       brew install fdroidserver\n'
@@ -279,7 +297,19 @@ play_build_result = build_releases(
     build_type=args.build_type,
     build_bundle=True,
     split_apks=True,
+    libsession_util_path=lib_util_path,
     )
+
+# A play-only build is just the signed AAB for a dev/test upload to the internal
+# track, so skip the other flavors and every upload/PR step below.
+if args.play_only:
+    print('\n=====================')
+    print('Build result (play only):')
+    for apk in play_build_result.apk_paths:
+        print(f'\t{apk}')
+    print(f'\t{play_build_result.bundle_path}')
+    print('=====================')
+    sys.exit(0)
 
 print("Building fdroid releases...")
 fdroid_build_result = build_releases(
@@ -290,6 +320,7 @@ fdroid_build_result = build_releases(
     build_type=args.build_type,
     build_bundle=False,
     split_apks=True,
+    libsession_util_path=lib_util_path,
     )
 
 if not args.build_only:
@@ -306,6 +337,7 @@ huawei_build_result = build_releases(
     build_type=args.build_type,
     build_bundle=False,
     split_apks=False,
+    libsession_util_path=lib_util_path,
     )
 
 # If the a github release draft exists, upload the apks to the release

--- a/scripts/play-store.py
+++ b/scripts/play-store.py
@@ -7,6 +7,8 @@ OS keyring (see _keyring.py). Subcommands:
   status                             show each track's releases (version code, status, rollout %)
   upload [AAB]                       upload an AAB to a track
   rollout {FRACTION|complete|halt}   change the current staged rollout on a track (no re-upload)
+  share [APK|AAB]                    upload to Internal App Sharing, print an install link (no
+                                     versionCode consumed; the fast iterate-with-Billing loop)
 
 Prerequisites:
   - apt install python3-google-auth python3-googleapi   (or the pip equivalents)
@@ -189,6 +191,34 @@ def cmd_rollout(pkg, args):
     print(f"Done. Track '{args.track}' release now: {fmt_release(rel)}")
 
 
+def cmd_share(pkg, args):
+    """Upload an APK/AAB to Internal App Sharing and print the install link.
+
+    Unlike a track release, this does NOT consume a versionCode (the same code can be re-uploaded
+    any number of times) and needs no release/rollout/track management — so it's the fast loop for
+    iterating on a build that still needs Google's signature (e.g. to exercise Play Billing)."""
+    if not os.path.isfile(args.artifact):
+        sys.exit(f"Artifact not found: {args.artifact}\n"
+                 f"Build it first (e.g. scripts/build-and-release.py --play-only) or pass the path.")
+    is_aab = args.artifact.lower().endswith(".aab")
+    print(f"Artifact: {args.artifact}\nPackage:  {pkg}\nTarget:   Internal App Sharing ({'bundle' if is_aab else 'APK'})")
+    if args.dry_run:
+        print("\nDry run -- not uploading.")
+        return
+
+    service = play_service()
+    from googleapiclient.http import MediaFileUpload
+    media = MediaFileUpload(args.artifact, mimetype="application/octet-stream", resumable=True)
+    artifacts = service.internalappsharingartifacts()
+    print("Uploading (this can take a while for an AAB)...")
+    call = artifacts.uploadbundle if is_aab else artifacts.uploadapk
+    result = call(packageName=pkg, media_body=media).execute()
+
+    print(f"\nDone. Internal App Sharing install link:\n\n  {result.get('downloadUrl')}\n\n"
+          "Open it on the device signed into an authorized account (an uploader, or an\n"
+          "internal-app-sharing tester). The same versionCode can be re-uploaded any number of times.")
+
+
 def main():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -216,6 +246,11 @@ def main():
     r.add_argument("--track", default="production", choices=TRACKS, help="release track (default: production)")
     r.add_argument("--dry-run", action="store_true", help="show current state and intended change only")
     r.set_defaults(func=cmd_rollout)
+
+    sh = sub.add_parser("share", help="upload an APK/AAB to Internal App Sharing and print the install link")
+    sh.add_argument("artifact", nargs="?", default=DEFAULT_AAB, help=f"path to the APK/AAB (default: {DEFAULT_AAB})")
+    sh.add_argument("--dry-run", action="store_true", help="don't upload; just show what would happen")
+    sh.set_defaults(func=cmd_share)
 
     args = p.parse_args()
     # Run from the repo root so the default AAB path resolves.


### PR DESCRIPTION
- Add `--play-only` flag to build just the Play AAB, for easier play store build testing.
- Add `--libsession` flag to more easily build with a full stack libsession (i.e. when test building against an unreleased libsession)
- Pass signing secrets via env rather than command-line to reduce visibility
- Add a play store `share` command that allows easy Internal App Sharing upload
- Actually put something useful in scripts/README.md