### PR TITLE
Add QA test tags to the shared Open URL confirmation dialog

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/BaseProSettingsScreens.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/BaseProSettingsScreens.kt
@@ -200,6 +200,7 @@ fun BaseCellButtonProSettingsScreen(
                         .widthIn(max = LocalDimensions.current.maxContentWidth)
                         .qaTag(R.string.qa_pro_screen_action),
                     text = buttonText,
+                    textQaTag = R.string.qa_pro_screen_action_label,
                     onClick = onButtonClick
                 )
             } else {
@@ -208,6 +209,7 @@ fun BaseCellButtonProSettingsScreen(
                         .widthIn(max = LocalDimensions.current.maxContentWidth)
                         .qaTag(R.string.qa_pro_screen_action),
                     text = buttonText,
+                    textQaTag = R.string.qa_pro_screen_action_label,
                     onClick = onButtonClick
                 )
             }

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/components/Button.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/components/Button.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
 import network.loki.messenger.R
 import org.thoughtcrime.securesms.ui.LaunchedEffectAsync
+import androidx.annotation.StringRes
 import org.thoughtcrime.securesms.ui.qaTag
 import org.thoughtcrime.securesms.ui.theme.LocalColors
 import org.thoughtcrime.securesms.ui.theme.LocalDimensions
@@ -106,9 +107,13 @@ fun Button(
     shape: Shape = buttonShape,
     minWidth: Dp = LocalDimensions.current.minButtonWidth,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    /// Tags the label rather than the button. A `qaTag` on the button covers a node whose own `text` is
+    /// empty - the copy sits on this child - so a UI test that filters a button by its text matches
+    /// nothing. Null leaves the label untagged, which is every existing caller.
+    @StringRes textQaTag: Int? = null,
 ) {
     Button(onClick, type, modifier, enabled, style, shape, minWidth = minWidth, interactionSource = interactionSource) {
-        Text(text)
+        Text(text, modifier = Modifier.qaTag(textQaTag))
     }
 }
 
@@ -128,11 +133,12 @@ fun Button(
     )
 }
 
-@Composable fun AccentFillButtonRect(text: String, modifier: Modifier = Modifier, enabled: Boolean = true, onClick: () -> Unit) {
+@Composable fun AccentFillButtonRect(text: String, modifier: Modifier = Modifier, enabled: Boolean = true, @StringRes textQaTag: Int? = null, onClick: () -> Unit) {
     Button(
         text, onClick, ButtonType.AccentFill, modifier, enabled,
         style = ButtonStyle.XLarge,
-        shape = sessionShapes().extraSmall
+        shape = sessionShapes().extraSmall,
+        textQaTag = textQaTag
     )
 }
 
@@ -144,11 +150,12 @@ fun Button(
     )
 }
 
