### PR TITLE
QA: give the message "Read more" affordance an accessibility id

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v3/compose/message/ExpandableMessageText.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v3/compose/message/ExpandableMessageText.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Constraints
 import network.loki.messenger.R
+import org.thoughtcrime.securesms.ui.qaTag
 import org.thoughtcrime.securesms.ui.theme.LocalColors
 import org.thoughtcrime.securesms.ui.theme.LocalDimensions
 import org.thoughtcrime.securesms.ui.theme.LocalType
@@ -91,6 +92,7 @@ fun ExpandableMessageText(
                 text = readMoreLabel,
                 style = readMoreTextStyle,
                 modifier = Modifier
+                    .qaTag(R.string.qa_message_read_more)
                     .clickable {
                         val extraHeightPx = collapsedLayout?.let { layout ->
                             calculateExpandedTextDeltaPx(

--- a/app/src/main/res/layout/view_visible_message_content.xml
+++ b/app/src/main/res/layout/view_visible_message_content.xml
@@ -82,6 +82,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/messageBubbleReadMore"
+            android:contentDescription="@string/qa_message_read_more"
             android:textSize="14sp"
             android:textStyle="bold"
             android:includeFontPadding="false"

--- a/content-descriptions/src/main/res/values/strings.xml
+++ b/content-descriptions/src/main/res/values/strings.xml
@@ -399,4 +399,11 @@
 
     <string name="qa_collapsing_footer_action">qa-collapsing-footer-action</string>
 
+    <!-- The expand affordance on a collapsed message bubble. Carried by the tap TARGET in both
+         conversation implementations (the v2 TextView, whose bounds are hit-tested, and the v3
+         Compose control), so flipping the convo-v3 debug flag cannot change the locator.
+         Android only: iOS marks the whole bubble as a single accessibility element, so an id on the
+         equivalent control there is not reachable, and its specs locate the affordance differently. -->
+    <string name="qa_message_read_more">message-read-more</string>
+
 </resources>


### PR DESCRIPTION
The expand control on a collapsed message bubble had no id, so an automated spec could only reach it by xpath over the visible "Read more" text — which breaks under localisation and matches by structure rather than identity.

Tagged in **both** conversation implementations. v3 is behind the `convo-v3` debug flag today, so the live target is the v2 view; tagging only whichever happens to be live would make the locator depend on a debug preference.

In v2 the `TextView` is not itself clickable — the handler is registered on the content view and hit-tests the touch against `readMore`'s global visible rect (`VisibleMessageContentView.kt:396-406`). So the id goes on the view whose **bounds** are the tap target, which is what a coordinate tap needs, rather than on the view that owns the listener.

Android only: iOS marks the whole bubble as a single accessibility element, so the equivalent id is not reachable there and those specs locate the affordance differently. Noted in the string resource so the asymmetry is not mistaken for an omission.

No user-visible change — a content description on an existing view plus one QA string.