### PR TITLE
App lock: cover the app instead of destroying it, and let debug builds lock at all

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,7 +66,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> <!-- Only used on Android API 29 and lower -->
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-    <uses-permission android:name="network.loki.messenger.ACCESS_SESSION_SECRETS" />
+    <uses-permission android:name="network.loki.messenger.ACCESS_SESSION_SECRETS${authority_postfix}" />
 
     <queries>
         <intent>

--- a/app/src/main/java/org/thoughtcrime/securesms/ScreenLockActionBarActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ScreenLockActionBarActivity.kt
@@ -80,6 +80,7 @@ abstract class ScreenLockActionBarActivity : BaseActionBarActivity() {
     }
 
     private var clearKeyReceiver: BroadcastReceiver? = null
+    private var hasStarted = false
 
     @Inject
     lateinit var loginStateRepository: LoginStateRepository
@@ -95,9 +96,7 @@ abstract class ScreenLockActionBarActivity : BaseActionBarActivity() {
 
         super.onCreate(savedInstanceState)
 
-        val locked = KeyCachingService.isLocked(this) && isScreenLockEnabled(this) &&
-                loginStateRepository.peekLoginState() != null
-        routeApplicationState(locked)
+        routeApplicationState(isScreenLocked())
 
         if (!isFinishing) {
             initializeClearKeyReceiver()
@@ -106,6 +105,34 @@ abstract class ScreenLockActionBarActivity : BaseActionBarActivity() {
     }
 
     protected open fun onCreate(savedInstanceState: Bundle?, ready: Boolean) {}
+
+    override fun onStart() {
+        super.onStart()
+
+        // Only re-locks an activity that is coming BACK to the foreground; a first start while locked
+        // is already handled by onCreate's routing. The distinction matters because the lock can be
+        // cleared while this activity is merely stopped, which happens on any excursion to another app
+        // - a file picker, the camera, the share sheet. Covering it here rather than destroying it is
+        // what lets such an excursion return to the state it left, including a pending
+        // onActivityResult.
+        val isReturningToForeground = hasStarted
+        hasStarted = true
+
+        if (isReturningToForeground && isScreenLocked()) presentScreenLock()
+    }
+
+    private fun isScreenLocked(): Boolean =
+        KeyCachingService.isLocked(this) && isScreenLockEnabled(this) &&
+                loginStateRepository.peekLoginState() != null
+
+    // Covers this activity with the lock screen WITHOUT finishing it, so the task and any pending
+    // activity result survive. No "next_intent" is supplied because there is nothing to route back to
+    // - this activity is still underneath, and ScreenLockActivity finishes itself on success to reveal
+    // it. ScreenLockActivity is singleInstancePerTask, so concurrent calls from several live activities
+    // reuse the one instance.
+    private fun presentScreenLock() {
+        startActivity(Intent(this, ScreenLockActivity::class.java))
+    }
 
     override fun onPause() {
         Log.i(TAG, "onPause()")
@@ -120,8 +147,10 @@ abstract class ScreenLockActionBarActivity : BaseActionBarActivity() {
 
     fun onMasterSecretCleared() {
         Log.i(TAG, "onMasterSecretCleared()")
-        if (appVisibilityManager.isAppVisible.value) routeApplicationState(true)
-        else finish()
+
+        // Nothing to cover while backgrounded, and finishing would discard whatever the user was in
+        // the middle of - onStart presents the lock when they come back instead.
+        if (appVisibilityManager.isAppVisible.value) presentScreenLock()
     }
 
     protected fun <T : Fragment?> initFragment(@IdRes target: Int, fragment: T): T? {

--- a/app/src/main/java/org/thoughtcrime/securesms/ScreenLockActionBarActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ScreenLockActionBarActivity.kt
@@ -46,6 +46,8 @@ abstract class ScreenLockActionBarActivity : BaseActionBarActivity() {
         private const val STATE_WELCOME_SCREEN    = 3
         private const val STATE_DATABASE_MIGRATE  = 4 // This is different from STATE_UPGRADE_DATABASE as it is used to migrate database in a whole rather than the internal db schema upgrades
 
+        private const val KEY_HAS_STARTED = "has_started"
+
         private fun getStateName(state: Int): String {
             return when (state) {
                 STATE_NORMAL           -> "STATE_NORMAL"
@@ -81,6 +83,7 @@ abstract class ScreenLockActionBarActivity : BaseActionBarActivity() {
 
     private var clearKeyReceiver: BroadcastReceiver? = null
     private var hasStarted = false
+    private var wasRecreated = false
 
     @Inject
     lateinit var loginStateRepository: LoginStateRepository
@@ -96,6 +99,11 @@ abstract class ScreenLockActionBarActivity : BaseActionBarActivity() {
 
         super.onCreate(savedInstanceState)
 
+        // Captured once, before routing: routeApplicationState is a coroutine, so reading hasStarted
+        // from inside it would race with onStart setting it and misread a cold start as a recreation.
+        wasRecreated = (savedInstanceState != null)
+        hasStarted = savedInstanceState?.getBoolean(KEY_HAS_STARTED) == true
+
         routeApplicationState(isScreenLocked())
 
         if (!isFinishing) {
@@ -105,6 +113,11 @@ abstract class ScreenLockActionBarActivity : BaseActionBarActivity() {
     }
 
     protected open fun onCreate(savedInstanceState: Bundle?, ready: Boolean) {}
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(KEY_HAS_STARTED, hasStarted)
+    }
 
     override fun onStart() {
         super.onStart()
@@ -125,13 +138,19 @@ abstract class ScreenLockActionBarActivity : BaseActionBarActivity() {
         KeyCachingService.isLocked(this) && isScreenLockEnabled(this) &&
                 loginStateRepository.peekLoginState() != null
 
-    // Covers this activity with the lock screen WITHOUT finishing it, so the task and any pending
+    // Puts the lock screen in front of this activity WITHOUT finishing it, so the task and any pending
     // activity result survive. No "next_intent" is supplied because there is nothing to route back to
-    // - this activity is still underneath, and ScreenLockActivity finishes itself on success to reveal
-    // it. ScreenLockActivity is singleInstancePerTask, so concurrent calls from several live activities
-    // reuse the one instance.
+    // - this activity is still here, and ScreenLockActivity finishes itself on success to reveal it.
+    //
+    // ScreenLockActivity is singleInstancePerTask, so it occupies its own task ABOVE this one rather
+    // than stacking in it: concurrent calls from several live activities reuse the one instance, and
+    // dismissing it without authenticating reveals this activity again - which is why it has to send
+    // the user to the launcher instead (see ScreenLockActivity.leaveAppLocked).
     private fun presentScreenLock() {
-        startActivity(Intent(this, ScreenLockActivity::class.java))
+        startActivity(
+            Intent(this, ScreenLockActivity::class.java)
+                .putExtra(ScreenLockActivity.EXTRA_PRESENTED_OVER, true)
+        )
     }
 
     override fun onPause() {
@@ -148,9 +167,14 @@ abstract class ScreenLockActionBarActivity : BaseActionBarActivity() {
     fun onMasterSecretCleared() {
         Log.i(TAG, "onMasterSecretCleared()")
 
-        // Nothing to cover while backgrounded, and finishing would discard whatever the user was in
-        // the middle of - onStart presents the lock when they come back instead.
-        if (appVisibilityManager.isAppVisible.value) presentScreenLock()
+        // KeyCachingService.onDestroy broadcasts this whether or not app lock is enabled, so the same
+        // isScreenLocked() check onStart uses is needed here too - without it the broadcast can raise a
+        // lock screen that never prompts for anything, because ScreenLockActivity only starts an
+        // authentication when the setting is on.
+        //
+        // Nothing to cover while backgrounded either, and finishing would discard whatever the user was
+        // in the middle of - onStart presents the lock when they come back instead.
+        if (appVisibilityManager.isAppVisible.value && isScreenLocked()) presentScreenLock()
     }
 
     protected fun <T : Fragment?> initFragment(@IdRes target: Int, fragment: T): T? {
@@ -194,7 +218,10 @@ abstract class ScreenLockActionBarActivity : BaseActionBarActivity() {
         Log.i(TAG, "routeApplicationState() - ${getStateName(state)}")
 
         return when (state) {
-            STATE_SCREEN_LOCKED    -> getScreenUnlockIntent() // Note: This is a suspend function
+            // Routing finishes this activity, which on a recreation would discard a pending activity
+            // result - a picker excursion survives a rotation only if the activity waiting on it does.
+            // A recreated instance is covered by onStart instead, via the restored hasStarted.
+            STATE_SCREEN_LOCKED    -> if (wasRecreated) null else getScreenUnlockIntent() // Note: This is a suspend function
             STATE_UPGRADE_DATABASE -> getUpgradeDatabaseIntent()
             STATE_WELCOME_SCREEN   -> getWelcomeIntent()
             STATE_DATABASE_MIGRATE -> getRoutedIntent(DatabaseMigrationStateActivity::class.java, getConversationListIntent())

--- a/app/src/main/java/org/thoughtcrime/securesms/ScreenLockActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ScreenLockActivity.kt
@@ -281,13 +281,10 @@ class ScreenLockActivity : BaseActionBarActivity() {
         keyCachingService?.setMasterSecret(Any())
 
         // The 'nextIntent' will take us to the MainActivity if this is a standard unlock, or it will
-        // take us to the ShareActivity if this is an external share.
-        val nextIntent = intent.getParcelableExtra<Intent?>("next_intent")
-        if (nextIntent == null) {
-            Log.w(TAG, "Got a null nextIntent - cannot proceed.")
-        } else {
-            startActivity(nextIntent)
-        }
+        // take us to the ShareActivity if this is an external share. It is absent when this lock was
+        // presented OVER a still-live activity (see ScreenLockActionBarActivity.presentScreenLock), in
+        // which case finishing is all that is needed to return to it.
+        intent.getParcelableExtra<Intent?>("next_intent")?.let(::startActivity)
 
         finish()
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/ScreenLockActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ScreenLockActivity.kt
@@ -30,6 +30,7 @@ import android.view.animation.TranslateAnimation
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.biometric.BiometricPrompt
 import androidx.biometric.BiometricManager
 import androidx.core.content.ContextCompat
@@ -47,6 +48,17 @@ import org.thoughtcrime.securesms.service.KeyCachingService
 import org.thoughtcrime.securesms.service.KeyCachingService.KeySetBinder
 
 class ScreenLockActivity : BaseActionBarActivity() {
+    companion object {
+        /**
+         * Marks a lock that was presented over a still-live activity, and which therefore carries no
+         * [EXTRA_NEXT_INTENT]. Without it there is no way to tell that case apart from a routed unlock
+         * whose destination has gone missing, and the second one has to stay reportable.
+         */
+        const val EXTRA_PRESENTED_OVER: String = "presented_over"
+
+        private const val EXTRA_NEXT_INTENT: String = "next_intent"
+    }
+
     private val TAG: String = ScreenLockActivity::class.java.simpleName
 
     private lateinit var fingerprintPrompt: ImageView
@@ -73,6 +85,14 @@ class ScreenLockActivity : BaseActionBarActivity() {
 
         setContentView(R.layout.screen_lock_activity)
         initializeResources()
+
+        // Back must leave the app, not just dismiss the lock: the activity underneath is still alive and
+        // would re-present it immediately.
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                leaveAppLocked()
+            }
+        })
 
         // Start and bind to the KeyCachingService instance.
         val bindIntent = Intent(this, KeyCachingService::class.java)
@@ -101,14 +121,14 @@ class ScreenLockActivity : BaseActionBarActivity() {
                     BiometricPrompt.ERROR_NEGATIVE_BUTTON,
                     BiometricPrompt.ERROR_USER_CANCELED -> {
                         onAuthenticationFailed()
-                        finish()
+                        leaveAppLocked()
                     }
 
                     // User made 5 incorrect biometric login attempts so they get a timeout
                     // Note: The SYSTEM provides the localised error "Too many attempts. Try again later.".
                     BiometricPrompt.ERROR_LOCKOUT -> {
                         Toast.makeText(context, errString, Toast.LENGTH_SHORT).show()
-                        finish()
+                        leaveAppLocked()
                     }
 
                     // User made a large number of incorrect biometric login attempts and Android disabled
@@ -116,12 +136,12 @@ class ScreenLockActivity : BaseActionBarActivity() {
                     // Note: The SYSTEM provides the localised error "Too many attempts. Fingerprint sensor disabled."
                     BiometricPrompt.ERROR_LOCKOUT_PERMANENT -> {
                         Toast.makeText(context, errString, Toast.LENGTH_SHORT).show()
-                        finish()
+                        leaveAppLocked()
                     }
 
                     else -> {
                         Log.w(TAG, "Unhandled authentication error: $errorCode $errString")
-                        finish()
+                        leaveAppLocked()
                     }
                 }
             }
@@ -219,7 +239,11 @@ class ScreenLockActivity : BaseActionBarActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        setIntent(intent)
+
+        // A lock presented over a live activity carries no "next_intent". Adopting such an intent would
+        // discard the destination a routed unlock still has to reach - the activity that routed here has
+        // already finished itself, so nothing else remembers where to go.
+        if (intent.hasExtra(EXTRA_NEXT_INTENT)) setIntent(intent)
     }
 
     public override fun onActivityResult(requestCode: Int, resultcode: Int, data: Intent?) {
@@ -276,15 +300,41 @@ class ScreenLockActivity : BaseActionBarActivity() {
             ?.start()
     }
 
+    // Declining the unlock has to leave the app, not merely finish this activity. The activity being
+    // locked is still alive (ScreenLockActionBarActivity.presentScreenLock) and finishing alone reveals
+    // it, whereupon its onStart presents the lock straight back - a loop with no way out, which during a
+    // biometric lockout spins with no user input at all and flashes the covered content each time.
+    //
+    // Backgrounding this task is not enough either: launchMode is singleInstancePerTask, so this lives
+    // in its OWN task and the app's task sits beneath it. Going to the launcher is what backgrounds
+    // both. Returning to the app afterwards presents the lock again, which is correct.
+    private fun leaveAppLocked() {
+        startActivity(
+            Intent(Intent.ACTION_MAIN)
+                .addCategory(Intent.CATEGORY_HOME)
+                .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        )
+        finish()
+    }
+
     private fun handleAuthenticated() {
         authenticated = true
         keyCachingService?.setMasterSecret(Any())
 
         // The 'nextIntent' will take us to the MainActivity if this is a standard unlock, or it will
-        // take us to the ShareActivity if this is an external share. It is absent when this lock was
-        // presented OVER a still-live activity (see ScreenLockActionBarActivity.presentScreenLock), in
-        // which case finishing is all that is needed to return to it.
-        intent.getParcelableExtra<Intent?>("next_intent")?.let(::startActivity)
+        // take us to the ShareActivity if this is an external share.
+        val nextIntent = intent.getParcelableExtra<Intent?>(EXTRA_NEXT_INTENT)
+
+        when {
+            nextIntent != null -> startActivity(nextIntent)
+
+            // Presented over a still-live activity, so there is nothing to route to and finishing
+            // reveals it again (see ScreenLockActionBarActivity.presentScreenLock).
+            intent.getBooleanExtra(EXTRA_PRESENTED_OVER, false) -> {}
+
+            // Routed here, but the destination is gone: unlocking will land on nothing.
+            else -> Log.w(TAG, "Got a null nextIntent - cannot proceed.")
+        }
 
         finish()
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/service/KeyCachingService.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/KeyCachingService.java
@@ -220,10 +220,29 @@ public class KeyCachingService extends Service {
       if (!TextSecurePreferences.isPasswordDisabled(context)) timeoutMillis = TimeUnit.MINUTES.toMillis(passphraseTimeoutMinutes);
       else                                                    timeoutMillis = TimeUnit.SECONDS.toMillis(screenLockTimeoutSeconds);
 
+      PendingIntent expirationIntent = buildExpirationPendingIntent(context);
+
+      // With no timeout there is nothing to schedule, and scheduling anyway is what left the lock
+      // unreliable: AlarmManager batches non-wakeup alarms, so an alarm for "now" was still arriving
+      // seconds later, and onAppForegrounded cancels it on the way back in. A quick trip to another app
+      // and straight back therefore never locked at all. Deliver it directly instead - the service is
+      // necessarily foregrounded here, because we only get this far with a secret set.
+      if (timeoutMillis <= 0) {
+        Log.i(TAG, "No timeout, expiring immediately");
+
+        try {
+          expirationIntent.send();
+        } catch (PendingIntent.CanceledException e) {
+          Log.w(TAG, "Immediate expiry was cancelled, falling back to an alarm", e);
+          ServiceUtil.getAlarmManager(context).set(AlarmManager.ELAPSED_REALTIME, SystemClock.elapsedRealtime(), expirationIntent);
+        }
+
+        return;
+      }
+
       Log.i(TAG, "Starting timeout: " + timeoutMillis);
 
-      AlarmManager  alarmManager     = ServiceUtil.getAlarmManager(context);
-      PendingIntent expirationIntent = buildExpirationPendingIntent(context);
+      AlarmManager alarmManager = ServiceUtil.getAlarmManager(context);
 
       alarmManager.cancel(expirationIntent);
       alarmManager.set(AlarmManager.ELAPSED_REALTIME, SystemClock.elapsedRealtime() + timeoutMillis, expirationIntent);


### PR DESCRIPTION
### The symptom

With app lock enabled, attaching a **File** to a message drops the user out of Session and the file is
never sent — no error, no toast, no failed-message bubble.

### Two defects, and they only show together

**1. `<uses-permission>` didn't match the `<permission>` declaration.**

`AndroidManifest.xml` declares the permission with the build's postfix but asked for it without one:

```xml
<permission android:name="network.loki.messenger.ACCESS_SESSION_SECRETS${authority_postfix}" … />
<uses-permission android:name="network.loki.messenger.ACCESS_SESSION_SECRETS" />
```

`KeyCachingService.handleClearKey` broadcasts with `"…ACCESS_SESSION_SECRETS" +
BuildConfig.AUTHORITY_POSTFIX`, so on any build with a non-empty postfix the app does not hold the
permission its own broadcast requires and the broadcast is dropped in silence. Only `debug` sets a
postfix (`release`/`qa` use `""`), so **app lock has never auto-locked anything in a debug build** — a
security feature that silently does nothing in the build developers run all day, and the reason the
defect below was invisible locally.

**2. Clearing the key destroyed the task.**

`onMasterSecretCleared()` called `finish()` when the app was not visible. Every
`ScreenLockActionBarActivity` in the process receives that broadcast, so the whole task emptied —
including a conversation waiting on a picker result, whose `onActivityResult` then had nowhere to go.

Opening the SAF picker stops the process (`ApplicationContext` observes `ProcessLifecycleOwner`), and
the screen-lock timeout is `0` — `getScreenLockTimeout` defaults to `0`, the only writer in the tree
also writes `0`, and no setting exposes it — so the alarm fires while the picker is open, every time.

The lock is now presented **in front of** the activity and `onStart` re-checks on return, so the
activity and its pending result survive.

**Scope of that claim:** this preserves a **direct return to the task** — coming back from a picker,
camera or share sheet, which is the case attachment flows depend on. It does *not* make a conversation
survive re-entry from the launcher icon: `HomeActivity` is `launchMode="singleTask"` and the launcher
alias targets it, so that clears everything above Home regardless of this change.

### Nothing was traded away for this

- the timeout stays `0` — "lock as soon as I leave" is the right posture, and raising it would trade
  security to hide this
- `masterSecret` is a sentinel `Object`, not a key ("*only indicates if the app was unlocked or not*"),
  so finishing evicted no cryptographic material
- `BaseActionBarActivity` already applies `FLAG_SECURE` in `onPause` for every activity, so a
  backgrounded conversation was never in the recents thumbnail whether or not it was finished

### Second commit: review fixes

- **Dismissing the lock without authenticating** used to reveal the activity underneath, whose
  `onStart` presented the lock straight back — a loop escapable only via Home, and one that spun with
  no user input during a biometric lockout. Every non-authenticating exit now leaves the app.
  Worth knowing for anyone touching this: `ScreenLockActivity` is `singleInstancePerTask`, so it is the
  root of its **own task above the app's**, not stacked inside it — `moveTaskToBack(true)` therefore
  reveals the app again and does not work here. Back is routed through the same path; it previously
  bypassed the error handling entirely.
- **A configuration change while stopped** recreated the activity, and `onCreate`'s route-and-finish
  path then discarded the pending result. `hasStarted` is saved/restored and the locked route is
  suppressed on a recreation, so `onStart` covers it instead.
- `onMasterSecretCleared` now applies the same `isScreenLocked()` guard as `onStart`:
  `KeyCachingService.onDestroy` broadcasts whether or not app lock is on, and `ScreenLockActivity` only
  prompts when the setting is on, so without it that broadcast could raise a lock screen with no way
  past it.
- `onNewIntent` no longer adopts an intent carrying no `next_intent`, which would discard the
  destination a routed unlock still has to reach.
- Restored the warning for a `next_intent` that has genuinely gone missing, distinguished from the
  expected-absent case by an explicit extra rather than by null alone.

### Third commit: the zero timeout was never immediate

Backgrounding the app and coming straight back did not lock it, and this predates the whole PR.
`startTimeoutIfAppropriate` scheduled even a **zero** timeout through `AlarmManager`, which batches
non-wakeup alarms — measured delivery for an alarm set to "now" was **~5 seconds** — and
`onAppForegrounded` cancels the pending alarm on the way back in. Any excursion shorter than the
batching delay therefore cancelled the lock before it happened, which with a timeout that is always 0
means every quick app switch:

```
App is no longer visible.
Starting timeout: 0
App is now visible.          ← no handleClearKey() between them, so no lock
```

Zero timeouts now send the existing expiry `PendingIntent` directly instead of scheduling it. That is
not a background service start — the branch is only reachable with a secret set, so
`foregroundService()` has already run — and it falls back to the old alarm if the `PendingIntent` has
been cancelled. Non-zero timeouts are unchanged. `handleClearKey` now runs **4ms** after backgrounding
rather than ~5s.

**This makes the lock noticeably stricter than the behaviour anyone has actually been using**, because
until now the alarm delay was quietly forgiving every short trip. That is what a 0 timeout means and
what the setting promises, but if it proves too aggressive in practice the answer is the timeout
setting this code has never exposed, not an alarm that happens to be slow.

### Testing

Pixel 6 / API 34 emulator with a device PIN, `websiteDebug` — which is itself the check on defect 1,
since that variant previously never received the broadcast:

```
handleClearKey()
onReceive() for clear key event      ← did not happen before
onMasterSecretCleared()
onReceive() for clear key event
onMasterSecretCleared()
        (no onDestroy)               ← the fix
Creating ScreenLockActivity
AttachmentDatabase: insertParts(1)
```

Unlocking returns to the same conversation with the file marked **Sent**. Also checked:
a **two-second** round trip out of the app and back now locks (the case the alarm delay used to swallow); Home then
reopen still demands authentication; a force-stop cold start still routes through `STATE_SCREEN_LOCKED`;
rotating the device while the picker is open keeps the attachment (`onCreate` logs `has_started=true`,
the locked route is skipped, the file still sends); and Back from a lock covering a live conversation
lands on the launcher having created exactly one lock screen.

### Not covered by that testing

- **The self-spinning `ERROR_LOCKOUT` case.** Everything above was re-run with a **fingerprint
  enrolled**, so the `BiometricPrompt` path and its `onAuthenticationError` arms do now execute rather
  than falling back to `createConfirmDeviceCredentialIntent` — worth checking with
  `adb shell dumpsys biometric | grep -i eligible` before trusting any app-lock test result, since a
  bare emulator reports `Ineligible … :7` and never runs that branch at all. Deliberately triggering a
  five-failed-attempts lockout is still untested.
- **Declining the unlock does not preserve state** — the conversation was gone on return. No worse than
  before, since the activity was already finished pre-PR, but not the same property as the picker case.
- **A possible one-frame reveal.** The lock starts from `onStart`, but the activity beneath also runs
  `onResume`, which clears `FLAG_SECURE`. Not observed, and not verified frame-by-frame. If it shows up,
  the answer is to blank content while locked rather than to go back to destroying the task.
