### PR TITLE
Fix: GroupUpdated send jobs could not be read back after a restart

### DIFF
--- a/app/src/main/java/org/session/libsession/messaging/jobs/AttachmentUploadJob.kt
+++ b/app/src/main/java/org/session/libsession/messaging/jobs/AttachmentUploadJob.kt
@@ -1,6 +1,5 @@
 package org.session.libsession.messaging.jobs
 
-import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import dagger.assisted.Assisted
@@ -248,8 +247,7 @@ class AttachmentUploadJob @AssistedInject constructor(
     }
 
     override fun serialize(): Data {
-        val kryo = Kryo()
-        kryo.isRegistrationRequired = false
+        val kryo = jobKryo()
         val serializedMessage = ByteArray(4096)
         val output = Output(serializedMessage, Job.MAX_BUFFER_SIZE_BYTES)
         kryo.writeClassAndObject(output, message)
@@ -277,8 +275,7 @@ class AttachmentUploadJob @AssistedInject constructor(
 
         override fun create(data: Data): AttachmentUploadJob? {
             val serializedMessage = data.getByteArray(MESSAGE_KEY)
-            val kryo = Kryo()
-            kryo.isRegistrationRequired = false
+            val kryo = jobKryo()
             val input = Input(serializedMessage)
             val message: Message
             try {

--- a/app/src/main/java/org/session/libsession/messaging/jobs/JobKryo.kt
+++ b/app/src/main/java/org/session/libsession/messaging/jobs/JobKryo.kt
@@ -1,0 +1,39 @@
+package org.session.libsession.messaging.jobs
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.Serializer
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
+import com.google.protobuf.MessageLite
+
+/**
+ * The [Kryo] instance used to persist jobs, and to read them back after a restart.
+ *
+ * Every job that persists a message must use this rather than a bare [Kryo]: the two directions
+ * have to agree on the serializers, and a job that writes with one configuration and reads with
+ * another is silently dropped on restart rather than failing at the point of the mistake.
+ */
+internal fun jobKryo(): Kryo = Kryo().apply {
+    isRegistrationRequired = false
+    addDefaultSerializer(MessageLite::class.java, ProtobufSerializer())
+}
+
+/**
+ * Kryo builds objects field by field, and parts of a protobuf message's object graph have no
+ * constructor it can call — so it writes one happily and then throws ("Class cannot be created") on
+ * the way back in, taking the job that held it with it. Persist the wire format the message can
+ * rebuild itself from instead.
+ */
+private class ProtobufSerializer : Serializer<MessageLite>() {
+    override fun write(kryo: Kryo, output: Output, message: MessageLite) {
+        val bytes = message.toByteArray()
+        output.writeVarInt(bytes.size, true)
+        output.writeBytes(bytes)
+    }
+
+    override fun read(kryo: Kryo, input: Input, type: Class<out MessageLite>): MessageLite {
+        val bytes = input.readBytes(input.readVarInt(true))
+
+        return type.getMethod("parseFrom", ByteArray::class.java).invoke(null, bytes) as MessageLite
+    }
+}

--- a/app/src/main/java/org/session/libsession/messaging/jobs/MessageSendJob.kt
+++ b/app/src/main/java/org/session/libsession/messaging/jobs/MessageSendJob.kt
@@ -1,6 +1,5 @@
 package org.session.libsession.messaging.jobs
 
-import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import dagger.assisted.Assisted
@@ -157,8 +156,7 @@ class MessageSendJob @AssistedInject constructor(
     }
 
     override fun serialize(): Data {
-        val kryo = Kryo()
-        kryo.isRegistrationRequired = false
+        val kryo = jobKryo()
         // Message
         val messageOutput = Output(ByteArray(4096), MAX_BUFFER_SIZE_BYTES)
         kryo.writeClassAndObject(messageOutput, message)
@@ -192,8 +190,7 @@ class MessageSendJob @AssistedInject constructor(
         override fun create(data: Data): MessageSendJob? {
             val serializedMessage = data.getByteArray(MESSAGE_KEY)
             val serializedDestination = data.getByteArray(DESTINATION_KEY)
-            val kryo = Kryo()
-            kryo.isRegistrationRequired = false
+            val kryo = jobKryo()
             // Message
             val messageInput = Input(serializedMessage)
             val message: Message

--- a/app/src/test/java/org/session/libsession/messaging/jobs/JobKryoTest.kt
+++ b/app/src/test/java/org/session/libsession/messaging/jobs/JobKryoTest.kt
@@ -1,0 +1,36 @@
+package org.session.libsession.messaging.jobs
+
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.session.libsession.messaging.messages.control.GroupUpdated
+import org.session.protos.SessionProtos
+
+class JobKryoTest {
+    @Test
+    fun `GroupUpdated survives a round trip`() {
+        val message = GroupUpdated(
+            SessionProtos.GroupUpdateMessage.newBuilder()
+                .setMemberLeftMessage(SessionProtos.GroupUpdateMemberLeftMessage.getDefaultInstance())
+                .build()
+        ).apply {
+            sentTimestamp = 1_234_567_890L
+        }
+
+        val restored = roundTrip(message)
+
+        assertTrue(restored is GroupUpdated)
+        assertEquals(message.inner, (restored as GroupUpdated).inner)
+        assertEquals(message.sentTimestamp, restored.sentTimestamp)
+    }
+
+    private fun roundTrip(value: Any): Any {
+        val output = Output(ByteArray(4096), Job.MAX_BUFFER_SIZE_BYTES)
+        jobKryo().writeClassAndObject(output, value)
+        output.close()
+
+        return jobKryo().readClassAndObject(Input(output.toBytes()))
+    }
+}


### PR DESCRIPTION
`MessageSendJob` persisted its message with a bare `Kryo`. Kryo builds objects field by field, and parts of a protobuf message's object graph have no constructor it can call — so it writes one happily and then throws on the way back in:

```
KryoException: Class cannot be created (missing no-arg constructor): com.google.protobuf.UnknownFieldSet
Serialization trace:
  inner (org.session.libsession.messaging.messages.control.GroupUpdated)
```

`Factory.create` catches that, returns null, and `JobQueue.resumePendingJobs` deletes the row. Nothing leaks and nothing is reported — but **no `GroupUpdated` queued for send survives an app restart**: member-left, promote, info-change, member-change and invite-response are all silently dropped. One reported log carried 552 of these.

### Changes

- New `JobKryo.kt`: `jobKryo()` registers a `Serializer<MessageLite>` that round-trips protobuf through `toByteArray()`/`parseFrom()`, which is the only representation protobuf guarantees it can rebuild.
- `MessageSendJob` and `AttachmentUploadJob` both use it, in both directions, so the write and read sides cannot drift apart.

No compatibility concern: a row containing a non-null protobuf field could not be read before this change either, so there is nothing already on disk that this stops being able to read.

### Tests

`JobKryoTest` round-trips a `GroupUpdated` through the same Kryo the job uses. It fails without the serializer registration (with the exception above) and passes with it. Full suite green: **299/299**.

### Notes for review

The leave-retry-loop fix (separate PR) touches a different region of `MessageSendJob`; the two branches merge cleanly and can land in either order. Without this one, a leave interrupted by a restart silently does nothing.
