### PR TITLE
Pro: drop the proof's version field

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/pro/ProProofs.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/pro/ProProofs.kt
@@ -6,11 +6,22 @@ import org.session.protos.SessionProtos
 
 /**
  * Copies values from a libsession ProProof into a protobuf-based ProProof.
+ *
+ * There is deliberately no version field. A proof's format is bound into its signature by the
+ * 16-byte domain prefix the signer selects (`ProProof_v0_____`), so the version was never part of
+ * the signed payload — carrying it alongside as a plain value proved nothing and could disagree
+ * with the format the signature actually attests to. Verification derives the format from the
+ * prefix instead, and libsession-util has dropped `ProProof::version` accordingly.
+ *
+ * Protobuf field tag 1 on `ProProof` is retired and must never be reused: peers built before the
+ * removal still put a `uint32` there, so a new field on tag 1 would be fed their stale version
+ * numbers. A peer that sends one is handled by libsession, which reports the proof as
+ * `ProStatus::UnsupportedVersion` and lets the message through without Pro content rather than
+ * dropping it.
  */
 fun SessionProtos.ProProof.Builder.copyFromLibSession(
     proProof: ProProof
-): SessionProtos.ProProof.Builder = setVersion(proProof.version)
-    .setExpiryUnixTs(proProof.expirySeconds)
+): SessionProtos.ProProof.Builder = setExpiryUnixTs(proProof.expirySeconds)
     .setRevocationTag(ByteString.copyFrom(proProof.revocationTagHex.hexToByteArray()))
     .setRotatingPublicKey(ByteString.copyFrom(proProof.rotatingPubKeyHex.hexToByteArray()))
     .setSig(ByteString.copyFrom(proProof.signatureHex.hexToByteArray()))


### PR DESCRIPTION
Propagates the libsession-util removal of `ProProof::version` to Android.

## Why the field goes away

A proof's format is bound into its signature by the 16-byte domain prefix the signer
selects (`ProProof_v0_____`). The version was **never part of the signed payload**, so
carrying it alongside as a plain value attested to nothing and could disagree with the
format the signature actually covers. Verification derives the format from the prefix,
which makes a separate version field redundant rather than merely unused.

Upstream: libsession-util PR #130, commit `f0b9ab23` *"fix: pro proof has no version field
at all"*, merged to `dev`. `session-pro-backend` has already dropped it too (PR #21).

## Wire compatibility

Protobuf field tag 1 on `ProProof` is **retired and must never be reused** — peers built
before the removal still write a `uint32` there, so a new field on tag 1 would be handed
their stale version numbers.

Those older peers degrade rather than break: a companion libsession change reports an
unknown/missing version as `ProStatus::UnsupportedVersion`, which **delivers the message
without Pro content** instead of dropping the whole message.

## What changed here

One call site: `ProProofs.kt` no longer calls `setVersion(proProof.version)` when building
the protobuf `ProProof`. The remaining four fields are unchanged.

A repo-wide sweep found **no other reference to a Pro proof version** — no test, no QA
launch extra, no receive-side `getVersion()` read.

Two things worth stating explicitly, because both were checked rather than assumed:

- **Android does not vendor `SessionProtos.proto`.** There is no `.proto` file in this
  repo; the generated `org.session.protos.*` classes ship inside the
  `libsession-util-android` artifact, whose own submodule owns
  `libsession-util/proto/SessionProtos.proto`. The proto half of the removal therefore
  arrives with the dependency bump and needs no change here.
- **Nothing switches exhaustively on libsession's `ProStatus`.** It reaches Kotlin as
  `typealias ProProofStatus = Int` with `const val` constants, not an enum or sealed
  class, so the new `UnsupportedVersion` case cannot break compilation. Every consumer
  branches by positive match — `ProfileUpdateHandler` keeps a record only for
  `STATUS_VALID || STATUS_EXPIRED`, `MessageParser` gates Pro on `STATUS_VALID` — so a new
  status falls through to the non-Pro path, which is exactly the graceful degradation the
  upstream change intends. No new branch is needed.

## CI will not be green yet — expected

This depends on two things that **do not exist yet**:

1. **A libsession-util release containing the removal.** v1.8.0 predates it; the change is
   only on `dev`.
2. **An `libsession-util-android` build published with that libsession**, which this repo
   would then bump to (currently pinned at `libsessionUtilAndroidVersion = "1.1.0-49-g5dbfffc"`).

Until both land, CI builds against the published artifact — which still *has* `.version`.
Note this particular change is source-compatible in both directions (it only stops calling
a getter), so the Kotlin compile passes against the current pin as well; but the wire
behaviour is not correct until the dependency moves. No dependency bump is included here
deliberately — the maintainer decides when to merge.

## Verification

`./gradlew :app:compilePlayAutomaticQaKotlin` — **BUILD SUCCESSFUL**, against the currently
pinned artifact. Per this repo's own warning, a Kotlin compile does not prove a JNI change
works; no JNI is touched here, so a typecheck is the appropriate check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
