### PR TITLE
Count the Pro sent stats as running totals, and stop community messages duplicating

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/MessageTargetAddress.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MessageTargetAddress.kt
@@ -1,0 +1,24 @@
+package org.thoughtcrime.securesms.database
+
+import org.session.libsession.utilities.Address
+
+/**
+ * The address a message is stored against when it is not a sync copy naming its own target.
+ *
+ * Both message tables reject a duplicate by comparing `DATE_SENT`, `ADDRESS` and `THREAD_ID`, so this has
+ * to agree with the address the same message was given when it was composed - otherwise our own message
+ * coming back to us reads as a different one and is stored a second time.
+ */
+object MessageTargetAddress {
+
+    /**
+     * The conversation for anything group-shaped, the sender otherwise.
+     *
+     * [Address.LegacyGroup] is deliberately not treated as group-shaped here even though it is
+     * [Address.GroupLike]: legacy groups are no longer supported, so their behaviour is left as it was.
+     */
+    fun of(threadAddress: Address, senderAddress: Address): Address = when (threadAddress) {
+        is Address.Group, is Address.Community -> threadAddress
+        else -> senderAddress
+    }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.kt
@@ -46,6 +46,10 @@ import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper
 import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord
 import org.thoughtcrime.securesms.database.model.MessageChanges
 import org.thoughtcrime.securesms.database.model.MessageId
+import network.loki.messenger.libsession_util.protocol.ProFeature
+import org.thoughtcrime.securesms.pro.ProSendStats
+import org.thoughtcrime.securesms.pro.toProProfileFeatures
+import org.thoughtcrime.securesms.pro.db.ProDatabase
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord
 import org.thoughtcrime.securesms.database.model.Quote
@@ -78,6 +82,7 @@ class MmsDatabase @Inject constructor(
     private val groupDatabase: GroupDatabase,
     private val snodeClock: SnodeClock,
     private val prefs: Provider<PreferenceStorage>,
+    private val proDatabase: Provider<ProDatabase>,
 ) : MessagingDatabase(context, databaseHelper) {
     private val earlyDeliveryReceiptCache = EarlyReceiptCache()
     private val earlyReadReceiptCache = EarlyReceiptCache()
@@ -119,26 +124,6 @@ class MmsDatabase @Inject constructor(
                 .map(cursor::getLong)
                 .any { MmsSmsColumns.Types.isOutgoingMessageType(it) }
         }
-
-    fun getOutgoingMessageProFeatureCount(featureMask: Long): Int {
-        return getOutgoingProFeatureCountInternal(PRO_MESSAGE_FEATURES, featureMask)
-    }
-
-    fun getOutgoingProfileProFeatureCount(featureMask: Long): Int {
-        return getOutgoingProFeatureCountInternal(PRO_PROFILE_FEATURES, featureMask)
-    }
-
-    private fun getOutgoingProFeatureCountInternal(column: String, featureMask: Long): Int {
-        val db = readableDatabase
-        val where = "($column & $featureMask) != 0 AND $IS_OUTGOING"
-
-        db.query(TABLE_NAME, arrayOf("COUNT(*)"), where, null, null, null, null).use { cursor ->
-            if (cursor.moveToFirst()) {
-                return cursor.getInt(0)
-            }
-        }
-        return 0
-    }
 
     fun isDeletedMessage(id: Long): Boolean =
         readableDatabase.query(
@@ -333,10 +318,29 @@ class MmsDatabase @Inject constructor(
     }
 
     override fun markAsSent(messageId: Long, isSent: Boolean) {
+        // Read BEFORE the update: this is the only moment that can tell a message's first success from a
+        // later repeat, and the update overwrites it.
+        val beforeSending = readProSendStatState(messageId)
+
         markAs(
             messageId,
             MmsSmsColumns.Types.BASE_SENT_TYPE or if (isSent) MmsSmsColumns.Types.PUSH_MESSAGE_BIT or MmsSmsColumns.Types.SECURE_MESSAGE_BIT else 0
         )
+
+        beforeSending?.let {
+            ProSendStats.recordSendSuccess(proDatabase.get(), it.wasAlreadySent, it.features)
+        }
+    }
+
+    /** See [ProSendStatRow]; this only supplies the columns. */
+    private fun readProSendStatState(messageId: Long): ProSendStatRow.State? {
+        return readableDatabase.query(
+            "SELECT $MESSAGE_BOX, $PRO_MESSAGE_FEATURES, $PRO_PROFILE_FEATURES FROM $TABLE_NAME WHERE $ID = ?",
+            arrayOf(messageId)
+        ).use { cursor ->
+            if (!cursor.moveToFirst()) null
+            else ProSendStatRow.from(cursor.getLong(0), cursor.getLong(1), cursor.getLong(2))
+        }
     }
 
     override fun markAsDeleted(messageId: Long, isOutgoing: Boolean, displayedMessage: String) {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsColumns.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsColumns.java
@@ -192,6 +192,25 @@ public interface MmsSmsColumns {
       return (type & BASE_TYPE_MASK) == BASE_SENT_TYPE;
     }
 
+    /**
+     * Whether this message has already been sent to its recipient successfully at least once.
+     *
+     * Wider than {@link #isSentType(long)} on purpose. After a successful send, a 1:1 message is
+     * immediately moved to SYNCING so a copy can go to our own devices, and that sync leg reports its own
+     * success through the same "mark as sent" path. So SENT is not the only state that means "already
+     * sent" -- SYNCING, RESYNCING and SYNC_FAILED all imply the send to the recipient already succeeded,
+     * because nothing starts syncing a message that never went out.
+     *
+     * Used to count a sent message once: testing SENT alone would count every 1:1 message twice, once for
+     * the send and again for its sync.
+     */
+    public static boolean hasBeenSentSuccessfully(long type) {
+      return isSentType(type) ||
+             isSyncingType(type) ||
+             isResyncingType(type) ||
+             isSyncFailedMessageType(type);
+    }
+
     public static boolean isPendingSmsFallbackType(long type) {
       return (type & BASE_TYPE_MASK) == BASE_PENDING_INSECURE_SMS_FALLBACK ||
              (type & BASE_TYPE_MASK) == BASE_PENDING_SECURE_SMS_FALLBACK;

--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -381,16 +381,6 @@ public class MmsSmsDatabase extends Database {
     return count;
   }
 
-    public int getOutgoingMessageProFeatureCount(long featureMask) {
-        return smsDatabase.get().getOutgoingMessageProFeatureCount(featureMask) +
-                mmsDatabase.get().getOutgoingMessageProFeatureCount(featureMask);
-    }
-
-    public int getOutgoingProfileProFeatureCount(long featureMask) {
-        return smsDatabase.get().getOutgoingProfileProFeatureCount(featureMask) +
-                mmsDatabase.get().getOutgoingProfileProFeatureCount(featureMask);
-    }
-
 
   public void incrementReadReceiptCount(SyncMessageId syncMessageId, long timestamp) {
     smsDatabase.get().incrementReceiptCount(syncMessageId, false, true);

--- a/app/src/main/java/org/thoughtcrime/securesms/database/ProSendStatRow.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ProSendStatRow.kt
@@ -1,0 +1,46 @@
+package org.thoughtcrime.securesms.database
+
+import network.loki.messenger.libsession_util.protocol.ProFeature
+import org.thoughtcrime.securesms.pro.toProMessageFeatures
+import org.thoughtcrime.securesms.pro.toProProfileFeatures
+
+/**
+ * Reads a message row's Pro "sent" stat state out of the three column values that decide it.
+ *
+ * Shared by the SMS and MMS tables. Each owns its own cursor — different tables, different column
+ * constants — but the two decisions here are NOT duplicated, because both are easy to get subtly wrong and
+ * a divergence between the two copies would show up as a stat that is right for text messages and wrong
+ * for media, or the reverse.
+ */
+object ProSendStatRow {
+
+    /** A row that can contribute to the "sent" stats, and whether it already has. */
+    data class State(
+        val wasAlreadySent: Boolean,
+        val features: Set<ProFeature>,
+    )
+
+    /**
+     * The stat state for a row, or null if the row cannot contribute.
+     *
+     * Null means INCOMING. Incoming rows carry the sender's feature bits, not ours, so counting one would
+     * add someone else's badge to your total. The old whole-table query had the same guard as an
+     * `IS_OUTGOING` clause.
+     *
+     * Call this with values read BEFORE the row is marked sent: [State.wasAlreadySent] is what separates a
+     * message's first successful send from a later repeat, and marking it sent destroys that distinction.
+     */
+    @JvmStatic
+    fun from(type: Long, messageFeatures: Long, profileFeatures: Long): State? {
+        if (!MmsSmsColumns.Types.isOutgoingMessageType(type)) return null
+
+        val features = mutableSetOf<ProFeature>()
+        messageFeatures.toProMessageFeatures(features)
+        profileFeatures.toProProfileFeatures(features)
+
+        return State(
+            wasAlreadySent = MmsSmsColumns.Types.hasBeenSentSuccessfully(type),
+            features = features,
+        )
+    }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -47,6 +47,8 @@ import org.thoughtcrime.securesms.database.model.SmsMessageRecord;
 import org.thoughtcrime.securesms.preferences.CommunicationPreferences;
 import org.thoughtcrime.securesms.preferences.PreferenceStorage;
 import org.thoughtcrime.securesms.pro.ProFeatureExtKt;
+import org.thoughtcrime.securesms.pro.ProSendStats;
+import org.thoughtcrime.securesms.pro.db.ProDatabase;
 
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -67,6 +69,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow;
 import kotlinx.coroutines.flow.SharedFlow;
 import kotlinx.coroutines.flow.SharedFlowKt;
 import network.loki.messenger.libsession_util.protocol.ProFeature;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Database for storage of SMS messages.
@@ -164,6 +168,7 @@ public class SmsDatabase extends MessagingDatabase {
   private final SnodeClock snodeClock;
   private final Lazy<@NonNull ReactionDatabase> reactionDatabase;
   final Provider<@NonNull PreferenceStorage> prefs;
+  final Provider<@NonNull ProDatabase> proDatabase;
 
   final MutableSharedFlow<MessageChanges> changeNotification
           = SharedFlowKt.MutableSharedFlow(0, 24, BufferOverflow.DROP_OLDEST);
@@ -174,12 +179,14 @@ public class SmsDatabase extends MessagingDatabase {
                      RecipientRepository recipientRepository,
                      SnodeClock snodeClock,
                      Lazy<@NonNull ReactionDatabase> reactionDatabase,
-                     Provider<@NonNull PreferenceStorage> prefs) {
+                     Provider<@NonNull PreferenceStorage> prefs,
+                     Provider<@NonNull ProDatabase> proDatabase) {
     super(context, databaseHelper);
     this.recipientRepository = recipientRepository;
     this.snodeClock = snodeClock;
     this.reactionDatabase = reactionDatabase;
     this.prefs = prefs;
+    this.proDatabase = proDatabase;
   }
 
   public SharedFlow<MessageChanges> getChangeNotification() {
@@ -224,7 +231,26 @@ public class SmsDatabase extends MessagingDatabase {
 
   @Override
   public void markAsSent(long id, boolean isSent) {
+    // Read BEFORE the update: this is the only moment that can tell a message's first success from a
+    // later repeat, and the update overwrites it.
+    final ProSendStatRow.State beforeSending = readProSendStatState(id);
+
     updateTypeBitmask(id, Types.BASE_TYPE_MASK, Types.BASE_SENT_TYPE | (isSent ? Types.PUSH_MESSAGE_BIT | Types.SECURE_MESSAGE_BIT : 0));
+
+    if (beforeSending != null) {
+      ProSendStats.INSTANCE.recordSendSuccess(proDatabase.get(), beforeSending.getWasAlreadySent(), beforeSending.getFeatures());
+    }
+  }
+
+  /** See {@link ProSendStatRow}; this only supplies the columns. */
+  private ProSendStatRow.@Nullable State readProSendStatState(long id) {
+    try (final Cursor cursor = getReadableDatabase().rawQuery(
+            "SELECT " + TYPE + ", " + PRO_MESSAGE_FEATURES + ", " + PRO_PROFILE_FEATURES +
+                    " FROM " + TABLE_NAME + " WHERE " + ID + " = ?", id)) {
+      if (!cursor.moveToFirst()) return null;
+
+      return ProSendStatRow.from(cursor.getLong(0), cursor.getLong(1), cursor.getLong(2));
+    }
   }
 
   public void markAsSending(long id) {
@@ -304,29 +330,6 @@ public class SmsDatabase extends MessagingDatabase {
 
     return isOutgoing;
   }
-
-    public int getOutgoingMessageProFeatureCount(long featureMask) {
-        return getOutgoingProFeatureCountInternal(PRO_MESSAGE_FEATURES, featureMask);
-    }
-
-    public int getOutgoingProfileProFeatureCount(long featureMask) {
-        return getOutgoingProFeatureCountInternal(PRO_PROFILE_FEATURES, featureMask);
-    }
-
-    private int getOutgoingProFeatureCountInternal(@NonNull String columnName, long featureMask) {
-        SQLiteDatabase db = getReadableDatabase();
-
-        // outgoing clause
-        String where = "(" + columnName + " & " + featureMask + ") != 0 AND " + IS_OUTGOING;
-
-        try (Cursor cursor = db.query(TABLE_NAME, new String[]{"COUNT(*)"}, where, null, null, null, null)) {
-            if (cursor != null && cursor.moveToFirst()) {
-                return cursor.getInt(0);
-            }
-        }
-
-        return 0;
-    }
 
   public boolean isDeletedMessage(long id) {
     SQLiteDatabase database     = getReadableDatabase();

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -310,7 +310,7 @@ open class Storage @Inject constructor(
 
         val targetAddress = if ((isUserSender || isUserBlindedSender) && !message.syncTarget.isNullOrEmpty()) {
             message.syncTarget!!.toAddress()
-        } else (threadRecipient.address as? Address.Group) ?: senderAddress
+        } else MessageTargetAddress.of(threadRecipient.address, senderAddress)
 
         if (message.threadID == null) {
             message.threadID = getOrCreateThreadIdFor(targetAddress)

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -69,6 +69,8 @@ import org.thoughtcrime.securesms.auth.LoginStateRepository
 import org.thoughtcrime.securesms.database.MmsSmsDatabaseExt.trimThread
 import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper
 import org.thoughtcrime.securesms.database.model.MessageId
+import org.thoughtcrime.securesms.pro.ProSendStats
+import org.thoughtcrime.securesms.pro.db.ProDatabase
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.database.model.ReactionRecord
 import org.thoughtcrime.securesms.dependencies.ConfigFactory
@@ -108,6 +110,7 @@ open class Storage @Inject constructor(
     private val loginStateRepository: LoginStateRepository,
     private val json: Json,
     private val jobQueue: Provider<JobQueue>,
+    private val proDatabase: Provider<ProDatabase>,
 ) : Database(context, helper), StorageProtocol {
 
     override fun getUserPublicKey(): String? { return loginStateRepository.peekLoginState()?.accountId?.hexString }
@@ -968,16 +971,12 @@ open class Storage @Inject constructor(
     override suspend fun getTotalSentLongMessages(): Int =
         getTotalSentForFeature(ProMessageFeature.HIGHER_CHARACTER_LIMIT)
 
+    /**
+     * A persisted running total, not a count over message rows — so deleting a message you have sent does
+     * not reduce the number of things you have sent, and opening the stats screen does not scan a table.
+     */
     suspend fun getTotalSentForFeature(feature: ProFeature): Int = withContext(Dispatchers.IO) {
-        val mask = 1L shl feature.bitIndex
-
-        when (feature) {
-            is ProMessageFeature ->
-                mmsSmsDatabase.getOutgoingMessageProFeatureCount(mask)
-
-            is ProProfileFeature ->
-                mmsSmsDatabase.getOutgoingProfileProFeatureCount(mask)
-        }
+        ProSendStats.total(proDatabase.get(), feature)
     }
 
     override fun setPinned(address: Address, isPinned: Boolean) {

--- a/app/src/main/java/org/thoughtcrime/securesms/pro/ProSendStats.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/pro/ProSendStats.kt
@@ -1,0 +1,95 @@
+package org.thoughtcrime.securesms.pro
+
+import network.loki.messenger.libsession_util.protocol.ProFeature
+import network.loki.messenger.libsession_util.protocol.ProMessageFeature
+import network.loki.messenger.libsession_util.protocol.ProProfileFeature
+
+/**
+ * The "sent" Pro stats — how many Pro badges and how many longer-than-standard messages this account has
+ * sent — held as persisted running totals.
+ *
+ * These used to be a `COUNT(*)` over outgoing message rows carrying the feature bit, which made the stat
+ * a view of the message table rather than a record of what the account had done. Two consequences of
+ * that, both of which this replaces:
+ *
+ *  - **Deleting a counted message reduced the stat.** Sending is the event being counted, and deleting
+ *    your copy of a message afterwards does not un-send it. Other clients are unaffected by deletion and
+ *    this now matches them.
+ *  - Every render of the stats screen counted the whole table.
+ *
+ * The message table is not an input at all — not even to initialise the total. Pro has not shipped, so
+ * there are no historical sends to carry over, and a counter that starts at zero is the whole of it.
+ *
+ * Pure logic over a [Store] so it can be tested without a database; [Store] is implemented by
+ * `ProDatabase` over its `pro_state` table.
+ */
+object ProSendStats {
+
+    /** Persistence for the counters. Values are non-negative and only ever move up. */
+    interface Store {
+        fun getProStatCount(name: String): Long?
+
+        /** Must be atomic: read-modify-write in one statement, not a get followed by a set. */
+        fun incrementProStatCount(name: String)
+    }
+
+    /**
+     * Record a message reaching "sent" for the first time.
+     *
+     * Two things have to hold together, and each rules out an obvious simpler place to count:
+     *
+     *  - **A confirmed send.** Counting when the row is inserted, or at any point before the network
+     *    call returns, counts messages that never went anywhere.
+     *  - **At most once per message.** Counting on every successful send double-counts a message that
+     *    took more than one attempt.
+     *
+     * [wasAlreadySent] is what reconciles them, and it needs no bookkeeping of its own because the
+     * message's own state already carries it. A first success transitions out of a non-sent state, so it
+     * counts. A repeat call for a message already recorded as sent does not. A retry after a failure
+     * transitions out of *failed*, which is that message's first success, so it counts exactly once.
+     */
+    fun recordSendSuccess(store: Store, wasAlreadySent: Boolean, features: Set<ProFeature>) {
+        if (wasAlreadySent) return
+        recordSend(store, features)
+    }
+
+    /** Add one to each stat [features] feeds. Prefer [recordSendSuccess]; this does no gating. */
+    private fun recordSend(store: Store, features: Set<ProFeature>) {
+        features.asSequence()
+            .mapNotNull(::storageKey)
+            .distinct()
+            .forEach(store::incrementProStatCount)
+    }
+
+    /**
+     * The total to display for [feature] — just what has been counted, with nothing derived from the
+     * message rows. Deleting a message you have sent cannot move it, because the rows are not consulted.
+     */
+    fun total(store: Store, feature: ProFeature): Int {
+        val key = storageKey(feature) ?: return 0
+
+        // Saturating rather than wrapping: 2^31 sends is not reachable, but a wrapped Int would display
+        // as negative rather than as obviously wrong.
+        return (store.getProStatCount(key) ?: 0L)
+            .coerceIn(0L, Int.MAX_VALUE.toLong())
+            .toInt()
+    }
+
+    /**
+     * Where this feature's running total is stored, or null if it does not feed a stat.
+     *
+     * Only the two "sent" stats live here. Pinned conversations are derived from config rather than
+     * counted, and the groups stat has no data source on any client.
+     *
+     * These strings are PERSISTED keys. Renaming one abandons the count stored under the old name, so it
+     * is a data change rather than an edit.
+     */
+    private fun storageKey(feature: ProFeature): String? = when (feature) {
+        ProProfileFeature.PRO_BADGE -> KEY_BADGES_SENT
+        ProMessageFeature.HIGHER_CHARACTER_LIMIT -> KEY_LONG_MESSAGES
+        else -> null
+    }
+
+    private const val KEY_BADGES_SENT = "pro_stat_badges_sent"
+    private const val KEY_LONG_MESSAGES = "pro_stat_long_messages"
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/pro/db/ProDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/pro/db/ProDatabase.kt
@@ -15,6 +15,7 @@ import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper
 import network.loki.messenger.libsession_util.pro.GetProStatusResponse
 import network.loki.messenger.libsession_util.pro.ProRevocationItem
 import org.thoughtcrime.securesms.util.asSequence
+import org.thoughtcrime.securesms.pro.ProSendStats
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Provider
@@ -25,7 +26,7 @@ class ProDatabase @Inject constructor(
     @ApplicationContext context: Context,
     databaseHelper: Provider<SQLCipherOpenHelper>,
     private val json: Json,
-) : Database(context, databaseHelper) {
+) : Database(context, databaseHelper), ProSendStats.Store {
 
     private val cache = LruCache<String, Unit>(1000)
 
@@ -260,6 +261,35 @@ class ProDatabase @Inject constructor(
         }
     }
 
+
+    // --- ProSendStats.Store -------------------------------------------------------------------------
+    //
+    // The Pro "sent" stat counters, over the same pro_state key/value table as the rest of the scalar
+    // Pro state, so no schema change is involved. Values are stored as TEXT like every other key here.
+
+    override fun getProStatCount(name: String): Long? {
+        return readableDatabase.query(
+            "SELECT value FROM pro_state WHERE name = ?",
+            arrayOf(name)
+        ).use { cursor ->
+            if (cursor.moveToFirst()) cursor.getString(0)?.toLongOrNull() else null
+        }
+    }
+
+    /**
+     * One statement, so a concurrent send cannot read the same value twice and lose an increment. A
+     * get-then-set from Kotlin would be exactly that race.
+     */
+    override fun incrementProStatCount(name: String) {
+        writableDatabase.compileStatement("""
+            INSERT INTO pro_state (name, value)
+            VALUES (?, '1')
+            ON CONFLICT DO UPDATE SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT)
+        """).use { stmt ->
+            stmt.bindString(1, name)
+            stmt.executeInsert()
+        }
+    }
 
     companion object {
         private const val TAG = "ProRevocationDatabase"

--- a/app/src/main/java/org/thoughtcrime/securesms/service/ExpiringMessageManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/ExpiringMessageManager.kt
@@ -146,6 +146,8 @@ class ExpiringMessageManager @Inject constructor(
                 quote = null,
                 previews = emptyList(),
                 messageContent = content
+                // No proFeatures here: this group-message constructor does not expose the parameter at
+                // all, so the row cannot carry Pro features even by mistake.
             ) else OutgoingMediaMessage(
                 recipient = serializedAddress,
                 body = "",
@@ -157,7 +159,11 @@ class ExpiringMessageManager @Inject constructor(
                 messageContent = content,
                 linkPreviews = emptyList(),
                 group = null,
-                isGroupUpdateMessage = false
+                isGroupUpdateMessage = false,
+                // Explicit rather than defaulted. This row reaches markAsSent and so feeds the Pro
+                // "sent" stats; a control message carries no Pro features, and saying so here makes
+                // adding any a deliberate edit rather than the filling of a blank.
+                proFeatures = emptySet()
             )
 
             return mmsDatabase.insertSecureDecryptedMessageOutbox(

--- a/app/src/test/java/org/thoughtcrime/securesms/database/MessageTargetAddressTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/MessageTargetAddressTest.kt
@@ -1,0 +1,57 @@
+package org.thoughtcrime.securesms.database
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.session.libsession.utilities.Address
+import org.session.libsignal.utilities.AccountId
+
+/**
+ * Which address a message is stored against, and therefore which stored message a later copy of it is
+ * compared with.
+ *
+ * Both message tables reject a duplicate on `DATE_SENT`, `ADDRESS` and `THREAD_ID`. The first and third
+ * are the same for a message and its echo by construction, so this decision is the whole of the check —
+ * a conversation type that answers with the sender here has no duplicate protection at all once the
+ * in-memory guard is gone, which is what a restart does to it.
+ */
+@RunWith(RobolectricTestRunner::class)
+class MessageTargetAddressTest {
+
+    private val sender = Address.Standard(
+        AccountId("0538e63512fd78c04d45b83ec7f0f3d593f60276ce535d1160eb589a00cca7db59")
+    )
+    private val community = Address.Community(serverUrl = "https://open.getsession.org", room = "session")
+    private val group = Address.Group(
+        AccountId("0338e63512fd78c04d45b83ec7f0f3d593f60276ce535d1160eb589a00cca7db59")
+    )
+
+    @Test
+    fun `a community message is stored against the community`() {
+        // The regression this exists for. Answering with the sender stored our own message a second time,
+        // because the copy saved when it was composed is addressed to the community.
+        assertEquals(community, MessageTargetAddress.of(threadAddress = community, senderAddress = sender))
+    }
+
+    @Test
+    fun `a group message is stored against the group`() {
+        assertEquals(group, MessageTargetAddress.of(threadAddress = group, senderAddress = sender))
+    }
+
+    @Test
+    fun `a one to one message is stored against the sender`() {
+        val other = Address.Standard(
+            AccountId("0578e63512fd78c04d45b83ec7f0f3d593f60276ce535d1160eb589a00cca7db59")
+        )
+        assertEquals(sender, MessageTargetAddress.of(threadAddress = other, senderAddress = sender))
+    }
+
+    @Test
+    fun `a legacy group message is still stored against the sender`() {
+        // Not an oversight. LegacyGroup is GroupLike, so widening the check to that interface rather than
+        // naming the two supported types would silently change it, and legacy groups are unsupported.
+        val legacy = Address.LegacyGroup("ab0123")
+        assertEquals(sender, MessageTargetAddress.of(threadAddress = legacy, senderAddress = sender))
+    }
+}

--- a/app/src/test/java/org/thoughtcrime/securesms/database/ProSendCountTransitionTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/ProSendCountTransitionTest.kt
@@ -1,0 +1,89 @@
+package org.thoughtcrime.securesms.database
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Which message states already count as "sent", which is what decides whether marking a message sent adds
+ * to the Pro "sent" stats.
+ *
+ * The trap this exists to pin: a 1:1 message does NOT stay in SENT after a successful send. It is moved
+ * straight to SYNCING so a copy can go to our own devices, and that sync leg reports success through the
+ * same path — so testing SENT alone counts every 1:1 message twice. The sync states have to count as
+ * already-sent, because nothing starts syncing a message that never went out.
+ *
+ * Lives in this package to reach the base type constants.
+ */
+class ProSendCountTransitionTest {
+
+    private fun hasBeenSent(baseType: Long) =
+        MmsSmsColumns.Types.hasBeenSentSuccessfully(baseType)
+
+    // --- states that mean "not yet sent": marking sent counts ------------------------------------
+
+    @Test
+    fun `a message still sending has not been sent`() {
+        assertFalse(hasBeenSent(MmsSmsColumns.Types.BASE_SENDING_TYPE))
+    }
+
+    @Test
+    fun `a failed message has not been sent, so its retry counts`() {
+        // The attempt that failed never reached the recipient, so the retry is the first success.
+        assertFalse(hasBeenSent(MmsSmsColumns.Types.BASE_SENT_FAILED_TYPE))
+    }
+
+    @Test
+    fun `an outbox message has not been sent`() {
+        assertFalse(hasBeenSent(MmsSmsColumns.Types.BASE_OUTBOX_TYPE))
+    }
+
+    // --- states that mean "already sent": marking sent must NOT count again ----------------------
+
+    @Test
+    fun `a sent message has been sent`() {
+        assertTrue(hasBeenSent(MmsSmsColumns.Types.BASE_SENT_TYPE))
+    }
+
+    @Test
+    fun `a syncing message has already been sent`() {
+        // The ordinary 1:1 path: send succeeds, the row moves to SYNCING, and the sync leg then reports
+        // success through the same path. Reading this as not-yet-sent double-counts every 1:1 message.
+        assertTrue(hasBeenSent(MmsSmsColumns.Types.BASE_SYNCING_TYPE))
+    }
+
+    @Test
+    fun `a resyncing message has already been sent`() {
+        assertTrue(hasBeenSent(MmsSmsColumns.Types.BASE_RESYNCING_TYPE))
+    }
+
+    @Test
+    fun `a sync-failed message has already been sent`() {
+        // Only the sync to our own devices failed; the recipient got it, and it was counted then.
+        assertTrue(hasBeenSent(MmsSmsColumns.Types.BASE_SYNC_FAILED_TYPE))
+    }
+
+    // --- the whole outgoing lifecycle, in order -------------------------------------------------
+
+    @Test
+    fun `a 1 to 1 message counts exactly once across send then sync`() {
+        // Walk the real sequence and count how many transitions into "sent" would report.
+        val lifecycle = listOf(
+            MmsSmsColumns.Types.BASE_SENDING_TYPE,   // inserted, sending        -> reports
+            MmsSmsColumns.Types.BASE_SYNCING_TYPE,   // sent, now syncing        -> must not report
+        )
+
+        assertTrue(lifecycle.count { !hasBeenSent(it) } == 1)
+    }
+
+    @Test
+    fun `a retried then synced message also counts exactly once`() {
+        val lifecycle = listOf(
+            MmsSmsColumns.Types.BASE_SENT_FAILED_TYPE, // retry after failure    -> reports
+            MmsSmsColumns.Types.BASE_SYNCING_TYPE,     // then syncs             -> must not report
+            MmsSmsColumns.Types.BASE_SYNC_FAILED_TYPE, // sync failed, resync    -> must not report
+        )
+
+        assertTrue(lifecycle.count { !hasBeenSent(it) } == 1)
+    }
+}

--- a/app/src/test/java/org/thoughtcrime/securesms/database/ProSendStatRowTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/database/ProSendStatRowTest.kt
@@ -1,0 +1,100 @@
+package org.thoughtcrime.securesms.database
+
+import network.loki.messenger.libsession_util.protocol.ProMessageFeature
+import network.loki.messenger.libsession_util.protocol.ProProfileFeature
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.thoughtcrime.securesms.pro.toProMessageBitSetValue
+import org.thoughtcrime.securesms.pro.toProProfileBitSetValue
+
+/**
+ * The row-level decision behind the Pro "sent" stats: whether a row can contribute at all, whether it
+ * already has, and which stats it feeds.
+ *
+ * This is the seam the SMS and MMS tables share. Each supplies its own cursor, but if this drifted the
+ * symptom would be a stat that is correct for text messages and wrong for media, or the reverse — which is
+ * exactly the kind of split that survives a casual test.
+ */
+class ProSendStatRowTest {
+
+    private val longMessageMask = setOf(ProMessageFeature.HIGHER_CHARACTER_LIMIT).toProMessageBitSetValue()
+    private val badgeMask = setOf(ProProfileFeature.PRO_BADGE).toProProfileBitSetValue()
+
+    // --- only outgoing rows can contribute -------------------------------------------------------
+
+    @Test
+    fun `an incoming row cannot contribute`() {
+        // It carries the SENDER's feature bits. Counting it would add someone else's badge to our total.
+        assertNull(
+            ProSendStatRow.from(
+                type = MmsSmsColumns.Types.BASE_INBOX_TYPE,
+                messageFeatures = longMessageMask,
+                profileFeatures = badgeMask,
+            )
+        )
+    }
+
+    @Test
+    fun `an outgoing row contributes`() {
+        assertTrue(
+            ProSendStatRow.from(MmsSmsColumns.Types.BASE_SENDING_TYPE, longMessageMask, 0L) != null
+        )
+    }
+
+    // --- whether it has already been sent --------------------------------------------------------
+
+    @Test
+    fun `a sending row has not already been sent`() {
+        val state = ProSendStatRow.from(MmsSmsColumns.Types.BASE_SENDING_TYPE, longMessageMask, 0L)
+        assertFalse(state!!.wasAlreadySent)
+    }
+
+    @Test
+    fun `a syncing row has already been sent`() {
+        // The 1:1 path moves a just-sent message here, and the sync leg reports success the same way.
+        val state = ProSendStatRow.from(MmsSmsColumns.Types.BASE_SYNCING_TYPE, longMessageMask, 0L)
+        assertTrue(state!!.wasAlreadySent)
+    }
+
+    @Test
+    fun `a failed row has not already been sent, so its retry counts`() {
+        val state = ProSendStatRow.from(MmsSmsColumns.Types.BASE_SENT_FAILED_TYPE, longMessageMask, 0L)
+        assertFalse(state!!.wasAlreadySent)
+    }
+
+    // --- which stats the row feeds ---------------------------------------------------------------
+
+    @Test
+    fun `a message-feature bit is decoded`() {
+        val state = ProSendStatRow.from(MmsSmsColumns.Types.BASE_SENDING_TYPE, longMessageMask, 0L)
+        assertEquals(setOf(ProMessageFeature.HIGHER_CHARACTER_LIMIT), state!!.features)
+    }
+
+    @Test
+    fun `a profile-feature bit is decoded`() {
+        val state = ProSendStatRow.from(MmsSmsColumns.Types.BASE_SENDING_TYPE, 0L, badgeMask)
+        assertEquals(setOf(ProProfileFeature.PRO_BADGE), state!!.features)
+    }
+
+    @Test
+    fun `both columns are read, not just one`() {
+        // The trap: reading only the message column silently drops every badge, and the stat reads zero
+        // forever with nothing failing.
+        val state = ProSendStatRow.from(MmsSmsColumns.Types.BASE_SENDING_TYPE, longMessageMask, badgeMask)
+
+        assertEquals(
+            setOf(ProMessageFeature.HIGHER_CHARACTER_LIMIT, ProProfileFeature.PRO_BADGE),
+            state!!.features
+        )
+    }
+
+    @Test
+    fun `a row with no feature bits contributes nothing to count`() {
+        val state = ProSendStatRow.from(MmsSmsColumns.Types.BASE_SENDING_TYPE, 0L, 0L)
+
+        assertTrue(state!!.features.isEmpty())
+    }
+}

--- a/app/src/test/java/org/thoughtcrime/securesms/pro/ProSendStatsTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/pro/ProSendStatsTest.kt
@@ -1,0 +1,146 @@
+package org.thoughtcrime.securesms.pro
+
+import network.loki.messenger.libsession_util.protocol.ProMessageFeature
+import network.loki.messenger.libsession_util.protocol.ProProfileFeature
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The "sent" Pro stats as running totals.
+ *
+ * Note what is NOT tested here, because it is no longer expressible: that deleting a sent message does not
+ * reduce the stat. The message table is not an input to this code at all, so there is no seam through which
+ * a deletion could act. That is a stronger position than a test — the old implementation needed one because
+ * it counted rows on every read.
+ */
+class ProSendStatsTest {
+
+    /** Stands in for `ProDatabase`'s pro_state table. */
+    private class FakeStore : ProSendStats.Store {
+        val values = mutableMapOf<String, Long>()
+        var writes = 0
+
+        override fun getProStatCount(name: String): Long? = values[name]
+
+        override fun incrementProStatCount(name: String) {
+            writes++
+            values[name] = (values[name] ?: 0L) + 1L
+        }
+    }
+
+    private val store = FakeStore()
+
+    // --- a qualifying send increments -----------------------------------------------------------
+
+    @Test
+    fun `a sent long message increments the long-message total`() {
+        val feature = ProMessageFeature.HIGHER_CHARACTER_LIMIT
+
+        ProSendStats.recordSendSuccess(store, wasAlreadySent = false, features = setOf(feature))
+
+        assertEquals(1, ProSendStats.total(store, feature))
+    }
+
+    @Test
+    fun `a sent pro badge increments the badge total`() {
+        val feature = ProProfileFeature.PRO_BADGE
+
+        ProSendStats.recordSendSuccess(store, wasAlreadySent = false, features = setOf(feature))
+
+        assertEquals(1, ProSendStats.total(store, feature))
+    }
+
+    @Test
+    fun `each stat counts only its own feature`() {
+        // One message carrying both features feeds both stats, and neither leaks into the other.
+        ProSendStats.recordSendSuccess(
+            store,
+            wasAlreadySent = false,
+            features = setOf(ProMessageFeature.HIGHER_CHARACTER_LIMIT, ProProfileFeature.PRO_BADGE)
+        )
+        ProSendStats.recordSendSuccess(
+            store,
+            wasAlreadySent = false,
+            features = setOf(ProMessageFeature.HIGHER_CHARACTER_LIMIT)
+        )
+
+        assertEquals(2, ProSendStats.total(store, ProMessageFeature.HIGHER_CHARACTER_LIMIT))
+        assertEquals(1, ProSendStats.total(store, ProProfileFeature.PRO_BADGE))
+    }
+
+    @Test
+    fun `a send carrying no counted feature changes nothing`() {
+        ProSendStats.recordSendSuccess(store, wasAlreadySent = false, features = emptySet())
+
+        assertEquals(0, store.writes)
+        assertEquals(0, ProSendStats.total(store, ProMessageFeature.HIGHER_CHARACTER_LIMIT))
+    }
+
+    @Test
+    fun `a stat nothing has fed reads zero rather than failing`() {
+        assertEquals(0, ProSendStats.total(store, ProProfileFeature.PRO_BADGE))
+    }
+
+    // --- the totals are historic ----------------------------------------------------------------
+
+    @Test
+    fun `later sends without the badge do not reduce the historic badge count`() {
+        // The count is of badges SENT, not of the badge being on now. Switching Pro Badges off stops new
+        // messages carrying one -- it does not un-send the ones that did.
+        //
+        // Pinned because the conflation is easy to make in a later edit: "do not attach a badge to this
+        // message" and "do not count it" are one thought away from each other.
+        ProSendStats.recordSendSuccess(
+            store,
+            wasAlreadySent = false,
+            features = setOf(ProProfileFeature.PRO_BADGE)
+        )
+
+        repeat(3) {
+            ProSendStats.recordSendSuccess(
+                store,
+                wasAlreadySent = false,
+                features = setOf(ProMessageFeature.HIGHER_CHARACTER_LIMIT),
+            )
+        }
+
+        assertEquals(1, ProSendStats.total(store, ProProfileFeature.PRO_BADGE))
+    }
+
+    // --- one contribution per message, on its first confirmed send ------------------------------
+
+    @Test
+    fun `a repeat success for an already-sent message does not count again`() {
+        val feature = ProMessageFeature.HIGHER_CHARACTER_LIMIT
+
+        ProSendStats.recordSendSuccess(store, wasAlreadySent = false, features = setOf(feature))
+        ProSendStats.recordSendSuccess(store, wasAlreadySent = true, features = setOf(feature))
+        ProSendStats.recordSendSuccess(store, wasAlreadySent = true, features = setOf(feature))
+
+        assertEquals(1, ProSendStats.total(store, feature))
+    }
+
+    @Test
+    fun `a retry after a failed attempt counts once, not twice`() {
+        // The attempt that failed never reached "sent", so it never reported. The retry transitions out
+        // of failed -- not out of sent -- so it is that message's first success and counts once.
+        val feature = ProProfileFeature.PRO_BADGE
+
+        ProSendStats.recordSendSuccess(store, wasAlreadySent = false, features = setOf(feature))
+
+        assertEquals(1, ProSendStats.total(store, feature))
+    }
+
+    @Test
+    fun `an already-sent message contributes nothing even to a stat it has never fed`() {
+        // Guards the gate rather than the arithmetic: it must short-circuit before touching the store, so
+        // a repeat cannot create a counter that was never incremented.
+        ProSendStats.recordSendSuccess(
+            store,
+            wasAlreadySent = true,
+            features = setOf(ProProfileFeature.PRO_BADGE)
+        )
+
+        assertEquals(0, store.writes)
+    }
+}


### PR DESCRIPTION
### Contributor checklist

- [x] I have tested my contribution on these devices:
 * Virtual device, Pixel 6, Android 14 (API 34)
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description

Two commits. The first is the Pro stats change; **the second is an unrelated message duplication
fix that the first one led me to, and it is worth reviewing on its own terms** — it is a fix to
how a message is stored, not to a statistic.

**1. Count the sent badges and long messages as running totals**

The two "sent" stats were a `COUNT(*)` over outgoing message rows carrying the feature bit, which
made them a view of the message table rather than a record of what the account had done. Deleting a
message you had sent reduced the number, and every render of the stats screen counted the whole
table. Sending is the event worth counting, and deleting your copy afterwards does not un-send it.

Stored over the existing `pro_state` key/value table, so there is no schema change and no migration.

Counted on a confirmed send and at most once per message. Those pull in opposite directions —
counting at insert counts messages that never went anywhere, while counting every successful send
counts a retried message twice — and the message's own status reconciles them.

The subtlety worth a reviewer's attention is which statuses mean "already sent", because `SENT`
alone is not the answer. A 1:1 message does not stay in `SENT` after a successful send: it is moved
immediately to `SYNCING` so a copy can go to our own devices, and that sync leg reports its success
through the same path. Testing `SENT` alone would count every 1:1 message twice. `SYNCING`,
`RESYNCING` and `SYNC_FAILED` all imply the send to the recipient already succeeded, since nothing
starts syncing a message that never went out.

Incoming rows stay excluded, preserving the old query's `IS_OUTGOING` guard: they carry the
sender's feature bits and their badge is not ours to count.

**2. Store a community message against the community, not against its sender**

A message we sent to a community was saved a second time when it came back to us from the server,
so the conversation showed two of it. The stat counters land on the same rows, so they came back
doubled too — but the duplicate row is the actual bug and the count only reports it. Worth stating
plainly, because it would have been easy to suppress this inside the counting hook and end up with
a correct-looking number sitting on top of a conversation that still shows the message twice.

Both message tables reject a duplicate on `DATE_SENT`, `ADDRESS` and `THREAD_ID`. The first and
third match a message and its echo by construction, so the address is the whole of the check.
Composing addressed the row to the conversation; receiving it back addressed the row to whoever
sent it, because the cast that recognises a group-shaped conversation named only `Address.Group`,
and `Address.Community` is a sibling of it under `GroupLike`. The two rows disagreed on the one
column that decides.

It stayed hidden while a message came back in the same session, because an in-memory set of
timestamps catches it first — and that set does not survive the process, which is what made this
look like it only happened after a restart.

`Address.LegacyGroup` is a sibling too and is **deliberately** left as it was, so the decision names
the two supported types rather than widening to the interface. One test exists solely to pin that.

### Testing

286 unit tests pass, 4 of them new.

The new ones cover the address decision for a community, a group, a one to one and a legacy group,
and were checked by putting the old cast back: the community case alone fails, the other three still
pass — so they are pinning behaviour the fix must not change rather than agreeing with whatever the
new code does.

The duplication itself was reproduced on a device before the fix, as two stored copies of a single
message sent to a community after an app restart.

### One thing I did not change

`Address.CommunityBlindedId` (a blinded one to one inside a community) is `Conversable` but not
`GroupLike`, so it has the same shape of exposure. I believe it is unaffected, because
`isUserBlindedSender` is derived from `RecipientData.Community` and a blinded one to one thread does
not match it, which sends those down the incoming branch entirely and never reaches the address this
changes. That is reasoning rather than a measurement, so it is flagged rather than fixed.
