### PR TITLE
Pro: show hero copy in every Pro status, not just never-subscribed and the sheet

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/ProSettingsHomeScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/ProSettingsHomeScreen.kt
@@ -208,21 +208,26 @@ fun ProSettingsHome(
             }
         }
     ) {
-        // Header for non-pro users or expired users in sheet mode
+        val headerText = when(subscriptionType) {
+            is ProStatus.NeverSubscribed -> R.string.proFullestPotential
+            is ProStatus.Expired -> R.string.proAccessRenewStart
+            is ProStatus.Active -> R.string.proThanksForSupporting
+        }
+
+        if(data.proDataState.refreshState !is State.Success){
+            Spacer(Modifier.height(LocalDimensions.current.contentSpacing))
+        }
+
+        Text(
+            text = Phrase.from(context.getText(headerText))
+                .format().toString(),
+            style = LocalType.current.base,
+            textAlign = TextAlign.Center,
+        )
+
+        // The Continue CTA belongs only where upgrading is what the screen is for — the expired
+        // main screen offers renewal through ProManage below instead.
         if(subscriptionType is ProStatus.NeverSubscribed || expiredInSheet) {
-            if(data.proDataState.refreshState !is State.Success){
-                Spacer(Modifier.height(LocalDimensions.current.contentSpacing))
-            }
-
-            Text(
-                text = if(expiredInSheet) Phrase.from(context.getText(R.string.proAccessRenewStart))
-                    .format().toString()
-                    else Phrase.from(context.getText(R.string.proFullestPotential))
-                    .format().toString(),
-                style = LocalType.current.base,
-                textAlign = TextAlign.Center,
-            )
-
             Spacer(Modifier.height(LocalDimensions.current.spacing))
 
             Box {


### PR DESCRIPTION
The Pro settings header rendered a description only for never-subscribed users, and for expired users in sheet mode. Expired users on the main screen, and active subscribers, saw the image with nothing under it.

Pick the string from the status alone, and split the Continue CTA out of that condition so it stays gated on never-subscribed-or-sheet — the expired main screen already offers renewal through ProManage, and iOS and Desktop attach no button to this text either.