### PR TITLE
Pro: correct the link destinations and read the home CTA windows from network time

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeViewModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.launch
 import network.loki.messenger.R
 import network.loki.messenger.libsession_util.PRIORITY_HIDDEN
 import org.session.libsession.database.StorageProtocol
+import org.session.libsession.network.SnodeClock
 import org.session.libsession.messaging.groups.GroupManagerV2
 import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.CommunityUrlParser
@@ -67,7 +68,6 @@ import org.thoughtcrime.securesms.util.UserProfileModalData
 import org.thoughtcrime.securesms.util.UserProfileUtils
 import org.thoughtcrime.securesms.webrtc.CallManager
 import org.thoughtcrime.securesms.webrtc.data.State
-import java.time.Instant
 import javax.inject.Inject
 
 @HiltViewModel
@@ -86,6 +86,7 @@ class HomeViewModel @Inject constructor(
     private val upmFactory: UserProfileUtils.UserProfileUtilsFactory,
     private val recipientRepository: RecipientRepository,
     private val dateUtils: DateUtils,
+    private val snodeClock: SnodeClock,
     private val donationManager: DonationManager,
     private val audioPlaybackManager: AudioPlaybackManager,
     private val openGroupManager: OpenGroupManager,
@@ -224,7 +225,11 @@ class HomeViewModel @Inject constructor(
                 // show a CTA (only once per install) when
                 // - subscription is expiring in less than 7 days
                 // - subscription expired less than 30 days ago
-                val now = Instant.now()
+                // Network time: both comparisons below are against instants the backend supplied,
+                // so device-clock skew moves the boundary rather than the subscription. The two CTAs
+                // also skew in opposite directions — a fast clock warns of expiry early and stops
+                // warning of expiration early — so a wrong reading here is not uniformly wrong.
+                val now = snodeClock.currentTime()
 
                 var showExpiring: Boolean = false
                 var showExpired: Boolean = false
@@ -250,7 +255,7 @@ class HomeViewModel @Inject constructor(
                         _dialogsState.update { state ->
                             state.copy(
                                 proExpiringCTA = ProExpiringCTA(
-                                    dateUtils.getExpiryString(validUntil)
+                                    dateUtils.getExpiryString(validUntil, now)
                                 )
                             )
                         }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/ProSettingsDialogs.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/ProSettingsDialogs.kt
@@ -11,6 +11,7 @@ import org.thoughtcrime.securesms.ui.dialog.OpenURLAlertDialog
 import org.thoughtcrime.securesms.ui.dialog.TCPolicyDialog
 import org.thoughtcrime.securesms.ui.components.annotatedStringResource
 import org.thoughtcrime.securesms.ui.theme.LocalColors
+import org.thoughtcrime.securesms.pro.ProUrls
 
 @Composable
 fun ProSettingsDialogs(
@@ -31,8 +32,8 @@ fun ProSettingsDialogs(
     // T&C + Policy dialog
     if(dialogsState.showTCPolicyDialog){
         TCPolicyDialog(
-            tcsUrl = "https://getsession.org/pro/terms",
-            privacyUrl = "https://getsession.org/pro/privacy",
+            tcsUrl = ProUrls.TERMS_OF_SERVICE,
+            privacyUrl = ProUrls.PRIVACY_POLICY,
             onDismissRequest = { sendCommand(HideTCPolicyDialog) },
         )
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/ProSettingsHomeScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/ProSettingsHomeScreen.kt
@@ -60,6 +60,7 @@ import org.thoughtcrime.securesms.pro.ProStatus
 import org.thoughtcrime.securesms.pro.ProStatusManager
 import org.thoughtcrime.securesms.pro.previewAutoRenewingApple
 import org.thoughtcrime.securesms.pro.previewExpiredApple
+import org.thoughtcrime.securesms.pro.ProUrls
 import org.thoughtcrime.securesms.ui.ActionRowItem
 import org.thoughtcrime.securesms.ui.CategoryCell
 import org.thoughtcrime.securesms.ui.Divider
@@ -725,7 +726,7 @@ fun ProFeatures(
                 iconGradientEnd = primaryYellow,
                 expired = disabled,
                 onClick = {
-                    sendCommand(ShowOpenUrlDialog("https://getsession.org/pro-roadmap"))
+                    sendCommand(ShowOpenUrlDialog(ProUrls.ROADMAP))
                 }
             )
         }
@@ -983,7 +984,7 @@ fun ProSettingsFooter(
                 iconColor = iconColor,
                 qaTag = R.string.qa_pro_settings_action_faq,
                 onClick = {
-                    sendCommand(ShowOpenUrlDialog("https://getsession.org/faq#pro"))
+                    sendCommand(ShowOpenUrlDialog(ProUrls.FAQ))
                 }
             )
             Divider()
@@ -998,7 +999,7 @@ fun ProSettingsFooter(
                 iconColor = iconColor,
                 qaTag = R.string.qa_pro_settings_action_support,
                 onClick = {
-                    sendCommand(ShowOpenUrlDialog(ProStatusManager.URL_PRO_SUPPORT))
+                    sendCommand(ShowOpenUrlDialog(ProUrls.SUPPORT))
                 }
             )
         }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/ProSettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/ProSettingsViewModel.kt
@@ -60,6 +60,7 @@ import org.thoughtcrime.securesms.pro.subscription.ProPlanPeriod
 import org.thoughtcrime.securesms.pro.subscription.ProSubscriptionDuration
 import org.thoughtcrime.securesms.pro.subscription.SubscriptionCoordinator
 import org.thoughtcrime.securesms.pro.subscription.SubscriptionManager
+import org.thoughtcrime.securesms.pro.ProUrls
 import org.thoughtcrime.securesms.ui.dialog.SimpleDialogData
 import org.thoughtcrime.securesms.ui.UINavigator
 import org.thoughtcrime.securesms.util.CurrencyFormatter
@@ -200,7 +201,7 @@ class ProSettingsViewModel @AssistedInject constructor(
                             negativeText = context.getString(R.string.close),
                             positiveStyleDanger = false,
                             negativeStyleDanger = true,
-                            onPositive = { onCommand(ShowOpenUrlDialog(ProStatusManager.URL_PRO_SUPPORT)) },
+                            onPositive = { onCommand(ShowOpenUrlDialog(ProUrls.SUPPORT)) },
                         )
                     )
                 }
@@ -441,7 +442,7 @@ class ProSettingsViewModel @AssistedInject constructor(
                                     showXIcon = true,
                                     onPositive = { refreshProStatus(true) },
                                     onNegative = {
-                                        onCommand(ShowOpenUrlDialog(ProStatusManager.URL_PRO_SUPPORT))
+                                        onCommand(ShowOpenUrlDialog(ProUrls.SUPPORT))
                                     }
                                 )
                             )
@@ -685,7 +686,7 @@ class ProSettingsViewModel @AssistedInject constructor(
                                     showXIcon = true,
                                     onPositive = { refreshProStatus(true) },
                                     onNegative = {
-                                        onCommand(ShowOpenUrlDialog(ProStatusManager.URL_PRO_SUPPORT))
+                                        onCommand(ShowOpenUrlDialog(ProUrls.SUPPORT))
                                     }
                                 )
                             )

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/chooseplan/ChoosePlanNoBilling.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/chooseplan/ChoosePlanNoBilling.kt
@@ -26,6 +26,7 @@ import org.thoughtcrime.securesms.pro.buildProStoresList
 import org.thoughtcrime.securesms.pro.getPlatformDisplayName
 import org.thoughtcrime.securesms.pro.providerStoreName
 import org.thoughtcrime.securesms.pro.previewExpiredApple
