### PR TITLE
feat(qa): make the Pro stats counts readable to a test

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/ProSettingsHomeScreen.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/prosettings/ProSettingsHomeScreen.kt
@@ -501,7 +501,12 @@ fun ProStatItem(
         }
 
         Text(
-            modifier = Modifier.weight(1f),
+            // The cell's own qa tag is on the Row above, which is a layout container and
+            // carries no text -- Compose's testTag sets a resource-id, not a description.
+            // So the count ("12 badges sent") was unreadable to a test: present on screen,
+            // absent from every node a reader could address. This tags the node that
+            // actually holds it, scoped by the row's id the same way action-item-title is.
+            modifier = Modifier.weight(1f).qaTag(R.string.qa_pro_stats_value),
             text = title,
             style = LocalType.current.h9,
             color = if(disabledState) LocalColors.current.textSecondary else LocalColors.current.text

--- a/content-descriptions/src/main/res/values/strings.xml
+++ b/content-descriptions/src/main/res/values/strings.xml
@@ -379,6 +379,11 @@
     <string name="qa_pro_stats_longer_messages">pro-stats-longer-messages</string>
     <string name="qa_pro_stats_pinned_conversations">pro-stats-pinned-conversations</string>
     <string name="qa_pro_stats_badges_sent">pro-stats-badges-sent</string>
+    <!-- The text inside a Pro stats cell. Generic on purpose: the cell's own id
+         (qa_pro_stats_*) sits on the row, which carries no text of its own, so a
+         reader scopes this child by that parent - the same shape as
+         qa_pro_screen_action_label and qa_action_item_title. -->
+    <string name="qa_pro_stats_value">pro-stats-value</string>
     <string name="qa_pro_stats_groups_upgraded">pro-stats-groups-upgraded</string>
     <string name="qa_pro_settings_manage_header">pro-settings-manage-header</string>
     <string name="qa_pro_settings_features_header">pro-settings-features-header</string>


### PR DESCRIPTION
Adds one qa tag so the "Your Pro Stats" counts can be read by the automation suite.

### The problem

Each cell already has an id — `pro-stats-badges-sent`, `-longer-messages`, `-pinned-conversations`, `-groups-upgraded` — but they sit on `ProStatItem`'s root `Row`. `qaTag` is `semantics { testTagsAsResourceId = true }.testTag(…)`, which sets a **resource-id and no description**, and a `Row` is a layout container with no text of its own.

So the number is visible on screen and unreadable to a test. A spec could only assert *"four cells exist"* — coverage that cannot fail.

### The change

One string (`qa_pro_stats_value` → `pro-stats-value`) and one `qaTag` on the `Text` that holds the value.

Generic on purpose. The cell's identity is already the row's id; a reader scopes this child by that parent. Same shape as the existing `action-item-title` and `pro-screen-action-label`.

```
pro-stats-badges-sent          (row — identity)
  └── pro-stats-value          (text — "12 badges sent")
```

### One thing worth knowing

`pro-stats-groups-upgraded` is readable **today**, but only by accident: its tooltip makes the row `clickable`, and `clickable` merges descendants into the parent's semantics. The other three have no tooltip and are not readable. That is not a property to depend on — it vanishes with the tooltip.

### Why now

It unblocks a Pro-stats spec on Android. That spec currently has to be `iosIt`, because iOS puts the id on the cell title where the text already is. With this, it becomes `bothPlatformsIt` with no other change.

Also relevant: `groups-upgraded` currently has **no data source on any client** — Android hard-codes 0, iOS's counter has no write site, Desktop assigns 0. Tagged here for symmetry; not something a test should assert yet.

### Verification

`./gradlew :app:compilePlayAutomaticQaKotlin` — BUILD SUCCESSFUL. Not exercised on a device; it is a semantics-only change with no runtime behaviour.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>