### PR TITLE
Pro: tag each message-info feature row for QA

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/MessageDetailActivity.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.MotionEvent.ACTION_UP
 import androidx.activity.viewModels
+import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -93,6 +94,7 @@ import org.thoughtcrime.securesms.ui.TitledText
 import org.thoughtcrime.securesms.ui.UserProfileModal
 import org.thoughtcrime.securesms.ui.components.Avatar
 import org.thoughtcrime.securesms.ui.components.annotatedStringResource
+import org.thoughtcrime.securesms.ui.qaTag
 import org.thoughtcrime.securesms.ui.setComposeContent
 import org.thoughtcrime.securesms.ui.theme.LocalColors
 import org.thoughtcrime.securesms.ui.theme.LocalDimensions
@@ -401,6 +403,7 @@ fun MessageProFeatures(
 
         features.forEach { feature ->
             ProCTAFeature(
+                modifier = Modifier.qaTag(feature.qaTagRes),
                 textStyle = LocalType.current.large,
                 padding = PaddingValues(),
                 data = CTAFeature.Icon(
@@ -416,6 +419,21 @@ fun MessageProFeatures(
         }
     }
 }
+
+/**
+ * QA tag for a feature row, so a test can assert WHICH features a message was sent with rather than
+ * how many of them there are.
+ *
+ * The values are a cross-platform contract: iOS defines the same strings in
+ * `SessionProUI.AccessibilityIdentifier` and Desktop derives them from its own feature vocabulary, so
+ * one feature is named the same on every client and on every screen it appears on.
+ */
+private val ProFeature.qaTagRes: Int
+    @StringRes get() = when (this) {
+        ProProfileFeature.PRO_BADGE -> R.string.qa_pro_message_feature_badges
+        ProMessageFeature.HIGHER_CHARACTER_LIMIT -> R.string.qa_pro_message_feature_longer_messages
+        ProProfileFeature.ANIMATED_AVATAR -> R.string.qa_pro_message_feature_animated_display_picture
+    }
 
 @Preview
 @Composable

--- a/content-descriptions/src/main/res/values/strings.xml
+++ b/content-descriptions/src/main/res/values/strings.xml
@@ -275,6 +275,13 @@
     <string name="qa_pro_settings_action_faq">pro-settings-faq</string>
     <string name="qa_pro_settings_action_support">pro-settings-support</string>
 
+    <!-- Pro features a message was sent with, listed on the message details screen. The names are the
+         subset of the Pro feature vocabulary that applies per message, so one feature is named the same
+         wherever it appears -->
+    <string name="qa_pro_message_feature_badges">pro-message-feature-badges</string>
+    <string name="qa_pro_message_feature_longer_messages">pro-message-feature-longer-messages</string>
+    <string name="qa_pro_message_feature_animated_display_picture">pro-message-feature-animated-display-picture</string>
+
     <!-- Manage members and admin -->
     <string name="qa_manage_members_invite_contacts">invite-contacts-menu-option</string>
     <string name="qa_manage_members_invite_account_id">invite-accountid-menu-option</string>


### PR DESCRIPTION
The message details screen lists the Session Pro features a message was sent with, but the rows carried no identifier — so an automated test can only match them by their localized text. That breaks on any wording or translation change, and it cannot distinguish *which* feature a row is without hard-coding three strings.

This tags each row with a per-feature id, via the existing `Modifier.qaTag` + `content-descriptions` mechanism:

| Feature | Tag |
|---|---|
| `PRO_BADGE` | `pro-message-feature-badges` |
| `HIGHER_CHARACTER_LIMIT` | `pro-message-feature-longer-messages` |
| `ANIMATED_AVATAR` | `pro-message-feature-animated-display-picture` |

The names are the **per-message subset of the shared Pro feature vocabulary** (the same words the Pro settings surface uses — `longer-messages`, `badges`, `animated-display-picture`), so one feature is called the same thing wherever it appears rather than gaining a second name per screen.

These strings are a **cross-platform contract**: the matching PRs give iOS the same values in `SessionProUI.AccessibilityIdentifier` and Desktop derives them from its own `ProFeatureItems` list, so one Appium locator serves all three clients.

No behaviour change — `qaTag` only adds a Compose test tag.

Verified with `./gradlew :app:compilePlayAutomaticQaKotlin` (BUILD SUCCESSFUL).