+import org.thoughtcrime.securesms.pro.ProUrls
 import org.thoughtcrime.securesms.ui.components.iconExternalLink
 import org.thoughtcrime.securesms.ui.theme.PreviewTheme
 import org.thoughtcrime.securesms.ui.theme.SessionColorsParameterProvider
@@ -170,7 +171,7 @@ fun ChoosePlanNoBilling(
         contentTitle = contentTitle,
         contentDescription = contentDescription,
         contentClick = {
-            sendCommand(ShowOpenUrlDialog("https://getsession.org/pro-roadmap"))
+            sendCommand(ShowOpenUrlDialog(ProUrls.ROADMAP))
         },
         linkCellsInfo = cellsInfo,
         linkCells = cells

--- a/app/src/main/java/org/thoughtcrime/securesms/pro/ProStatusManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/pro/ProStatusManager.kt
@@ -1001,7 +1001,6 @@ class ProStatusManager @Inject constructor(
         private val MAX_CHARACTER_REGULAR by lazy { SessionProtocol.STANDARD_CHARACTER_LIMIT } // max message codepoints for non-pro users
         const val MAX_PIN_REGULAR = 5 // max pinned conversation for non pro users
 
-        const val URL_PRO_SUPPORT = "https://getsession.org/pro-form"
 
         /**
          * Remaining access for the `EXPIRING_GOOGLE_LATER` debug fixture, in days. **An Appium spec

--- a/app/src/main/java/org/thoughtcrime/securesms/pro/ProUrls.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/pro/ProUrls.kt
@@ -1,0 +1,20 @@
+package org.thoughtcrime.securesms.pro
+
+/**
+ * The Pro destinations, mirroring libsession's URL registry
+ * (`session_protocol.cpp`, the `url_pro_*` fields).
+ *
+ * Copies rather than reads: the registry is a C struct of `const char*` with no accessor exposed to
+ * Kotlin, so consuming it directly would mean adding JNI surface for five constants.
+ *
+ * Being copies, they can drift from it, and they have — every value here was once wrong at the use site
+ * that needed it. They are defined together so that comparing this file against the registry is the whole
+ * check; correcting a single link where it happens to be used is what let them diverge one at a time.
+ */
+object ProUrls {
+    const val FAQ = "https://getsession.org/pro#faq"
+    const val PRIVACY_POLICY = "https://getsession.org/pro-privacy"
+    const val ROADMAP = "https://getsession.org/pro#roadmap"
+    const val SUPPORT = "https://getsession.org/pro-support"
+    const val TERMS_OF_SERVICE = "https://getsession.org/pro-terms"
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/util/DateUtils.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/DateUtils.kt
@@ -241,7 +241,7 @@ class DateUtils @Inject constructor(
         }
     }
 
-    fun getExpiryString(instant: Instant?, now: Instant = Instant.now()): String {
+    fun getExpiryString(instant: Instant?, now: Instant): String {
         if (instant == null) return context.getString(R.string.proExpired)
         return getExpiryString(
             remaining = Duration.between(now, instant)


### PR DESCRIPTION
The Android half of two fixes iOS has just had (#746). Three commits, each independent.

### The Pro link destinations

Five Pro URLs had drifted from the libSession registry they mirror (`session_protocol.cpp`, the
`url_pro_*` fields): `/pro/terms`, `/pro/privacy`, `/pro-roadmap`, `/faq#pro` and `/pro-form` are now
`/pro-terms`, `/pro-privacy`, `/pro#roadmap`, `/pro#faq` and `/pro-support`.

They were literals at six use sites — `/pro-roadmap` had two copies — which is how they diverged one at a
time. They now come from a single `ProUrls` object, with the existing `ProStatusManager.URL_PRO_SUPPORT`
moved into it so there is one convention rather than two. Constant names mirror the registry's field
suffixes so comparing the two is a line-up rather than a translation.

The registry is a C struct of `const char*` with no accessor exposed to Kotlin, so these stay copies:
reading it directly would mean new JNI surface for five constants.

### The home CTAs and the device clock

`HomeViewModel` took `Instant.now()` — the device clock — and compared it against two backend-supplied
instants: `renewingAt` for the expiring CTA and `coverageEndedAt` for the expired one, plus the rendered
"expires in N days" label. Every *entitlement* comparison already used network time; this was the CTA
layer only.

Skew does not fail in one direction here: a fast clock fires the expiring warning early *and* stops
warning of expiration early, so one over-warns while the other under-warns. It now reads `SnodeClock`,
matching `ProSettingsViewModel`, and passes that one instant into the label so the window and the text
cannot disagree.

`DateUtils.getExpiryString` defaulted its `now` parameter to `Instant.now()`, which is what let the wrong
clock in without anything looking wrong at the call site. The parameter is now required. All three callers
already pass it, so this changes no behaviour — it removes the way back in.

### Testing

`:app:compilePlayDebugKotlin` green, and the generated `HomeViewModel_Factory` confirmed to carry the
`SnodeClock` provider. No device run yet: the clock change alters when two CTAs fire, and the
session-appium spec that covers that will be re-run against this branch before merge.
