### PR TITLE
Media: describe a thumbnail by whether it could be decoded

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/ThumbnailView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/ThumbnailView.kt
@@ -13,10 +13,14 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
 import com.bumptech.glide.RequestBuilder
 import com.bumptech.glide.RequestManager
+import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
+import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.RequestOptions
+import com.bumptech.glide.request.target.Target
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ThumbnailViewBinding
 import org.session.libsession.utilities.Util.equals
@@ -179,7 +183,41 @@ open class ThumbnailView @JvmOverloads constructor(
         .overrideDimensions()
         .transition(DrawableTransitionOptions.withCrossFade())
         .optionalTransform(CenterCrop())
+        .listener(mediaStateListener)
         .missingThumbnailPicture(slide.isInProgress, errorDrawable)
+
+    /**
+     * Describes the thumbnail by whether it could be decoded, so the two outcomes are distinguishable
+     * from outside the app.
+     *
+     * A file that arrives but will not decode still produces a full-size bubble carrying the error
+     * drawable, so "the media message is present" is true either way and says nothing about the picture.
+     * Returning false throughout leaves Glide's own handling untouched.
+     */
+    private val mediaStateListener = object : RequestListener<Drawable> {
+        override fun onLoadFailed(
+            e: GlideException?,
+            model: Any?,
+            target: Target<Drawable>,
+            isFirstResource: Boolean
+        ): Boolean {
+            binding.thumbnailImage.contentDescription =
+                context.getString(R.string.AccessibilityId_mediaInvalid)
+            return false
+        }
+
+        override fun onResourceReady(
+            resource: Drawable,
+            model: Any,
+            target: Target<Drawable>?,
+            dataSource: DataSource,
+            isFirstResource: Boolean
+        ): Boolean {
+            binding.thumbnailImage.contentDescription =
+                context.getString(R.string.AccessibilityId_mediaMessage)
+            return false
+        }
+    }
 
     private fun buildPlaceholderGlideRequest(
         glide: RequestManager,

--- a/app/src/main/res/layout/thumbnail_view.xml
+++ b/app/src/main/res/layout/thumbnail_view.xml
@@ -23,6 +23,7 @@
         android:layout_height="@dimen/accent_line_thickness"
         android:layout_gravity="bottom"
         android:visibility="gone"
+        android:contentDescription="@string/AccessibilityId_mediaLoading"
         tools:visibility="visible" />
 
     <FrameLayout

--- a/content-descriptions/src/main/res/values/strings.xml
+++ b/content-descriptions/src/main/res/values/strings.xml
@@ -353,6 +353,8 @@
     <string name="AccessibilityId_navigateBack">Navigate back</string>
     <string name="AccessibilityId_close">Close Dialog</string>
     <string name="AccessibilityId_expand">Expand</string>
+    <string name="AccessibilityId_mediaInvalid">Media invalid</string>
+    <string name="AccessibilityId_mediaLoading">Media loading</string>
     <string name="AccessibilityId_mediaMessage">Media message</string>
     <string name="AccessibilityId_save">Save</string>
     <string name="AccessibilityId_remove">Remove</string>


### PR DESCRIPTION
The media bubble carried one content description for every outcome, so a file that arrived but would not
decode was indistinguishable from one that rendered correctly: both leave a full-size media message in
place, and the error drawable fills it.

That makes any check written against the bubble unable to fail in the way it claims to. An end-to-end
test asserting "the photo rendered" passes on a placeholder, which is exactly the state a wrong-format or
undecryptable attachment produces.

## What this adds

- `Media invalid` when the thumbnail fails to load, and `Media message` when it succeeds, set from a
  Glide `RequestListener` on the thumbnail request.
- `Media loading` on the progress bar, so a bubble that is still downloading can be told from one that
  has drawn. Neither presence nor size separates those today — the bubble keeps its description and
  reserves the eventual image's full size throughout.

The listener returns `false` from both callbacks, so Glide's own error handling and the existing
`missingThumbnailPicture` error drawable are untouched. This only describes what already happens.

## Why these names

They match the identifiers iOS already exposes for the same three states (`Media invalid`, `Media retry`,
and `Media loading` in session-ios#758), so one cross-platform assertion means the same thing on both
platforms rather than each suite carrying its own per-platform vocabulary.

## How it was found

The cross-client attachment matrix in session-appium reported an attachment as rendered on a bubble that
was still showing a spinner. The equivalent iOS states already existed, which is what made the gap
visible — the Android half of the same assertion had nothing to check.

Compiles clean (`:app:compilePlayAutomaticQaKotlin`). No behaviour change.

