### PR TITLE
Fix: server request paths were built with a doubled slash

### DIFF
--- a/app/src/main/java/org/session/libsession/messaging/open_groups/api/CommunityApiBatcher.kt
+++ b/app/src/main/java/org/session/libsession/messaging/open_groups/api/CommunityApiBatcher.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.json.Json
 import org.session.libsession.database.StorageProtocol
 import org.thoughtcrime.securesms.api.ApiExecutorContext
 import org.thoughtcrime.securesms.api.batch.Batcher
+import org.thoughtcrime.securesms.api.server.trimTrailingSlashes
 import javax.inject.Inject
 
 class CommunityApiBatcher @Inject constructor(
@@ -21,7 +22,8 @@ class CommunityApiBatcher @Inject constructor(
 
         return BatchApi.BatchRequestItem(
             httpRequest = req.api.buildRequest(
-                baseUrl = req.serverBaseUrl,
+                // This path does not go through ServerApiRequest, which normalises for everything else.
+                baseUrl = req.serverBaseUrl.trimTrailingSlashes(),
                 x25519PubKeyHex = pubKey
             ),
             json = json

--- a/app/src/main/java/org/thoughtcrime/securesms/api/server/ServerApiExecutor.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/api/server/ServerApiExecutor.kt
@@ -9,10 +9,16 @@ import org.thoughtcrime.securesms.api.execute
 import javax.inject.Inject
 
 class ServerApiRequest<RespType: ServerApiResponse>(
-    val serverBaseUrl: String,
+    serverBaseUrl: String,
     val serverX25519PubKeyHex: String,
     val api: ServerApi<RespType>,
 ) {
+    /**
+     * Normalised on the way in, so every `buildRequest` can append "/path" without having to know whether
+     * its caller's base URL ended in a slash. See [trimTrailingSlashes].
+     */
+    val serverBaseUrl: String = serverBaseUrl.trimTrailingSlashes()
+
     constructor(fileServer: FileServer, api: ServerApi<RespType>) : this(
         serverBaseUrl = fileServer.url.toString(),
         serverX25519PubKeyHex = fileServer.x25519PubKeyHex,

--- a/app/src/main/java/org/thoughtcrime/securesms/api/server/ServerBaseUrl.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/api/server/ServerBaseUrl.kt
@@ -1,0 +1,19 @@
+package org.thoughtcrime.securesms.api.server
+
+/**
+ * Strips trailing slashes from a server base URL so a path with a leading slash can be appended to it.
+ *
+ * Every `buildRequest` builds its URL as `"$baseUrl/$path"`, which assumes the base does NOT end in a
+ * slash. That assumption is quietly false whenever the base came from an OkHttp `HttpUrl`: for a host-only
+ * URL, `HttpUrl.toString()` always emits a trailing slash, so `http://host:8000` comes back as
+ * `http://host:8000/` and the result is `http://host:8000//file`.
+ *
+ * Normalised here, once, where a base URL enters a request, rather than at each place a path is appended —
+ * there are several of those already and the next one added would repeat the mistake.
+ *
+ * Servers route the doubled path fine, which is why this survived: nothing fails. It is still worth
+ * getting right, because the path shape identifies the client on the wire, and anything path-sensitive in
+ * front of the server (proxy, cache key, path-based rate limiting) may treat `//file` and `/file` as two
+ * different resources.
+ */
+fun String.trimTrailingSlashes(): String = trimEnd('/')

--- a/app/src/test/java/org/thoughtcrime/securesms/api/server/ServerBaseUrlTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/api/server/ServerBaseUrlTest.kt
@@ -1,0 +1,89 @@
+package org.thoughtcrime.securesms.api.server
+
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * Server base URLs must not end in a slash, because every `buildRequest` appends `"/$path"` to them.
+ *
+ * The reason this needs pinning: servers route the doubled path perfectly well and return 200, so getting
+ * it wrong breaks nothing and nothing fails. It regresses silently or not at all.
+ */
+class ServerBaseUrlTest {
+
+    // --- the premise, verified here rather than assumed --------------------------------------------
+
+    @Test
+    fun `OkHttp adds a trailing slash to a host-only URL`() {
+        // This is where the bug came from, and it is a property of HttpUrl rather than of any config
+        // value -- so it applies to the shipped default file server exactly as much as to a QA one.
+        assertEquals("http://filev2.getsession.org/", "http://filev2.getsession.org".toHttpUrl().toString())
+        assertEquals("http://localhost:8000/", "http://localhost:8000".toHttpUrl().toString())
+    }
+
+    @Test
+    fun `appending to an unnormalised host-only URL is what produced the doubled slash`() {
+        // Documents the defect this fixes: the shape the file server was actually seeing.
+        val baseUrl = "http://localhost:8000".toHttpUrl().toString()
+
+        assertEquals("http://localhost:8000//file", "$baseUrl/file")
+    }
+
+    // --- the fix -----------------------------------------------------------------------------------
+
+    @Test
+    fun `a host-only URL yields a single slash once normalised`() {
+        val baseUrl = "http://localhost:8000".toHttpUrl().toString().trimTrailingSlashes()
+
+        assertEquals("http://localhost:8000/file", "$baseUrl/file")
+    }
+
+    @Test
+    fun `a URL that already has no trailing slash is unchanged`() {
+        // Community base URLs arrive as plain config strings and are already correct; normalising must be
+        // a no-op for them rather than eating a character.
+        assertEquals(
+            "http://open.getsession.org",
+            "http://open.getsession.org".trimTrailingSlashes()
+        )
+    }
+
+    @Test
+    fun `a base URL with a path keeps that path`() {
+        assertEquals(
+            "http://host:8000/sogs",
+            "http://host:8000/sogs/".trimTrailingSlashes()
+        )
+    }
+
+    @Test
+    fun `repeated trailing slashes are all removed`() {
+        // A user-entered community URL is one plausible source of these.
+        assertEquals("http://host:8000", "http://host:8000///".trimTrailingSlashes())
+    }
+
+    @Test
+    fun `normalising is idempotent`() {
+        val once = "http://localhost:8000".toHttpUrl().toString().trimTrailingSlashes()
+
+        assertEquals(once, once.trimTrailingSlashes())
+    }
+
+    // --- the real request path ----------------------------------------------------------------------
+
+    @Test
+    fun `a request built from an HttpUrl-derived base exposes it without a trailing slash`() {
+        // The end-to-end shape: ServerApiRequest is where a base URL enters, and this is the property the
+        // four buildRequest implementations rely on.
+        val request = ServerApiRequest(
+            serverBaseUrl = "http://localhost:8000".toHttpUrl().toString(),
+            serverX25519PubKeyHex = "00",
+            api = mock<ServerApi<Any>>(),
+        )
+
+        assertEquals("http://localhost:8000", request.serverBaseUrl)
+        assertEquals("http://localhost:8000/file", "${request.serverBaseUrl}/file")
+    }
+}


### PR DESCRIPTION
# Fix: server request paths were built with a doubled slash

Every request Android sent to the file server arrived as `POST //file` rather than `POST /file`.

## Cause

`buildRequest` builds its URL as `"$baseUrl/$path"`, which assumes the base does **not** end in a slash.
That assumption is false whenever the base came from an OkHttp `HttpUrl`: for a host-only URL,
`HttpUrl.toString()` always emits a trailing slash, so `http://host:8000` comes back as
`http://host:8000/`.

Because the slash comes from `HttpUrl` rather than from configuration, this does not depend on the URL a
user or a QA build supplies — it applies to the shipped default file server too.

## Scope

**Two servers were affected**, both of which hold their URL as an `HttpUrl` and stringify it into
`serverBaseUrl`:

| server | where |
|---|---|
| file server | `ServerApiRequest(fileServer:)` — `fileServer.url.toString()` |
| Pro backend | `ProApi.kt:133` — `proBackendConfig.url.toString()` |

**Six** places append a path to that base, not four:

    FileUploadApi.kt:38          "$baseUrl/file"
    FileDownloadApi.kt:25        "$baseUrl/file/$fileId"
    FileRenewApi.kt:23           "$baseUrl/file/$fileId/extend"
    JsonServerApi.kt:41          "$baseUrl/$httpEndpoint"     <- the shared base for every JSON endpoint
    GetTokenApi.kt:48            "$baseUrl/info"
    GetClientVersionApi.kt:54    "$baseUrl/session_version?platform=android"

**Communities were NOT affected**, and it is worth saying why: their base URL comes from a config string
(`community.serverUrl`), not from an `HttpUrl`, so it carries no trailing slash. They are normalised on the
same path anyway, so a community URL that does end in a slash cannot reintroduce this.

The token server and the notification server hold their URLs as plain `String` constants and were also
unaffected.

## Fix

Normalised once where a base URL enters a request — `ServerApiRequest`, plus the batched community path
which bypasses it — rather than at each of the six append sites. `FileServerApis` already builds its URL
correctly with `.addPathSegment("file")`, so both idioms were living side by side; this makes the
string-concatenation idiom safe instead of removing it.

## Impact

Nothing was broken by this. Servers route `//file` and return 200. It is worth fixing because:

- the path shape **identifies the client on the wire** — Android was distinguishable from the path alone;
- anything path-sensitive in front of the server (proxy, WAF, cache key, path-based rate limiting) may
  treat `//file` and `/file` as two different resources;
- `JsonServerApi` is the shared base, so the blast radius was every JSON endpoint rather than uploads.

**This does not fix any upload failure.** Upload errors seen while investigating were a file server fault
(`psycopg_pool.PoolTimeout`, host memory pressure) on one machine; a second file server returns 200 to the
same doubled path. This is a correctness and tidiness fix on its own merits.

## Tests

`ServerBaseUrlTest` — 8 tests, and they pin the premise rather than assuming it:

- that `HttpUrl.toString()` really does add the trailing slash, for both a real default URL and a local one
- the pre-fix doubled path, documented so the defect is legible
- the fix, a no-op on already-correct bases, path preservation, repeated slashes, idempotence
- the end-to-end property on `ServerApiRequest`

Verified to fail if the normalisation is reverted to a no-op (4 of 8 red). This is the kind of fix that
regresses silently, because the server tolerates both shapes.
