### PR TITLE
fix: don't load session_util from ProStatusManager class init

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/pro/ProStatusManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/pro/ProStatusManager.kt
@@ -491,9 +491,15 @@ class ProStatusManager @Inject constructor(
     }
 
     companion object {
-        // Single-sourced from libsession (see SessionProtocol) rather than hard-coded here.
-        val MAX_CHARACTER_PRO = SessionProtocol.PRO_HIGHER_CHARACTER_LIMIT // max message codepoints for pro users
-        private val MAX_CHARACTER_REGULAR = SessionProtocol.STANDARD_CHARACTER_LIMIT // max message codepoints for non-pro users
+        // Single-sourced from libsession (see SessionProtocol) rather than hard-coded here. Read
+        // through getters, not stored in the initialiser: touching SessionProtocol loads the
+        // session_util native library, and doing that from ProStatusManager's <clinit> makes the
+        // class impossible to even load (let alone mock) on the JVM, where there is no native
+        // library. SessionProtocol already caches both values, so this stays a cheap field read.
+        val MAX_CHARACTER_PRO: Int // max message codepoints for pro users
+            get() = SessionProtocol.PRO_HIGHER_CHARACTER_LIMIT
+        private val MAX_CHARACTER_REGULAR: Int // max message codepoints for non-pro users
+            get() = SessionProtocol.STANDARD_CHARACTER_LIMIT
         const val MAX_PIN_REGULAR = 5 // max pinned conversation for non pro users
 
         const val URL_PRO_SUPPORT = "https://getsession.org/pro-form"


### PR DESCRIPTION
## Problem

`testPlayDebugUnitTest` has been failing on `dev` since c203de90a0 ("Native codepoint counting; route char-limit policy through libsession") — 9 `ConversationViewModelTest` failures. Every PR branched off `dev` inherits it (e.g. #2137, which only bumps `actions/cache`).

From the `test-reports` artifact (the console log only shows the truncated `ExceptionInInitializerError`):

```
java.lang.UnsatisfiedLinkError: no session_util in java.library.path: …
  at network.loki.messenger.libsession_util.LibSessionUtilCApi.<init>(LibSessionUtilCApi.kt:10)
  at …protocol.SessionProtocol.<clinit>(SessionProtocol.kt)
  at org.thoughtcrime.securesms.pro.ProStatusManager.<clinit>(ProStatusManager.kt:495)
  at org.mockito…InlineBytecodeGenerator.assureInitialization(…)
```

`SessionProtocol` is a Kotlin `object` extending `LibSessionUtilCApi`, whose constructor calls `System.loadLibrary("session_util")`. Because the char limits were read into companion `val`s, they were compiled into `ProStatusManager.<clinit>` — so merely *class-loading* `ProStatusManager` loaded the native library. There is no `session_util` on the JVM, so `mock<ProStatusManager>()` in `ConversationViewModelTest.createViewModel` blew up and the 8 subsequent tests followed with `NoClassDefFoundError`.

## Fix

Read both limits through getters instead of storing them in the initialiser, keeping class init free of native side effects. `SessionProtocol` already caches both values via `by lazy`, so each call site is still a field read, and the values are only fetched when a real `ProStatusManager` needs them.

Both are only used from instance methods (`getIncomingMessageMaxLength`, `getCharacterLimit`) and nowhere outside the file, so no callers change.

## Verification

`./gradlew testPlayDebugUnitTest` locally: **198 tests, 0 failures** (was `198 tests completed, 9 failed` in CI).