-@Composable fun DangerFillButtonRect(text: String, modifier: Modifier = Modifier, enabled: Boolean = true, onClick: () -> Unit) {
+@Composable fun DangerFillButtonRect(text: String, modifier: Modifier = Modifier, enabled: Boolean = true, @StringRes textQaTag: Int? = null, onClick: () -> Unit) {
     Button(
         text, onClick, ButtonType.DangerFill, modifier, enabled,
         style = ButtonStyle.XLarge,
-        shape = sessionShapes().extraSmall
+        shape = sessionShapes().extraSmall,
+        textQaTag = textQaTag
     )
 }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/dialog/AlertDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/dialog/AlertDialog.kt
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.ui.dialog
 
 import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
@@ -97,6 +98,7 @@ fun AlertDialog(
     title: String? = null,
     text: String? = null,
     maxLines:  Int? = null,
+    @StringRes textQaTag: Int? = null,
     buttons: List<DialogButtonData>? = null,
     showCloseButton: Boolean = false,
     content: @Composable () -> Unit = {}
@@ -107,6 +109,7 @@ fun AlertDialog(
         title = if(title != null) AnnotatedString(title) else null,
         text = if(text != null) AnnotatedString(text) else null,
         maxLines = maxLines,
+        textQaTag = textQaTag,
         buttons = buttons,
         showCloseButton = showCloseButton,
         content = content
@@ -121,6 +124,7 @@ fun AlertDialog(
     title: AnnotatedString? = null,
     text: AnnotatedString? = null,
     maxLines: Int? = null,
+    @StringRes textQaTag: Int? = null,
     buttons: List<DialogButtonData>? = null,
     showCloseButton: Boolean = false,
     content: @Composable () -> Unit = {}
@@ -134,6 +138,7 @@ fun AlertDialog(
                 title = title,
                 text = text,
                 maxLines = maxLines,
+                textQaTag = textQaTag,
                 buttons = buttons,
                 showCloseButton = showCloseButton,
                 content = content
@@ -178,6 +183,7 @@ fun AlertDialogContent(
     title: AnnotatedString? = null,
     text: AnnotatedString? = null,
     maxLines: Int? = null,
+    @StringRes textQaTag: Int? = null,
     buttons: List<DialogButtonData>? = null,
     showCloseButton: Boolean = false,
     content: @Composable () -> Unit = {}
@@ -235,7 +241,7 @@ fun AlertDialogContent(
                         textAlign = TextAlign.Center,
                         style = textStyle,
                         modifier = textModifier
-                            .qaTag(R.string.AccessibilityId_modalMessage)
+                            .qaTag(textQaTag ?: R.string.AccessibilityId_modalMessage)
                     )
                 }
                 content()

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/dialog/LinkDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/dialog/LinkDialog.kt
@@ -17,6 +17,7 @@ import org.thoughtcrime.securesms.links.LinkType.CommunityLink.DisplayType.*
 import org.thoughtcrime.securesms.ui.GetString
 import org.thoughtcrime.securesms.ui.components.annotatedStringResource
 import org.thoughtcrime.securesms.ui.openUrl
+import org.thoughtcrime.securesms.ui.qaTag
 import org.thoughtcrime.securesms.ui.theme.LocalColors
 import org.thoughtcrime.securesms.ui.theme.PreviewTheme
 
@@ -67,14 +68,16 @@ fun OpenURLAlertDialog(
 
 
     AlertDialog(
-        modifier = modifier,
+        modifier = modifier.qaTag(R.string.qa_open_url_dialog),
         title = AnnotatedString(stringResource(R.string.urlOpen)),
         text = annotatedStringResource(text = unformattedText),
+        textQaTag = R.string.qa_open_url_description,
         maxLines = 5,
         showCloseButton = true, // display the 'x' button
         buttons = listOf(
             DialogButtonData(
                 text = GetString(R.string.open),
+                qaTag = stringResource(R.string.qa_open_url_confirm_button),
                 color = LocalColors.current.danger,
                 dismissOnClick = false,
                 onClick = {

--- a/content-descriptions/src/main/res/values/strings.xml
+++ b/content-descriptions/src/main/res/values/strings.xml
@@ -411,6 +411,10 @@
     <string name="qa_pro_screen_title">pro-screen-title</string>
     <string name="qa_pro_screen_description">pro-screen-description</string>
     <string name="qa_pro_screen_action">pro-screen-action</string>
+    <!-- The label inside qa_pro_screen_action. Separate because the tagged Button node
+         exposes no text of its own: the copy lives on an untagged child, so a test filtering
+         on the button's text matches nothing. -->
+    <string name="qa_pro_screen_action_label">pro-screen-action-label</string>
     <!-- The "how to manage this elsewhere" cells on the non-originating screens. Two are shown at
          once, so unlike the parts above these are named per option. -->
     <string name="qa_pro_link_cell_device">pro-link-cell-device</string>

--- a/content-descriptions/src/main/res/values/strings.xml
+++ b/content-descriptions/src/main/res/values/strings.xml
@@ -440,4 +440,14 @@
          equivalent control there is not reachable, and its specs locate the affordance differently. -->
     <string name="qa_message_read_more">message-read-more</string>
 
+    <!-- The shared "Open URL" confirmation dialog, which every urlOpen confirmation in the app goes
+         through, so these three ids cover all of them rather than one caller. The description is the
+         node carrying the interpolated URL, so a spec reads its TEXT to assert WHICH url is about to
+         be opened - do not add a contentDescription to it. Same strings on Desktop - one locator
+         serves both. The "Copy URL" button is deliberately left untagged: a spec already finds it by
+         its label, and a testTag would change its resource-id. -->
+    <string name="qa_open_url_dialog">open-url-dialog</string>
+    <string name="qa_open_url_description">open-url-description</string>
+    <string name="qa_open_url_confirm_button">open-url-confirm-button</string>
+
 </resources>


### PR DESCRIPTION
The e2e suite (session-appium) cannot assert anything about the Open URL confirmation dialog. Its body carried only the generic modal-message id, and the dialog root and Open button had none — so a spec cannot check that the dialog appeared, read which url it offers, or confirm it by anything more stable than a localized button title.

Adds three tags, applied in the shared `OpenURLAlertDialog`, so every `urlOpen` confirmation in the app is covered rather than just the Pro refund ones:

- `open-url-dialog` — the dialog root
- `open-url-description` — the body text, which carries the interpolated url
- `open-url-confirm-button` — the Open button (the same id session-desktop already uses, so the harness needs one locator rather than one per platform)

`AlertDialogContent` hardcoded `AccessibilityId_modalMessage` on its body, so a caller could not tag it. Rather than restructure the component it gains an optional `textQaTag` that falls back to the shared modal id — matching the existing convention in `Components.kt`. Every other dialog is unaffected.

"Copy URL" is deliberately left untagged: an existing harness locator finds it by its display string, and a testTag there would change its resource-id and break that spec.

Verified with `./gradlew :app:compilePlayAutomaticQaKotlin` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)