### PR TITLE
Notifications: report fast mode unavailable on the website flavour

### DIFF
--- a/app/src/website/kotlin/org/thoughtcrime/securesms/onboarding/messagenotifications/FastModeAvailability.kt
+++ b/app/src/website/kotlin/org/thoughtcrime/securesms/onboarding/messagenotifications/FastModeAvailability.kt
@@ -2,4 +2,11 @@ package org.thoughtcrime.securesms.onboarding.messagenotifications
 
 import android.app.Application
 
-internal fun Application.isFastModeAvailable(): Boolean = true
+/**
+ * Fast mode can never work on this flavour, however capable the device is: it binds
+ * `NoOpTokenFetcher`, whose token is permanently null, and `PushRegistrationHandler` combines on
+ * `token.filterNotNull()` — so registration is never even attempted. Reporting it unavailable also
+ * preserves the battery-optimisation prompt in `HomeViewModel`, which is gated on the user not being
+ * in fast mode and is the only mitigation left once delivery depends on `BackgroundPollWorker`.
+ */
+internal fun Application.isFastModeAvailable(): Boolean = false


### PR DESCRIPTION
### The bug

The de-googled build offers "Fast Mode (Recommended)" in onboarding and in Notification settings, lets
the user switch it on, and then never registers for push — with nothing saying so.

`isFastModeAvailable()` returned an unconditional `true` for this flavour, but the flavour has no FCM at
all:

- `firebase-messaging` is added only to the `play` and `fdroid` variants (`app/build.gradle.kts`)
- `FirebasePushService` is registered only in the `play` and `fdroid` manifests
- `website` binds `NoOpTokenFetcher`, whose token is permanently `null`, and
  `PushRegistrationHandler` combines on `token.filterNotNull()` — so registration is never even
  attempted

Because the flavour is a build-time choice, the device's capability is irrelevant: a fully
Google-serviced phone that installs this APK still gets no push. Confirmed on an emulator with Play
Services present.

### Why it is worse than "notifications are slower"

Choosing fast mode sets `PUSH_ENABLED`, and `HomeViewModel` gates the battery-optimisation prompt on the
user **not** being in fast mode. So the one mitigation that helps someone who is actually depending on
15-minute `BackgroundPollWorker` polling is suppressed for exactly the users who cannot receive push.

### The change

Report fast mode unavailable on this flavour, with a comment recording why so it isn't "fixed" back to
`true`. The settings toggle then shows as disabled and the battery-optimisation prompt returns.

### Known gap: existing installs are not migrated

A user who already enabled fast mode keeps `PUSH_ENABLED` set, so their prompt stays suppressed. The
clean follow-up is to treat "effectively in fast mode" as `PUSH_ENABLED && isFastModeAvailable()` at the
two read sites rather than mutating the stored preference — deliberately left out of this change.

### Alternative considered

Giving `website` the same wiring `fdroid` already has (Firebase dependency plus the real
`com.google.android.gms` check) would let capable devices receive push. Not taken: this flavour exists to
be Google-free, and it began life as *"add no op push manager for de-googled"*.