### PR TITLE
A revoked proof keeps the synced access expiry, and a lapse stores the dates it returns

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/pro/ProProofGenerationWorker.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/pro/ProProofGenerationWorker.kt
@@ -197,21 +197,52 @@ class ProProofGenerationWorker @AssistedInject constructor(
                         notEntitled && purchasePending -> Result.retry()
 
                         notEntitled -> {
-                            // Backend authoritatively says we're not (or no longer) entitled. Clear the
-                            // synced access-expiry (E) so the renewal loop terminates: libsession's renewal
-                            // target now fires on "future E but no proof", so a stale future E left here
-                            // would spin. (subscription_expired's past account_expiry is redundant with the
-                            // get_pro_status horizon, so we clear E rather than re-set it.) Also drop a now-
-                            // defunct credential, guarded so a proof another device just landed survives.
+                            // The backend says this device is not (or no longer) entitled, and the defunct
+                            // credential goes either way — guarded, so a proof another device just landed
+                            // survives.
+                            //
+                            // Whether the synced access-expiry (E) goes with it depends on WHICH answer
+                            // this is, and REVOKED is not the same answer as the other two:
+                            //
+                            //  * REVOKED says this PROOF is void. It says nothing about the subscription,
+                            //    and it carries no expiry to say it with — a revocation with
+                            //    revoke_payments=false is a rotation, leaving the account paid and
+                            //    re-provable, and locally we cannot tell that from a refund. Clearing E
+                            //    here would answer a question the backend did not answer. E is SYNCED, so
+                            //    that answer would propagate to every other device and erase the shared
+                            //    record that the user ever subscribed: with no E and no proof, the seeded
+                            //    display status reads "never subscribed" — a confident claim, not an
+                            //    absence — and a refunded subscriber gets offered "Upgrade" instead of
+                            //    "Renew". Matches the reasoning in `ProStatusManager`, which keeps E on the
+                            //    revocation-LIST path for the same reason.
+                            //
+                            //  * NOT_SUBSCRIBED means no account row exists, so there is genuinely nothing
+                            //    to record and clearing is right.
+                            //
+                            // Keeping E on REVOKED leaves libsession's renewal target firing on
+                            // "future E but no proof", so the acquire loop keeps running. That is bounded
+                            // rather than unbounded — the dark backoff widens to DARK_CAP_SECONDS spacing —
+                            // and it ends when a status fetch writes a past E. Deliberately no extra
+                            // limiter here: a third guard would suppress the symptom of a loop that already
+                            // terminates.
+                            val keepAccessExpiry = code == ProErrorCode.REVOKED
+
                             configFactory.withMutableUserConfigs { configs ->
-                                configs.userProfile.removeProAccessExpiry()
+                                if (!keepAccessExpiry) {
+                                    configs.userProfile.removeProAccessExpiry()
+                                }
                                 val nowSeconds = snodeClock.currentTime().epochSecond
                                 val existing = configs.userProfile.getProConfig()?.proProof
                                 if (existing == null || existing.expirySeconds <= nowSeconds) {
                                     configs.userProfile.removeProConfig()
                                 }
                             }
-                            Log.w(WORK_NAME, "Pro proof denied (code=$code); cleared access-expiry, ending the acquire loop")
+                            Log.w(
+                                WORK_NAME,
+                                "Pro proof denied (code=$code); " +
+                                    if (keepAccessExpiry) "kept access-expiry (the proof is void, the plan may not be)"
+                                    else "cleared access-expiry, ending the acquire loop"
+                            )
                             Result.failure()
                         }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/pro/ProProofGenerationWorker.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/pro/ProProofGenerationWorker.kt
@@ -53,6 +53,7 @@ class ProProofGenerationWorker @AssistedInject constructor(
     private val loginStateRepository: LoginStateRepository,
     private val configFactory: ConfigFactoryProtocol,
     private val snodeClock: SnodeClock,
+    private val proStatusRepository: Provider<ProStatusRepository>,
 ) : CoroutineWorker(context, params) {
     override suspend fun doWork(): Result {
         val proMasterKey = requireNotNull(loginStateRepository.peekLoginState()?.seeded?.proMasterPrivateKey) {
@@ -169,9 +170,8 @@ class ProProofGenerationWorker @AssistedInject constructor(
                         // it: it would wipe a flag `get_pro_status` had correctly learned, on the
                         // strength of a response that said nothing about the account.
                         //
-                        // The entitlement-denied path needs no equivalent write. It clears `E`, and
-                        // libsession erases `G` and `A` with it — a grace that outlived its expiry
-                        // would pair with whatever wrote `E` next.
+                        // The entitlement-denied path writes the same three, but only for
+                        // `subscription_expired` — the one denial that returns them. See that branch.
                         configs.userProfile.setProAutoRenewing(response.accountAutoRenewing)
                         configs.userProfile.setProGracePeriod(response.accountGracePeriod)
                     }
@@ -197,51 +197,88 @@ class ProProofGenerationWorker @AssistedInject constructor(
                         notEntitled && purchasePending -> Result.retry()
 
                         notEntitled -> {
-                            // The backend says this device is not (or no longer) entitled, and the defunct
-                            // credential goes either way — guarded, so a proof another device just landed
-                            // survives.
+                            // The backend says this device is not (or no longer) entitled. The defunct
+                            // credential goes in every case — guarded, so a proof another device just
+                            // landed survives. What happens to the synced access expiry (E) does NOT
+                            // generalise, because the three slugs are three different answers:
                             //
-                            // Whether the synced access-expiry (E) goes with it depends on WHICH answer
-                            // this is, and REVOKED is not the same answer as the other two:
+                            //  * REVOKED — this PROOF is void, and that is all it says. It returns no
+                            //    dates to say more with. A revocation that does not revoke payments is a
+                            //    rotation, leaving the account paid and re-provable, and locally we cannot
+                            //    tell that from a refund. So KEEP E: clearing it would answer a question
+                            //    the backend did not answer, and E is SYNCED, so that answer would reach
+                            //    every other device and erase the shared record that the user ever
+                            //    subscribed. With no E and no proof the seeded display reads "never
+                            //    subscribed" — a confident claim rather than an absence — and a refunded
+                            //    subscriber is offered "Upgrade" where they should see "Renew".
+                            //    `ProStatusManager` keeps E on the revocation-LIST path for this reason.
                             //
-                            //  * REVOKED says this PROOF is void. It says nothing about the subscription,
-                            //    and it carries no expiry to say it with — a revocation with
-                            //    revoke_payments=false is a rotation, leaving the account paid and
-                            //    re-provable, and locally we cannot tell that from a refund. Clearing E
-                            //    here would answer a question the backend did not answer. E is SYNCED, so
-                            //    that answer would propagate to every other device and erase the shared
-                            //    record that the user ever subscribed: with no E and no proof, the seeded
-                            //    display status reads "never subscribed" — a confident claim, not an
-                            //    absence — and a refunded subscriber gets offered "Upgrade" instead of
-                            //    "Renew". Matches the reasoning in `ProStatusManager`, which keeps E on the
-                            //    revocation-LIST path for the same reason.
+                            //  * SUBSCRIPTION_EXPIRED — a lapse or cancellation, and the response carries
+                            //    the expiry, grace period and renewing flag so a client can persist them.
+                            //    SET all three. Not the expiry alone: on a cancellation the expiry is
+                            //    typically the value that did NOT change while the grace and the flag did,
+                            //    so writing only the expiry leaves a stale grace claiming coverage the
+                            //    backend has stopped honouring. Coverage end is derived as E + G.
                             //
-                            //  * NOT_SUBSCRIBED means no account row exists, so there is genuinely nothing
-                            //    to record and clearing is right.
+                            //  * NOT_SUBSCRIBED — no account row exists, so there is genuinely nothing to
+                            //    record. CLEAR E.
                             //
-                            // Keeping E on REVOKED leaves libsession's renewal target firing on
-                            // "future E but no proof", so the acquire loop keeps running. That is bounded
-                            // rather than unbounded — the dark backoff widens to DARK_CAP_SECONDS spacing —
-                            // and it ends when a status fetch writes a past E. Deliberately no extra
-                            // limiter here: a third guard would suppress the symptom of a loop that already
-                            // terminates.
-                            val keepAccessExpiry = code == ProErrorCode.REVOKED
+                            // The three-value write is gated on the slug, and that gate is doing real
+                            // work: libsession only populates those fields for SUBSCRIPTION_EXPIRED and
+                            // otherwise leaves them at 0/false, which are indistinguishable from genuine
+                            // zeroes. Writing `false` to a presence-only key ERASES it, so an ungated
+                            // write would wipe a flag `get_pro_status` had correctly learned.
+                            val expiredWithDates = code == ProErrorCode.SUBSCRIPTION_EXPIRED
 
                             configFactory.withMutableUserConfigs { configs ->
-                                if (!keepAccessExpiry) {
-                                    configs.userProfile.removeProAccessExpiry()
+                                when {
+                                    expiredWithDates -> {
+                                        result.parsed.accountExpiry?.let {
+                                            configs.userProfile.setProAccessExpiry(it.epochSecond)
+                                        }
+                                        configs.userProfile.setProGracePeriod(result.parsed.accountGracePeriod)
+                                        configs.userProfile.setProAutoRenewing(result.parsed.accountAutoRenewing)
+                                    }
+
+                                    // REVOKED keeps whatever the backend last said; only NOT_SUBSCRIBED
+                                    // clears.
+                                    code == ProErrorCode.NOT_SUBSCRIBED -> {
+                                        configs.userProfile.removeProAccessExpiry()
+                                    }
                                 }
+
                                 val nowSeconds = snodeClock.currentTime().epochSecond
                                 val existing = configs.userProfile.getProConfig()?.proProof
                                 if (existing == null || existing.expirySeconds <= nowSeconds) {
                                     configs.userProfile.removeProConfig()
                                 }
                             }
+
+                            // Change the local record, then ask the server — on every one of the three,
+                            // not just the ones that cleared something.
+                            //
+                            // IMMEDIATE, bypassing the routine freshness floor. A floored request is
+                            // dropped whenever a status fetch already ran inside the floor, which is the
+                            // ordinary case because launch fetches, so flooring drops exactly the fetch
+                            // that matters. It matters because it is the acquire loop's TERMINATOR:
+                            // libsession's renewal target fires while E is in the future with no proof, and
+                            // only a status response writing a past E stops it.
+                            //
+                            // This does make the proof loop a source of status fetches, which the success
+                            // branch above deliberately avoids. The difference is that the success branch
+                            // has another trigger — its own E write fires the config-change trigger —
+                            // whereas REVOKED writes nothing, so without this the terminator would have to
+                            // arrive via the revocation-LIST path. That would be a dependency between two
+                            // paths that neither of them states.
+                            proStatusRepository.get().requestRefresh(immediate = true)
+
                             Log.w(
                                 WORK_NAME,
-                                "Pro proof denied (code=$code); " +
-                                    if (keepAccessExpiry) "kept access-expiry (the proof is void, the plan may not be)"
-                                    else "cleared access-expiry, ending the acquire loop"
+                                "Pro proof denied (code=$code); " + when {
+                                    expiredWithDates -> "stored the returned expiry, grace and renewing flag"
+                                    code == ProErrorCode.NOT_SUBSCRIBED -> "cleared access-expiry"
+                                    else -> "kept access-expiry (the proof is void, the plan may not be)"
+                                } + "; fetching status immediately"
                             )
                             Result.failure()
                         }

--- a/app/src/main/java/org/thoughtcrime/securesms/pro/api/ProApi.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/pro/api/ProApi.kt
@@ -60,11 +60,12 @@ abstract class ProApi<Res : ProResponse>(private val deps: ProApiDependencies)
             ProApiResponse.Success(parsed)
         } else {
             ProApiResponse.Failure(
-                ProApiError(
+                error = ProApiError(
                     status = parsed.header.status,
                     errorCode = parsed.header.errorCode,
                     error = parsed.header.error,
-                )
+                ),
+                parsed = parsed,
             )
         }
     }
@@ -113,7 +114,19 @@ object ProErrorCode {
  */
 sealed interface ProApiResponse<out Res> {
     data class Success<T>(val data: T) : ProApiResponse<T>
-    data class Failure(val error: ProApiError) : ProApiResponse<Nothing>
+
+    /**
+     * A failure still carries the [parsed] body, because some error slugs are informative rather than
+     * merely negative: `subscription_expired` returns the account expiry, grace period and renewing flag
+     * precisely so a client can persist them.
+     *
+     * Reaching here means the ENVELOPE parsed — a body that could not be parsed throws before this — so
+     * [parsed] is a real struct rather than defaults built from nothing. That distinction is what makes it
+     * safe to write config from a failure at all, and it is only safe **per slug**: libsession populates
+     * those fields for `subscription_expired` and leaves them at their defaults otherwise, and the defaults
+     * are indistinguishable from genuine zeroes. Gate any write on the slug.
+     */
+    data class Failure<T>(val error: ProApiError, val parsed: T) : ProApiResponse<T>
 }
 
 fun <T> ProApiResponse<T>.successOrThrow(): T {


### PR DESCRIPTION
Android is the reference for this rule — its `ProStatusManager` comment is what iOS and Desktop were changed to match — but its proof worker contradicted it three files away.

Two changes:

1. `ProProofGenerationWorker` lumped `REVOKED` in with `NOT_SUBSCRIBED` and `SUBSCRIPTION_EXPIRED` under `notEntitled` and cleared `E` for all three. `REVOKED` now keeps it.

2. `SUBSCRIPTION_EXPIRED` now sets `E`, `G` and `A` from the response instead of clearing. The old comment said the returned expiry was "redundant with the get_pro_status horizon" — it is not: it is the only thing distinguishing a lapsed subscriber from one who never subscribed, and the backend supplies it deliberately. This needed the API layer to carry the parsed body onto a failure (`Failure : ProApiResponse<Nothing>` becoming generic), which ripples through every `ProApi` subclass.

The post-revocation status fetch is also now immediate rather than floored.

One rule, applied to every `generate_pro_proof` failure, and a fetch afterwards.

| response | config | then |
|---|---|---|
| `revoked` | **keep `E`** (the response carries no expiry) | fetch status, **immediate** |
| `subscription_expired` | **set `E`, `G`, `A`** from the response | fetch status, **immediate** |
| `not_subscribed` | **clear `E`** (no user row exists) | fetch status, **immediate** |

The principle underneath: **`E` reflects what the backend last said. Clear it only when the backend says
there is nothing to say — never as a side effect of a local decision.**

## Why keeping `E` on `revoked` matters

A revocation says this proof is void; it does not say what the subscription is. A revocation with
`revoke_payments=false` is a **rotation** — the account stays paid and re-provable — and no client can tell
that apart from a refund locally. Android already said so in its own comment:

> "`E` is not cleared locally. A revocation says this proof is void, not what the subscription is now — the
> account may be fine and re-provable, or genuinely gone, and only the server knows which."

`E` is also **synced config**, not device-local: a client that clears it pushes that clear to every other
device, erasing the shared record that the user ever subscribed. Both mobile clients seed display status
from `E` plus the proof, so clearing it makes "lapsed subscriber" indistinguishable from "never subscribed".
That shipped on iOS as a refunded subscriber being offered "Recover Pro Access" and "Upgrade to" instead of
"Renew".

## Why the trio travels together

Verified in libsession's parser (`src/pro_backend.cpp`, `parse_pro_proof`) — all three fields are populated
inside the FAILURE branch when the slug is `subscription_expired`, with the comment:

> "They must travel together: coverage ends at `account_expiry + grace`, and an expiry has typically NOT
> changed on this failure (it is a lapse/cancellation) while the grace and flag have — refreshing only the
> expiry would leave a stale grace claiming coverage the backend has stopped honouring."

The backend sends all three unconditionally on that slug, so "absent" cannot arise from a current backend.

## Why immediate, not floored

Neither `E` choice gives a correct display on its own: after a refund `E` is still the OLD, FUTURE expiry, so
keeping it seeds "active" just as clearing it seeds "never". Only the status fetch fixes it — the backend
keeps the user row and writes `expiry_at = now`, returning `user_status: "expired"` with a real PAST
`expiry_ts`, which every client mirrors into `E`.

A floored fetch is dropped whenever a status fetch ran inside the floor, which is the normal case because
launch fetches. **Measured on iOS: adding a FLOORED fetch changed nothing — 5 runs out of 5 still wrong.**

That mirrored past `E` is also what TERMINATES the acquire loop: libsession's `pro_renewal_target` acquires
only while `access && *access > now`. Flooring the terminator is the wrong place to economise.

## Verification

Desktop 8/8 revocation specs. Android 15/15 revocation plus the wider `ProApi` surface, and 12/12 pin specs.
iOS pin 13/14 across two builds, refund 5/5, recipient 3/3.

`subscription_expired` has **no spec on any platform** — the slug only fires once
`expiry + grace + RENEWAL_LATENCY_ALLOWANCE` has passed, that allowance is a hard-coded hour, and
`/dev/add_payment` validates `duration` positive. Nothing can reach it in a test. Recorded as a blocked row
in the coverage table; a dev expire hook would make it reachable in seconds.
