### PR TITLE
Remove a dead rotating-key constant that contradicts the real design

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/pro/db/ProDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/pro/db/ProDatabase.kt
@@ -308,8 +308,6 @@ class ProDatabase @Inject constructor(
         private const val STATE_PRO_STATUS_LAST_STARTUP_FETCH_ATTEMPT_AT =
             "pro_status_last_startup_fetch_attempt_at"
 
-        private const val ROTATING_KEY_VALIDITY_DAYS = 15
-
         fun createTable(db: SupportSQLiteDatabase) {
             // A table to hold the list of pro revocations. This is the ORIGINAL (lokiV57) shipped
             // shape; `reshapeRevocationsForSeconds` (lokiV61) drops and recreates it with the


### PR DESCRIPTION
### Description

`ROTATING_KEY_VALIDITY_DAYS = 15` in `ProDatabase` is unreferenced — the declaration is its only
occurrence in the tree, and it is `private`, so nothing outside its own file could have read it.

It is worth removing rather than leaving because it now reads as a policy that contradicts the real
one. The rotating-key design is libsession's: `ProProof::rotating_seed` derives the seed
deterministically so every device on an account converges without coordination, quantized by
`PRO_ROTATING_SEED_PERIOD` of **7 days** — and libsession is explicit that even that is not a cadence:

> the 7-day quantization is a property of this derivation only; it is NOT the key-rotation cadence,
> which is dictated by the backend via the proof expiry

Android already consumes that derivation correctly (`ProProofGenerationWorker`, `ProStatusManager`),
so the constant is not a leftover hook for something unfinished — it is a number that disagrees with
the design and has no code to correct it.

### Test approach

`:app:assemblePlayAutomaticQa` builds; 294 unit tests, 0 failures.
